### PR TITLE
Declare MCP OAuth access scope

### DIFF
--- a/aichat/core/oauth.py
+++ b/aichat/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/aichat/core/server.py
+++ b/aichat/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/aichat/tools/chat_tools.py
+++ b/aichat/tools/chat_tools.py
@@ -15,11 +15,7 @@ from core.types import DEFAULT_MODEL, AiChatModel
 async def aichat_create_conversation(
     question: Annotated[
         str,
-        Field(
-            description=(
-                "The prompt or question to be answered by the AI model. Required."
-            )
-        ),
+        Field(description=("The prompt or question to be answered by the AI model. Required.")),
     ],
     model: Annotated[
         AiChatModel,
@@ -44,9 +40,7 @@ async def aichat_create_conversation(
     preset: Annotated[
         str | None,
         Field(
-            description=(
-                "An optional preset model configuration to apply for this conversation."
-            )
+            description=("An optional preset model configuration to apply for this conversation.")
         ),
     ] = None,
     stateful: Annotated[

--- a/flux/core/oauth.py
+++ b/flux/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/flux/core/server.py
+++ b/flux/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/hailuo/core/oauth.py
+++ b/hailuo/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/hailuo/core/server.py
+++ b/hailuo/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/kling/core/oauth.py
+++ b/kling/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/kling/core/server.py
+++ b/kling/core/server.py
@@ -38,8 +38,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/luma/core/oauth.py
+++ b/luma/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/luma/core/server.py
+++ b/luma/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/midjourney/core/oauth.py
+++ b/midjourney/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/midjourney/core/server.py
+++ b/midjourney/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/nanobanana/core/oauth.py
+++ b/nanobanana/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/nanobanana/core/server.py
+++ b/nanobanana/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/openai/core/oauth.py
+++ b/openai/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/openai/core/server.py
+++ b/openai/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/openai/tools/image_tools.py
+++ b/openai/tools/image_tools.py
@@ -81,9 +81,7 @@ async def openai_generate_image(
     ] = None,
     output_format: Annotated[
         ImageOutputFormat,
-        Field(
-            description="Output file format. Options: 'png' (default), 'jpeg', 'webp'."
-        ),
+        Field(description="Output file format. Options: 'png' (default), 'jpeg', 'webp'."),
     ] = DEFAULT_IMAGE_OUTPUT_FORMAT,
     response_format: Annotated[
         ImageResponseFormat,
@@ -124,9 +122,7 @@ async def openai_generate_image(
     output_compression: Annotated[
         int | None,
         Field(
-            description=(
-                "Compression level (0-100%) for jpeg/webp output formats. Default is 100."
-            )
+            description=("Compression level (0-100%) for jpeg/webp output formats. Default is 100.")
         ),
     ] = None,
     partial_images: Annotated[
@@ -276,9 +272,7 @@ async def openai_edit_image(
     ] = None,
     output_format: Annotated[
         ImageOutputFormat,
-        Field(
-            description="Output file format. Options: 'png' (default), 'jpeg', 'webp'."
-        ),
+        Field(description="Output file format. Options: 'png' (default), 'jpeg', 'webp'."),
     ] = DEFAULT_IMAGE_OUTPUT_FORMAT,
     response_format: Annotated[
         ImageResponseFormat,
@@ -291,9 +285,7 @@ async def openai_edit_image(
     ] = DEFAULT_IMAGE_RESPONSE_FORMAT,
     output_compression: Annotated[
         int | None,
-        Field(
-            description="Compression level (0-100%) for jpeg/webp output. Default is 100."
-        ),
+        Field(description="Compression level (0-100%) for jpeg/webp output. Default is 100."),
     ] = None,
     callback_url: Annotated[
         str | None,

--- a/openai/tools/responses_tools.py
+++ b/openai/tools/responses_tools.py
@@ -55,9 +55,7 @@ async def openai_create_response(
     ] = None,
     n: Annotated[
         int | None,
-        Field(
-            description="Number of response choices to generate. Default is 1."
-        ),
+        Field(description="Number of response choices to generate. Default is 1."),
     ] = None,
     background: Annotated[
         bool | None,

--- a/producer/core/oauth.py
+++ b/producer/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/producer/core/server.py
+++ b/producer/core/server.py
@@ -38,8 +38,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/seedance/core/oauth.py
+++ b/seedance/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/seedance/core/server.py
+++ b/seedance/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/seedream/core/oauth.py
+++ b/seedream/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/seedream/core/server.py
+++ b/seedream/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/serp/core/oauth.py
+++ b/serp/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/serp/core/server.py
+++ b/serp/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/shorturl/core/oauth.py
+++ b/shorturl/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/shorturl/core/server.py
+++ b/shorturl/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/sora/core/oauth.py
+++ b/sora/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/sora/core/server.py
+++ b/sora/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/suno/core/oauth.py
+++ b/suno/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/suno/core/server.py
+++ b/suno/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/suno/tests/test_oauth.py
+++ b/suno/tests/test_oauth.py
@@ -1,0 +1,26 @@
+"""Tests for hosted MCP OAuth behavior."""
+
+import pytest
+
+
+def test_normalize_scopes_defaults_to_mcp_access():
+    from core.oauth import MCP_ACCESS_SCOPE, _normalize_scopes
+
+    assert _normalize_scopes(None) == [MCP_ACCESS_SCOPE]
+    assert _normalize_scopes([]) == [MCP_ACCESS_SCOPE]
+
+
+@pytest.mark.asyncio
+async def test_direct_api_token_gets_mcp_access_scope(monkeypatch):
+    from core import oauth
+
+    captured = {}
+    monkeypatch.setattr(
+        oauth, "set_request_api_token", lambda token: captured.setdefault("token", token)
+    )
+
+    provider = oauth.AceDataCloudOAuthProvider()
+    access_token = await provider.load_access_token("test-api-token")
+
+    assert captured["token"] == "test-api-token"
+    assert access_token.scopes == [oauth.MCP_ACCESS_SCOPE]

--- a/veo/core/oauth.py
+++ b/veo/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/veo/core/server.py
+++ b/veo/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 

--- a/wan/core/oauth.py
+++ b/wan/core/oauth.py
@@ -37,6 +37,12 @@ from starlette.responses import JSONResponse, RedirectResponse
 from core.client import set_request_api_token
 from core.config import settings
 
+MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _normalize_scopes(scopes: list[str] | None) -> list[str]:
+    return scopes or [MCP_ACCESS_SCOPE]
+
 
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
@@ -80,7 +86,7 @@ class AceDataCloudOAuthProvider:
             "state": params.state,
             "code_challenge": params.code_challenge,
             "redirect_uri_provided_explicitly": params.redirect_uri_provided_explicitly,
-            "scopes": params.scopes,
+            "scopes": _normalize_scopes(params.scopes),
             "resource": params.resource,
             "auth_code_verifier": code_verifier,
         }
@@ -165,7 +171,7 @@ class AceDataCloudOAuthProvider:
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
-                scopes=pending.get("scopes") or [],
+                scopes=_normalize_scopes(pending.get("scopes")),
                 expires_at=time.time() + 600,  # 10 minutes
                 client_id=pending["client_id"],
                 code_challenge=pending["code_challenge"],
@@ -218,7 +224,7 @@ class AceDataCloudOAuthProvider:
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
             expires_at=None,  # API credential tokens don't expire by time
         )
 
@@ -227,13 +233,14 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[refresh_token_str] = RefreshToken(
             token=refresh_token_str,
             client_id=client_id,
-            scopes=authorization_code.scopes,
+            scopes=_normalize_scopes(authorization_code.scopes),
         )
 
         logger.info(f"OAuth token exchange: issued access token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
+            scope=" ".join(_normalize_scopes(authorization_code.scopes)),
             refresh_token=refresh_token_str,
         )
 
@@ -261,7 +268,7 @@ class AceDataCloudOAuthProvider:
         self._refresh_tokens[new_refresh] = RefreshToken(
             token=new_refresh,
             client_id=client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=_normalize_scopes(scopes or refresh_token.scopes),
         )
 
         # Find the access token for this client
@@ -270,6 +277,7 @@ class AceDataCloudOAuthProvider:
                 return OAuthToken(
                     access_token=token,
                     token_type="Bearer",
+                    scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
                     refresh_token=new_refresh,
                 )
 
@@ -292,7 +300,7 @@ class AceDataCloudOAuthProvider:
 
         # Accept direct API credential tokens (for VS Code, Cursor, etc.)
         set_request_api_token(token)
-        return AccessToken(token=token, client_id="direct", scopes=[])
+        return AccessToken(token=token, client_id="direct", scopes=[MCP_ACCESS_SCOPE])
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):

--- a/wan/core/server.py
+++ b/wan/core/server.py
@@ -34,8 +34,13 @@ if settings.server_url:
     mcp_kwargs["auth"] = AuthSettings(
         issuer_url=AnyHttpUrl(settings.server_url),
         resource_server_url=AnyHttpUrl(settings.server_url),
-        client_registration_options=ClientRegistrationOptions(enabled=True),
+        client_registration_options=ClientRegistrationOptions(
+            enabled=True,
+            valid_scopes=["mcp:access"],
+            default_scopes=["mcp:access"],
+        ),
         revocation_options=RevocationOptions(enabled=True),
+        required_scopes=["mcp:access"],
     )
     logger.info(f"OAuth enabled: issuer_url={settings.server_url}")
 


### PR DESCRIPTION
## Summary
- declare mcp:access as the hosted MCP OAuth scope in every server package
- return scope in authorization-code and refresh-token responses
- keep direct AceDataCloud API key bearer access compatible with required MCP scope checks
- add representative Suno OAuth tests

## Verification
- python -m ruff check */core/oauth.py */core/server.py suno/tests/test_oauth.py
- python -m py_compile */core/oauth.py */core/server.py suno/tests/test_oauth.py
- cd suno && python -m pytest tests/test_oauth.py