### PR TITLE
fix(midjourney): apply ruff format to tools/task_tools.py

### DIFF
--- a/midjourney/tools/task_tools.py
+++ b/midjourney/tools/task_tools.py
@@ -73,9 +73,7 @@ async def midjourney_get_tasks_batch(
     ] = 0,
     limit: Annotated[
         int,
-        Field(
-            description="Maximum number of tasks to return in a batch. Default is 12."
-        ),
+        Field(description="Maximum number of tasks to return in a batch. Default is 12."),
     ] = 12,
 ) -> str:
     """Query multiple Midjourney generation tasks at once.


### PR DESCRIPTION
Lint job failing on main after auto-sync from Docs: https://github.com/AceDataCloud/MCPs/actions/runs/24961885567/job/73089858729

Ran ruff format tools/task_tools.py to collapse a multi-line Field(description=...) call onto a single line.