### PR TITLE
feat(kling): add kling-v3, v3-omni, v2-6 model support

### DIFF
--- a/kling/core/types.py
+++ b/kling/core/types.py
@@ -9,6 +9,9 @@ KlingModel = Literal[
     "kling-v2-master",
     "kling-v2-1-master",
     "kling-v2-5-turbo",
+    "kling-v2-6",
+    "kling-v3",
+    "kling-v3-omni",
     "kling-video-o1",
 ]
 
@@ -24,8 +27,8 @@ Mode = Literal["std", "pro"]
 # Kling video aspect ratios
 AspectRatio = Literal["16:9", "9:16", "1:1"]
 
-# Kling video durations
-Duration = Literal[5, 10]
+# Kling video durations (V3/V3-Omni support 3-15s, others support 5 or 10)
+Duration = int
 
 # Kling camera control types
 CameraControlType = Literal[

--- a/kling/tools/video_tools.py
+++ b/kling/tools/video_tools.py
@@ -30,7 +30,7 @@ async def kling_generate_video(
     model: Annotated[
         KlingModel,
         Field(
-            description="Kling model to use. Options: 'kling-v1', 'kling-v1-6', 'kling-v2-master' (default), 'kling-v2-1-master', 'kling-v2-5-turbo', 'kling-video-o1'."
+            description="Kling model to use. Options: 'kling-v1', 'kling-v1-6', 'kling-v2-master' (default), 'kling-v2-1-master', 'kling-v2-5-turbo', 'kling-v2-6', 'kling-v3', 'kling-v3-omni', 'kling-video-o1'."
         ),
     ] = DEFAULT_MODEL,
     mode: Annotated[
@@ -47,8 +47,16 @@ async def kling_generate_video(
     ] = DEFAULT_ASPECT_RATIO,
     duration: Annotated[
         Duration,
-        Field(description="Video duration in seconds. Options: 5 (default) or 10."),
+        Field(
+            description="Video duration in seconds. For kling-v3/kling-v3-omni: 3-15 (integer). Other models: 5 or 10."
+        ),
     ] = DEFAULT_DURATION,
+    generate_audio: Annotated[
+        bool,
+        Field(
+            description="Whether to generate audio synchronously. Supported by kling-v3, kling-v3-omni, and kling-v2-6 (pro mode only). Default is false."
+        ),
+    ] = False,
     negative_prompt: Annotated[
         str | None,
         Field(
@@ -104,6 +112,8 @@ async def kling_generate_video(
         "callback_url": callback_url,
     }
 
+    if generate_audio:
+        payload["generate_audio"] = True
     if negative_prompt:
         payload["negative_prompt"] = negative_prompt
     if cfg_scale is not None:
@@ -149,8 +159,16 @@ async def kling_generate_video_from_image(
     ] = DEFAULT_ASPECT_RATIO,
     duration: Annotated[
         Duration,
-        Field(description="Video duration in seconds. Options: 5 (default) or 10."),
+        Field(
+            description="Video duration in seconds. For kling-v3/kling-v3-omni: 3-15 (integer). Other models: 5 or 10."
+        ),
     ] = DEFAULT_DURATION,
+    generate_audio: Annotated[
+        bool,
+        Field(
+            description="Whether to generate audio synchronously. Supported by kling-v3, kling-v3-omni, and kling-v2-6 (pro mode only)."
+        ),
+    ] = False,
     negative_prompt: Annotated[
         str | None,
         Field(description="Things to avoid in the video."),
@@ -207,6 +225,8 @@ async def kling_generate_video_from_image(
         payload["start_image_url"] = start_image_url
     if end_image_url:
         payload["end_image_url"] = end_image_url
+    if generate_audio:
+        payload["generate_audio"] = True
     if negative_prompt:
         payload["negative_prompt"] = negative_prompt
     if cfg_scale is not None:


### PR DESCRIPTION
## Summary
- Add `kling-v2-6`, `kling-v3`, `kling-v3-omni` to `KlingModel` Literal type
- Change `Duration` from `Literal[5, 10]` to `int` for V3 flexible 3-15s support
- Add `generate_audio` parameter to `kling_generate_video` and `kling_generate_video_from_image` tools
- Update model/duration descriptions across all tool functions

## Test plan
- [x] All 23 existing tests pass (3 skipped integration tests)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)