### PR TITLE
fix: add missing space in error message across 4 MCP servers

### DIFF
--- a/hailuo/core/config.py
+++ b/hailuo/core/config.py
@@ -56,7 +56,7 @@ class Settings:
         """Validate required settings."""
         if not self.api_token:
             raise ValueError(
-                "ACEDATACLOUD_API_TOKEN environment variable is required."
+                "ACEDATACLOUD_API_TOKEN environment variable is required. "
                 "Get your token from https://platform.acedata.cloud"
             )
 

--- a/kling/core/config.py
+++ b/kling/core/config.py
@@ -64,7 +64,7 @@ class Settings:
         """Validate required settings."""
         if not self.api_token:
             raise ValueError(
-                "ACEDATACLOUD_API_TOKEN environment variable is required."
+                "ACEDATACLOUD_API_TOKEN environment variable is required. "
                 "Get your token from https://platform.acedata.cloud"
             )
 

--- a/midjourney/core/config.py
+++ b/midjourney/core/config.py
@@ -54,7 +54,7 @@ class Settings:
         """Validate required settings."""
         if not self.api_token:
             raise ValueError(
-                "ACEDATACLOUD_API_TOKEN environment variable is required."
+                "ACEDATACLOUD_API_TOKEN environment variable is required. "
                 "Get your token from https://platform.acedata.cloud"
             )
 

--- a/wan/core/config.py
+++ b/wan/core/config.py
@@ -59,7 +59,7 @@ class Settings:
         """Validate required settings."""
         if not self.api_token:
             raise ValueError(
-                "ACEDATACLOUD_API_TOKEN environment variable is required."
+                "ACEDATACLOUD_API_TOKEN environment variable is required. "
                 "Get your token from https://platform.acedata.cloud"
             )
 


### PR DESCRIPTION
Python implicit string concatenation missing a trailing space after the period, causing error messages like:

```
ACEDATACLOUD_API_TOKEN environment variable is required.Get your token from ...
```

Fixed in: midjourney, kling, hailuo, wan. The other 11 servers already had the correct spacing.