### PR TITLE
feat(veo): add upsample, extend, reshoot, objects, ingredients tools

### DIFF
--- a/veo/CHANGELOG.md
+++ b/veo/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Five new tools matching the platform's expanded `/veo/*` surface:
+  - `veo_upsample` — upscale to 1080p / 4K or render an animated GIF preview (new dedicated `/veo/upsample` endpoint).
+  - `veo_extend` — extend the duration of a previously generated video (`veo31` series only).
+  - `veo_reshoot` — re-render with a different camera motion (15 motion-type aliases mapped to upstream `RESHOOT_MOTION_TYPE_*`).
+  - `veo_object_insert` — insert an object/effect into an existing video, with optional image-mask placement.
+  - `veo_object_remove` — erase a region defined by a white-pixel image mask.
+- New `veo_ingredients_to_video` tool for the `veo31-fast-ingredients` multi-image fusion mode (previously had to be invoked through `veo_image_to_video` with implicit model selection).
+- New types in `core/types.py`: `UpsampleAction`, `ExtendModel`, `ObjectAction`, `MotionType`.
+- New client convenience methods in `core/client.py`: `upsample_video`, `extend_video`, `reshoot_video`, `manipulate_object`.
+
+### Changed
+
+- Updated `veo_list_actions` to document all 12 tools, the workflow examples, and the upstream constraint that extend outputs cannot be reshot / object-edited.
+
+### Backward compatibility
+
+- The legacy `veo_get_1080p` tool is preserved unchanged; it continues to call `/veo/videos` with `action=get1080p`, which the platform now aliases to `/veo/upsample` with `action=1080p`. New code should prefer `veo_upsample`.
+
 ## [0.1.0] - 2025-06-01
 
 ### Added

--- a/veo/core/client.py
+++ b/veo/core/client.py
@@ -174,11 +174,58 @@ class VeoClient:
         return await self.request("/veo/videos", self._with_async_callback(kwargs))
 
     async def get_1080p(self, video_id: str) -> dict[str, Any]:
-        """Get 1080p version of a video."""
+        """Get 1080p version of a video.
+
+        Kept for backward compatibility with existing MCP clients. Internally
+        forwards to the /veo/videos endpoint with action=get1080p, which the
+        platform aliases to /veo/upsample with action=1080p.
+        """
         logger.info(f"📺 Getting 1080p video for: {video_id}")
         return await self.request(
             "/veo/videos", self._with_async_callback({"action": "get1080p", "video_id": video_id})
         )
+
+    async def upsample_video(self, video_id: str, action: str) -> dict[str, Any]:
+        """Upsample a video to 1080p / 4k or render a GIF preview."""
+        logger.info(f"📺 Upsampling video {video_id} to {action}")
+        return await self.request(
+            "/veo/upsample",
+            self._with_async_callback({"video_id": video_id, "action": action}),
+        )
+
+    async def extend_video(
+        self, video_id: str, model: str, prompt: str | None = None
+    ) -> dict[str, Any]:
+        """Extend the duration of a previously generated video (veo31 only)."""
+        logger.info(f"⏩ Extending video {video_id} with model {model}")
+        payload: dict[str, Any] = {"video_id": video_id, "model": model}
+        if prompt:
+            payload["prompt"] = prompt
+        return await self.request("/veo/extend", self._with_async_callback(payload))
+
+    async def reshoot_video(self, video_id: str, motion_type: str) -> dict[str, Any]:
+        """Re-render a video with a different camera motion."""
+        logger.info(f"🎥 Reshooting video {video_id} with motion {motion_type}")
+        return await self.request(
+            "/veo/reshoot",
+            self._with_async_callback({"video_id": video_id, "motion_type": motion_type}),
+        )
+
+    async def manipulate_object(
+        self,
+        video_id: str,
+        action: str,
+        prompt: str | None = None,
+        image_mask: str | None = None,
+    ) -> dict[str, Any]:
+        """Insert or remove an object in a previously generated video."""
+        logger.info(f"✂️ {action.title()}ing object in video {video_id}")
+        payload: dict[str, Any] = {"video_id": video_id, "action": action}
+        if prompt:
+            payload["prompt"] = prompt
+        if image_mask:
+            payload["image_mask"] = image_mask
+        return await self.request("/veo/objects", self._with_async_callback(payload))
 
     async def query_task(self, **kwargs: Any) -> dict[str, Any]:
         """Query task status using the tasks endpoint."""

--- a/veo/core/types.py
+++ b/veo/core/types.py
@@ -24,3 +24,32 @@ VideoResolution = Literal["4k", "1080p", "gif"]
 
 # Default aspect ratio
 DEFAULT_ASPECT_RATIO: AspectRatio = "16:9"
+
+# /veo/upsample actions
+UpsampleAction = Literal["1080p", "4k", "gif"]
+
+# /veo/extend supported models
+ExtendModel = Literal["veo31-fast", "veo31"]
+
+# /veo/objects actions
+ObjectAction = Literal["insert", "remove"]
+
+# /veo/reshoot motion types — short uppercase aliases mapped to upstream
+# RESHOOT_MOTION_TYPE_* values by the platform-service worker.
+MotionType = Literal[
+    "STATIONARY",
+    "STATIONARY_UP",
+    "STATIONARY_DOWN",
+    "STATIONARY_LEFT",
+    "STATIONARY_RIGHT",
+    "STATIONARY_DOLLY_IN_ZOOM_OUT",
+    "STATIONARY_DOLLY_OUT_ZOOM_IN",
+    "UP",
+    "DOWN",
+    "LEFT_TO_RIGHT",
+    "RIGHT_TO_LEFT",
+    "FORWARD",
+    "BACKWARD",
+    "DOLLY_IN_ZOOM_OUT",
+    "DOLLY_OUT_ZOOM_IN",
+]

--- a/veo/tests/test_client.py
+++ b/veo/tests/test_client.py
@@ -17,3 +17,25 @@ def test_with_async_callback_preserves_explicit_callback() -> None:
         {"action": "text2video", "callback_url": "https://example.com/webhook"}
     )
     assert payload["callback_url"] == "https://example.com/webhook"
+
+
+def test_new_endpoint_methods_exist() -> None:
+    """The 4 new mountsea-backed endpoints (upsample / extend / reshoot /
+    objects) must each have a dedicated convenience method on VeoClient.
+    """
+    client = VeoClient(api_token="test-token", base_url="https://api.test.com")
+    for method in (
+        "upsample_video",
+        "extend_video",
+        "reshoot_video",
+        "manipulate_object",
+    ):
+        assert callable(getattr(client, method)), f"VeoClient is missing {method}"
+
+
+def test_get_1080p_kept_for_backcompat() -> None:
+    """The legacy get_1080p() method must remain callable so existing MCP
+    clients keep working after the new /veo/upsample tool ships.
+    """
+    client = VeoClient(api_token="test-token", base_url="https://api.test.com")
+    assert callable(client.get_1080p)

--- a/veo/tools/info_tools.py
+++ b/veo/tools/info_tools.py
@@ -68,13 +68,21 @@ async def veo_list_actions() -> str:
     Returns:
         Categorized list of all actions and their corresponding tools.
     """
-    # Last updated: 2026-04-05
+    # Last updated: 2026-05-04
     return """Available Veo Actions and Tools:
 
 Video Generation:
 - veo_text_to_video: Create video from a text prompt only
-- veo_image_to_video: Create video from reference image(s) + prompt
-- veo_get_1080p: Get high-resolution 1080p version of a video
+- veo_image_to_video: Create video from reference image(s) + prompt (1-3 images, first/last frame mode)
+- veo_ingredients_to_video: Fuse 1-3 reference images into a new scene (veo31-fast-ingredients model)
+
+Video Post-Processing (operate on a previously generated video_id):
+- veo_upsample: Upscale to 1080p / 4K, or render an animated GIF preview
+- veo_extend: Extend the video's duration (veo31 series only). Output may be extended further but not reshot/edited.
+- veo_reshoot: Re-render with a different camera motion (15 motion types: STATIONARY*, UP/DOWN, LEFT_TO_RIGHT, FORWARD/BACKWARD, DOLLY_IN/OUT_ZOOM_OUT/IN, ...). Not supported on extend outputs.
+- veo_object_insert: Add an object/effect to the video (with optional mask for placement). Not supported on extend outputs.
+- veo_object_remove: Erase an object via white-pixel mask. Not supported on extend outputs.
+- veo_get_1080p: [legacy] Equivalent to veo_upsample with action='1080p'. Kept for backward compatibility.
 
 Task Management:
 - veo_get_task: Check status of a single video generation
@@ -86,10 +94,19 @@ Information:
 - veo_get_prompt_guide: Get tips for writing effective video prompts
 
 Workflow Examples:
-1. Quick video: veo_text_to_video → veo_get_task → (optional) veo_get_1080p
-2. Image animation: veo_image_to_video → veo_get_task
-3. Image transition: veo_image_to_video (with 2-3 images) → veo_get_task
-4. Multi-image fusion: veo_image_to_video (model=veo31-fast-ingredients) → veo_get_task
+1. Quick video: veo_text_to_video → veo_get_task → (optional) veo_upsample(action='1080p')
+2. 4K production: veo_text_to_video → veo_get_task → veo_upsample(action='4k')
+3. Image animation: veo_image_to_video → veo_get_task
+4. Image transition: veo_image_to_video (with 2-3 images) → veo_get_task
+5. Multi-image fusion: veo_ingredients_to_video → veo_get_task
+6. Try a different camera move: veo_text_to_video → veo_reshoot(motion_type='LEFT_TO_RIGHT') → veo_get_task
+7. Make it longer: veo_text_to_video (model=veo31-fast) → veo_extend(prompt='...') → veo_get_task
+8. Remove an unwanted element: veo_text_to_video → veo_object_remove(image_mask='https://.../mask.jpg') → veo_get_task
+9. Add a flourish: veo_text_to_video → veo_object_insert(prompt='add fireworks') → veo_get_task
+
+Constraint to remember:
+  Outputs of veo_extend can be extended further, but cannot be passed to
+  veo_reshoot / veo_object_insert / veo_object_remove (upstream limit).
 
 API Response States:
 - processing: Video is being generated
@@ -99,7 +116,7 @@ API Response States:
 Tips:
 - Generation typically takes 1-2 minutes
 - Use callback_url for async notifications
-- Request 1080p after initial generation succeeds
+- Request 1080p / 4K after initial generation succeeds
 """
 
 

--- a/veo/tools/video_tools.py
+++ b/veo/tools/video_tools.py
@@ -6,7 +6,16 @@ from pydantic import Field
 
 from core.client import client
 from core.server import mcp
-from core.types import DEFAULT_ASPECT_RATIO, DEFAULT_MODEL, AspectRatio, VeoModel, VideoResolution
+from core.types import (
+    DEFAULT_ASPECT_RATIO,
+    DEFAULT_MODEL,
+    AspectRatio,
+    ExtendModel,
+    MotionType,
+    UpsampleAction,
+    VeoModel,
+    VideoResolution,
+)
 from core.utils import format_video_result
 
 
@@ -190,4 +199,312 @@ async def veo_get_1080p(
         Task ID and the 1080p video information including the new video URL.
     """
     result = await client.get_1080p(video_id)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_upsample(
+    video_id: Annotated[
+        str,
+        Field(
+            description="The video ID from a previous generation result (the 'id' field of a video data item, not the task_id). May come from any of veo_text_to_video, veo_image_to_video, veo_extend, veo_reshoot, veo_object_insert, veo_object_remove."
+        ),
+    ],
+    action: Annotated[
+        UpsampleAction,
+        Field(
+            description="What to produce. '1080p' upscales to 1080p HD, '4k' upscales to 4K, 'gif' renders an animated GIF preview."
+        ),
+    ],
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when the upsample completes."),
+    ] = "",
+) -> str:
+    """Upsample a generated Veo video to 1080p / 4K, or render a GIF preview.
+
+    Successor to veo_get_1080p — use this whenever you want anything other
+    than just 1080p, or when you want the new dedicated /veo/upsample
+    endpoint instead of the legacy /veo/videos action=get1080p alias.
+
+    Use this when:
+    - You need 4K resolution for production-quality delivery
+    - You need an animated GIF preview for embedding/sharing
+    - You want explicit semantics over the legacy get1080p alias
+
+    Note: The source video must be in 'succeeded' state.
+
+    Returns:
+        Task ID and the upsampled video information.
+    """
+    payload: dict = {"video_id": video_id, "action": action}
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.upsample_video(**payload)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_extend(
+    video_id: Annotated[
+        str,
+        Field(
+            description="The video ID from a previous generation result (the 'id' field of a video data item, not the task_id). The source video must NOT itself be the result of /veo/reshoot or /veo/objects — extend can chain on its own outputs but not on those."
+        ),
+    ],
+    model: Annotated[
+        ExtendModel,
+        Field(
+            description="Model to extend with. Only the Veo 3.1 series is supported upstream: 'veo31-fast' for the cheap fast tier, 'veo31' for the higher-quality slower tier."
+        ),
+    ] = "veo31-fast",
+    prompt: Annotated[
+        str,
+        Field(
+            description="Optional prompt that guides the extended section's content. Examples: 'the camera slowly zooms out to reveal more of the landscape', 'the bird flies up toward the moon'. If empty, the model continues the existing scene's momentum on its own."
+        ),
+    ] = "",
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when the extension completes."),
+    ] = "",
+) -> str:
+    """Extend the duration of a previously generated Veo video.
+
+    Adds extra seconds to the end of an existing video. The model continues
+    the scene; an optional prompt steers what happens next.
+
+    Use this when:
+    - The first generation was too short and you want to keep it going
+    - You want to add a specific follow-up action (described via prompt)
+    - You want a longer final piece without re-running the whole prompt
+
+    Important constraints (enforced upstream):
+    - Only veo31-fast / veo31 models are supported.
+    - Outputs of /veo/extend can be extended further, but cannot be passed
+      to /veo/reshoot, /veo/objects (insert/remove). The platform returns
+      400 in that case with a clear message.
+
+    Returns:
+        Task ID and the extended video information.
+    """
+    payload: dict = {"video_id": video_id, "model": model}
+    if prompt:
+        payload["prompt"] = prompt
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.extend_video(**payload)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_reshoot(
+    video_id: Annotated[
+        str,
+        Field(
+            description="The video ID from a previous generation result (the 'id' field of a video data item, not the task_id). NOT supported on outputs of /veo/extend."
+        ),
+    ],
+    motion_type: Annotated[
+        MotionType,
+        Field(
+            description=(
+                "Camera motion to apply when re-rendering. STATIONARY* keeps the camera "
+                "fixed (with optional pan/tilt/dolly-zoom). UP/DOWN move the camera "
+                "vertically. LEFT_TO_RIGHT/RIGHT_TO_LEFT translate it horizontally. "
+                "FORWARD/BACKWARD move it along the depth axis. DOLLY_IN_ZOOM_OUT / "
+                "DOLLY_OUT_ZOOM_IN apply the classic Hitchcock dolly-zoom effect."
+            )
+        ),
+    ],
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when the reshoot completes."),
+    ] = "",
+) -> str:
+    """Re-render an existing Veo video with a different camera motion.
+
+    Keeps the same scene content (subjects, action, lighting) but changes
+    how the camera moves through it. Useful for trying alternative shot
+    framings without re-prompting the whole video.
+
+    Use this when:
+    - You like the content but want a different camera move (push-in,
+      tracking, dolly zoom, etc.)
+    - You want to A/B-test framings cheaply
+    - You need a static-camera version (e.g. STATIONARY) of a video that
+      originally had unwanted motion
+
+    Important: NOT supported on /veo/extend outputs (upstream limitation).
+
+    Returns:
+        Task ID and the reshot video information.
+    """
+    payload: dict = {"video_id": video_id, "motion_type": motion_type}
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.reshoot_video(**payload)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_object_insert(
+    video_id: Annotated[
+        str,
+        Field(
+            description="The video ID from a previous generation result (the 'id' field of a video data item, not the task_id). NOT supported on outputs of /veo/extend."
+        ),
+    ],
+    prompt: Annotated[
+        str,
+        Field(
+            description="What to insert. Examples: 'add a flying pig with black wings', 'add a small bird gliding past the moon', 'add a coffee cup on the table in the foreground'."
+        ),
+    ],
+    image_mask: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional mask. Either a publicly reachable HTTP(S) URL to a JPEG, or a "
+                "base64-encoded JPEG string (with or without a 'data:image/jpeg;base64,' "
+                "prefix). White pixels mark where to insert. If omitted, the AI "
+                "auto-determines placement based on the prompt."
+            )
+        ),
+    ] = "",
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when the insert completes."),
+    ] = "",
+) -> str:
+    """Insert an object into a previously generated Veo video.
+
+    Adds a new element to the scene without re-prompting the whole video.
+
+    Use this when:
+    - You want to add a character, prop, or visual effect to existing footage
+    - You like the original video but it's missing one element
+    - You want fine-grained control over placement (via image_mask)
+
+    Important: NOT supported on /veo/extend outputs (upstream limitation).
+
+    Returns:
+        Task ID and the modified video information.
+    """
+    payload: dict = {"video_id": video_id, "action": "insert", "prompt": prompt}
+    if image_mask:
+        payload["image_mask"] = image_mask
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.manipulate_object(**payload)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_object_remove(
+    video_id: Annotated[
+        str,
+        Field(
+            description="The video ID from a previous generation result (the 'id' field of a video data item, not the task_id). NOT supported on outputs of /veo/extend."
+        ),
+    ],
+    image_mask: Annotated[
+        str,
+        Field(
+            description=(
+                "REQUIRED for remove. Either a publicly reachable HTTP(S) URL to a JPEG, "
+                "or a base64-encoded JPEG string. White pixels mark the object to erase; "
+                "the AI fills the area with contextually appropriate content."
+            )
+        ),
+    ],
+    prompt: Annotated[
+        str,
+        Field(
+            description="Optional description of what is being removed. Mostly used for logging — the actual erase region is defined entirely by image_mask. Examples: 'remove the white cloud', 'remove the person in the foreground'."
+        ),
+    ] = "",
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when the remove completes."),
+    ] = "",
+) -> str:
+    """Remove an object from a previously generated Veo video.
+
+    Erases a region defined by an image mask and inpaints contextually
+    appropriate replacement content.
+
+    Use this when:
+    - You need to remove an unwanted element (logo, person, prop, distraction)
+    - You want a clean version of footage that came out almost-right
+    - The mask is what's authoritative — prompt is just for log/audit
+
+    Important: NOT supported on /veo/extend outputs (upstream limitation).
+
+    Returns:
+        Task ID and the modified video information.
+    """
+    payload: dict = {"video_id": video_id, "action": "remove", "image_mask": image_mask}
+    if prompt:
+        payload["prompt"] = prompt
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.manipulate_object(**payload)
+    return format_video_result(result)
+
+
+@mcp.tool()
+async def veo_ingredients_to_video(
+    image_urls: Annotated[
+        list[str],
+        Field(
+            description="1-3 reference image URLs whose elements should be fused into the generated video. Unlike veo_image_to_video (which uses images as start/end frames), this blends multiple visual elements into a single new scene."
+        ),
+    ],
+    prompt: Annotated[
+        str,
+        Field(
+            description="Optional prompt to steer how the elements are combined. Examples: 'the cat from image 1 wearing the hat from image 2 walking through the meadow from image 3'."
+        ),
+    ] = "",
+    aspect_ratio: Annotated[
+        AspectRatio,
+        Field(description="Video aspect ratio. '16:9' for landscape, '9:16' for portrait."),
+    ] = DEFAULT_ASPECT_RATIO,
+    translation: Annotated[
+        bool,
+        Field(description="If true, auto-translate the prompt to English for better quality."),
+    ] = False,
+    callback_url: Annotated[
+        str,
+        Field(description="Optional URL to receive a POST callback when generation completes."),
+    ] = "",
+) -> str:
+    """Generate a video by fusing 1-3 reference images (ingredients mode).
+
+    Uses the dedicated veo31-fast-ingredients model to blend multiple
+    visual elements into a single new scene. Different from
+    veo_image_to_video, which uses images as start/end frames.
+
+    Use this when:
+    - You have multiple images representing parts of what you want
+      (character + outfit + setting)
+    - You want a fused/blended result, not a frame-by-frame transition
+    - You're combining 2-3 distinct visual concepts into one shot
+
+    Returns:
+        Task ID and the generated video information.
+    """
+    payload: dict = {
+        "action": "ingredients2video",
+        "image_urls": image_urls,
+        "aspect_ratio": aspect_ratio,
+    }
+    if prompt:
+        payload["prompt"] = prompt
+    if translation:
+        payload["translation"] = translation
+    if callback_url:
+        payload["callback_url"] = callback_url
+    result = await client.generate_video(**payload)
     return format_video_result(result)


### PR DESCRIPTION
Mirrors the new `/veo/{upsample,extend,reshoot,objects}` endpoints shipped in [PlatformService #820](https://github.com/AceDataCloud/PlatformService/pull/820) and [PlatformBackend #389](https://github.com/AceDataCloud/PlatformBackend/pull/389). Also adds an explicit `veo_ingredients_to_video` tool that previously had to be triggered by passing the magic `veo31-fast-ingredients` model to `veo_image_to_video`.

## New tools

| Tool | Backed by | Purpose |
|---|---|---|
| `veo_upsample` | `POST /veo/upsample` | 1080p / 4K / GIF preview |
| `veo_extend` | `POST /veo/extend` | Extend duration (veo31 series only) |
| `veo_reshoot` | `POST /veo/reshoot` | Re-render with a different camera motion (15 motion-type aliases) |
| `veo_object_insert` | `POST /veo/objects` action=insert | Add an object/effect (with optional mask) |
| `veo_object_remove` | `POST /veo/objects` action=remove | Erase via white-pixel mask |
| `veo_ingredients_to_video` | `POST /veo/videos` action=ingredients2video | Multi-image fusion (1-3 ref imgs) |

## Backward compat

`veo_get_1080p` is preserved unchanged. It continues to hit `/veo/videos` with `action=get1080p`, which the platform aliases to `/veo/upsample` `action=1080p`. New code should prefer `veo_upsample`.

## Constraint surfaced in docstrings

Tool docstrings explicitly warn that **outputs of `veo_extend` can be further extended but cannot be passed to `veo_reshoot` / `veo_object_insert` / `veo_object_remove`** (upstream limitation, enforced by the worker with a 400).

## Files

- `core/types.py` — 4 new `Literal` types: `UpsampleAction`, `ExtendModel`, `ObjectAction`, `MotionType`
- `core/client.py` — 4 new convenience methods: `upsample_video`, `extend_video`, `reshoot_video`, `manipulate_object`
- `tools/video_tools.py` — 6 new `@mcp.tool()` definitions with rich Pydantic field descriptions
- `tools/info_tools.py` — `veo_list_actions` updated to document all 12 tools, new workflow examples, and the extend constraint
- `tests/test_client.py` — +2 tests asserting the new client methods exist + `get_1080p` backcompat
- `CHANGELOG.md` — Unreleased section documents the additions

## Validation

```
$ ruff check .
All checks passed!

$ ruff format --check .
20 files already formatted

$ pytest tests/test_client.py tests/test_config.py tests/test_utils.py
13 passed in 0.42s    # was 11; +2 new tests
```