### PR TITLE
chore: standardize GitHub token secret names

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Dispatch update-profile to Index repo
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           repository: AceDataCloud/Index
           event-type: update-profile
 
@@ -55,7 +55,7 @@ jobs:
       - name: Trigger Dify plugin sync
         run: |
           curl -s -X POST \
-            -H "Authorization: token ${{ secrets.BOT_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.BOT_GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/AceDataCloud/Dify/dispatches" \
             -d '{"event_type":"mcp-plugin-update","client_payload":{"source":"MCPs","changed":"${{ needs.detect-changes.outputs.changed_mcps }}"}}'

--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           repository: AceDataCloud/Docs
           path: _docs
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
           fetch-depth: 5
 
       - name: Get Docs changes
@@ -45,7 +45,7 @@ jobs:
 
       - name: Close existing sync issues
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           gh issue list --repo "${{ github.repository }}" --label "auto-sync" --state open --json number --jq '.[].number' | while read -r num; do
             gh issue close "$num" --repo "${{ github.repository }}" --comment "Superseded by new sync trigger." 2>/dev/null || true
@@ -54,7 +54,7 @@ jobs:
       - name: Create issue for Copilot
         id: create-issue
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           COMMIT_INFO: ${{ steps.docs.outputs.commit_info }}
           RECENT_CHANGES: ${{ steps.docs.outputs.recent_changes }}
           CHANGED_SERVICES: ${{ steps.docs.outputs.changed_services }}
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Wait for Copilot PR and merge
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ needs.create-task.outputs.issue_number }}
         run: |
           echo "Waiting for Copilot to process issue #$ISSUE_NUMBER..."

--- a/.github/workflows/sync-to-repos.yml
+++ b/.github/workflows/sync-to-repos.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Sync ${{ matrix.dir }} to ${{ matrix.repo }}
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           set -e
 


### PR DESCRIPTION
## Summary

Standardize GitHub token secret names across workflows. Replace legacy `secrets.BOT_TOKEN` with `secrets.BOT_GITHUB_TOKEN` (the org-level standardized name).

Both secrets exist at the org level and resolve to the same bot account (`acedatacloud-dev`). This change eliminates naming confusion across repos.

## Why

The org has multiple duplicate token secrets:
- `BOT_TOKEN` (legacy) → `BOT_GITHUB_TOKEN` (standardized)  
- `REPO_PAT` (legacy) → `BOT_GITHUB_TOKEN` / `ADMIN_GITHUB_TOKEN` (standardized)

Consolidating to consistent names makes it easier to manage and audit secrets.

## Testing

Verified `BOT_GITHUB_TOKEN` can:
- Clone private org repos
- List org repos (for dependabot management)
- Dispatch workflows
- Push to org repos (used for PR creation)