### PR TITLE
feat(midjourney): add V8.1 to MidjourneyVersion and refresh prompt/tool docs

### DIFF
--- a/midjourney/core/types.py
+++ b/midjourney/core/types.py
@@ -6,7 +6,7 @@ from typing import Literal
 MidjourneyMode = Literal["fast", "relax", "turbo"]
 
 # Midjourney version
-MidjourneyVersion = Literal["5.2", "6", "6.1", "7", "8"]
+MidjourneyVersion = Literal["5.2", "6", "6.1", "7", "8", "8.1"]
 
 # Midjourney imagine actions
 ImagineAction = Literal[

--- a/midjourney/prompts/__init__.py
+++ b/midjourney/prompts/__init__.py
@@ -75,14 +75,15 @@ When the user wants to generate images, choose the appropriate tool based on the
 3. Use 'turbo' for faster results (more credits)
 4. Use 'relax' for slower, cheaper generation
 
-## Midjourney V8 (Alpha) Features:
-- **V8 is the latest model** - use `version='8'` for the newest capabilities
-- **HD Mode** (`hd=True`): Generates 2K resolution images. V8 only. Costs 4x credits.
-- **Quality 4** (`quality='4'`): Ultra-detail mode. V8 only. Costs 4x credits.
-- **HD + Q4 combined**: Maximum quality. Costs 16x credits.
-- **Style Reference** (`style_reference=True`): When prompt uses --sref. V8 premium feature, costs 4x.
-- **Moodboard** (`moodboard=True`): Blending multiple reference images. V8 premium feature, costs 4x.
-- V8 does NOT support --iw (image weight) parameter.
+## Midjourney V8.1 / V8 Features:
+- **V8.1 is the latest model** - use `version='8.1'` for the newest capabilities. HD is the default in V8.1.
+- **V8** (`version='8'`) is the prior Alpha; still available but more expensive than V8.1.
+- **HD Mode** (`hd=True`): Generates 2K resolution images. V8/V8.1 only. On V8 costs 4x credits; on V8.1 HD is ~3x cheaper and faster than V8 HD.
+- **Quality 4** (`quality='4'`): Ultra-detail mode. V8/V8.1 only. Costs 4x credits on V8 (cheaper on V8.1).
+- **HD + Q4 combined**: Maximum quality. Costs 16x credits on V8; ~3x cheaper on V8.1.
+- **Style Reference** (`style_reference=True`): When prompt uses --sref. V8 4x; V8.1 significantly cheaper & more stable.
+- **Moodboard** (`moodboard=True`): Blending multiple reference images. V8 4x; V8.1 super stable & cheaper.
+- V8/V8.1 do NOT support --iw (image weight) parameter on V8; image weights are restored on V8.1.
 """
 
 
@@ -130,8 +131,9 @@ def midjourney_workflow_examples() -> str:
 - Use aspect ratio parameter (--ar) for specific dimensions
 - Use --no parameter to exclude unwanted elements
 - For Chinese speakers, offer translation with `midjourney_translate`
-- For V8: use `version='8'` and consider `hd=True` for 2K, `quality='4'` for ultra detail
-- V8 premium features (sref, moodboard, HD, Q4) cost 4x credits each; HD+Q4 together cost 16x
+- For V8.1 (default for new requests): use `version='8.1'`; HD is default and ~3x cheaper than V8 HD. Consider `quality='4'` for ultra detail.
+- For V8 (legacy alpha): use `version='8'` and consider `hd=True` for 2K, `quality='4'` for ultra detail
+- V8 premium features (sref, moodboard, HD, Q4) cost 4x credits each; HD+Q4 together cost 16x. V8.1 is roughly 3x cheaper across these.
 """
 
 

--- a/midjourney/tools/imagine_tools.py
+++ b/midjourney/tools/imagine_tools.py
@@ -49,13 +49,13 @@ async def midjourney_imagine(
     version: Annotated[
         MidjourneyVersion | None,
         Field(
-            description="Midjourney model version to use. '8' is the latest V8 Alpha with HD and ultra quality support. Leave unset to use Midjourney's default."
+            description="Midjourney model version to use. '8.1' is the latest version (HD default, ~3x cheaper than V8). '8' is the prior V8 Alpha with HD/Q4 support. Leave unset to use Midjourney's default."
         ),
     ] = None,
     hd: Annotated[
         bool,
         Field(
-            description="Enable HD mode (V8 only). Generates higher resolution images at 4x cost. Requires version='8'."
+            description="Enable HD mode (V8/V8.1 only). Generates higher resolution images. V8 costs 4x; V8.1 HD is default and ~3x cheaper than V8 HD. Requires version='8' or '8.1'."
         ),
     ] = False,
     quality: Annotated[


### PR DESCRIPTION
## Why

[Midjourney V8.1](https://updates.midjourney.com/v8-1-alpha/) is now GA with HD as default, ~3x cheaper HD, ~25% cheaper SD, more stable moodboards/srefs, and image weights restored. The Midjourney MCP server should accept and recommend it.

## What

- `midjourney/core/types.py`: add `"8.1"` to the `MidjourneyVersion` Literal.
- `midjourney/prompts/__init__.py`: rewrite the V8 (Alpha) Features section to mention V8.1 as the latest (HD-default, ~3x cheaper); update the workflow tips so agents recommend `version='8.1'`.
- `midjourney/tools/imagine_tools.py`: update the `version` and `hd` parameter descriptions to mention V8.1 as latest and call out the HD pricing change.

No runtime behavior change — everything still routes through Midjourney's `version` field.

## Related

- AceDataCloud/PlatformBackend#472 — V8.1 cost rules + OpenAPI + tests
- AceDataCloud/PlatformService#885 — ttapi worker V8.1 detection fix
- AceDataCloud/Nexior#733 — Nexior V8.1 selectors + isV8 checks