### PR TITLE
fix: standardize veo model name to veo31-fast-ingredients

### DIFF
--- a/veo/core/types.py
+++ b/veo/core/types.py
@@ -10,7 +10,7 @@ VeoModel = Literal[
     "veo3-fast",
     "veo31",
     "veo31-fast",
-    "veo31-fast-ingredient",
+    "veo31-fast-ingredients",
 ]
 
 # Aspect ratio options

--- a/veo/tools/info_tools.py
+++ b/veo/tools/info_tools.py
@@ -15,7 +15,7 @@ async def veo_list_models() -> str:
     - veo2/veo2-fast: Standard models, 1 image (first frame)
     - veo3/veo3-fast: Improved quality, 1-3 images supported
     - veo31/veo31-fast: Latest models, 1-3 images supported
-    - veo31-fast-ingredient: Multi-image fusion mode (image2video only)
+    - veo31-fast-ingredients: Multi-image fusion mode (image2video only)
 
     Returns:
         Table of all models with their capabilities and image rules.
@@ -31,18 +31,18 @@ async def veo_list_models() -> str:
 | veo3-fast              | ✅         | ✅          | 1-3 images (first/last)      |
 | veo31                  | ✅         | ✅          | 1-3 images (first/last)      |
 | veo31-fast             | ✅         | ✅          | 1-3 images (first/last)      |
-| veo31-fast-ingredient  | ❌         | ✅          | 1-3 images (multi-fusion)    |
+| veo31-fast-ingredients  | ❌         | ✅          | 1-3 images (multi-fusion)    |
 
 Image Input Modes:
 - First Frame Mode (1 image): Video starts from your image
 - First/Last Frame Mode (2-3 images): Video interpolates between images
-- Multi-Fusion Mode (veo31-fast-ingredient only): Blends elements from all images
+- Multi-Fusion Mode (veo31-fast-ingredients only): Blends elements from all images
 
 Recommendations:
 - For quick generation: Use '-fast' suffix models
 - For best quality: Use veo31 or veo3 (non-fast)
-- For image fusion: Use veo31-fast-ingredient
-- For text-only: Any model except veo31-fast-ingredient
+- For image fusion: Use veo31-fast-ingredients
+- For text-only: Any model except veo31-fast-ingredients
 
 Aspect Ratios:
 - 16:9: Landscape/widescreen (default)
@@ -89,7 +89,7 @@ Workflow Examples:
 1. Quick video: veo_text_to_video → veo_get_task → (optional) veo_get_1080p
 2. Image animation: veo_image_to_video → veo_get_task
 3. Image transition: veo_image_to_video (with 2-3 images) → veo_get_task
-4. Multi-image fusion: veo_image_to_video (model=veo31-fast-ingredient) → veo_get_task
+4. Multi-image fusion: veo_image_to_video (model=veo31-fast-ingredients) → veo_get_task
 
 API Response States:
 - processing: Video is being generated

--- a/veo/tools/video_tools.py
+++ b/veo/tools/video_tools.py
@@ -99,7 +99,7 @@ async def veo_image_to_video(
     model: Annotated[
         VeoModel,
         Field(
-            description="Veo model version. Note: 'veo31-fast-ingredient' is for multi-image fusion mode only. Other models support 1 image (first frame) or 2-3 images (first/last frame)."
+            description="Veo model version. Note: 'veo31-fast-ingredients' is for multi-image fusion mode only. Other models support 1 image (first frame) or 2-3 images (first/last frame)."
         ),
     ] = DEFAULT_MODEL,
     aspect_ratio: Annotated[


### PR DESCRIPTION
## Summary
- Fix VeoMCP types, video_tools, and info_tools to use `veo31-fast-ingredients`

🤖 Generated with [Claude Code](https://claude.com/claude-code)