### PR TITLE
chore: remove VSCodeMCP dispatch from notify-downstream workflow

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,0 +1,61 @@
+name: Notify Downstream
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/**"
+      - sync.yaml
+
+jobs:
+  notify-index:
+    name: Trigger Index Profile Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch update-profile to Index repo
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.SYNC_TOKEN }}
+          repository: AceDataCloud/Index
+          event-type: update-profile
+
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed_mcps: ${{ steps.detect.outputs.changed_mcps }}
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed MCPs
+        id: detect
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD)
+          CHANGED_MCPS=$(echo "$CHANGED" | grep -oP '^[^/]+(?=/)' | sort -u | tr '\n' ',' | sed 's/,$//')
+          echo "changed_mcps=$CHANGED_MCPS" >> $GITHUB_OUTPUT
+          if [ -n "$CHANGED_MCPS" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Changed MCPs: $CHANGED_MCPS"
+
+  notify-dify:
+    name: Notify Dify Plugin Update
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dify plugin sync
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.SYNC_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/AceDataCloud/Dify/dispatches" \
+            -d '{"event_type":"mcp-plugin-update","client_payload":{"source":"MCPs","changed":"${{ needs.detect-changes.outputs.changed_mcps }}"}}'


### PR DESCRIPTION
VSCodeMCP repo has been deprecated. Removes the `notify-vscode` job that dispatched rebuild events to it.