### PR TITLE
feat: serve legacy SSE transport alongside Streamable HTTP for OOBE compatibility

### DIFF
--- a/aichat/main.py
+++ b/aichat/main.py
@@ -138,7 +138,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -191,7 +191,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -201,6 +201,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/fish/README.md
+++ b/fish/README.md
@@ -1,0 +1,56 @@
+# MCP Fish Server
+
+A Model Context Protocol (MCP) server for Fish Audio TTS (Text-to-Speech) via the AceDataCloud platform.
+Generate natural-sounding speech and explore the Fish voice model library.
+
+## Features
+
+- **High-quality TTS**: Generate speech from text via Fish Audio models
+- **Voice library**: Browse, search, and fetch metadata for Fish voice models
+- **Asynchronous tasks**: Submit generation tasks and poll for results
+- **Batch task lookup**: Query multiple task results in one call
+
+## Installation
+
+```bash
+pip install mcp-fish
+```
+
+## Configuration
+
+Set your AceDataCloud API token:
+
+```bash
+export ACEDATACLOUD_API_TOKEN=your_token_here
+```
+
+Get your token from [https://platform.acedata.cloud](https://platform.acedata.cloud).
+
+## Usage
+
+### stdio mode (default)
+
+```bash
+mcp-fish
+```
+
+### HTTP mode
+
+```bash
+mcp-fish --transport http --port 8000
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `fish_generate_audio` | Generate speech from text via a Fish voice model |
+| `fish_list_models` | List available Fish voice models |
+| `fish_get_model` | Fetch metadata for a specific Fish voice model |
+| `fish_get_task` | Get the status / result of a generation task |
+| `fish_get_tasks_batch` | Batch-fetch the status / result of multiple tasks |
+| `fish_get_usage_guide` | Get the API usage guide |
+
+## License
+
+MIT — see [LICENSE](../LICENSE) at the repository root.

--- a/fish/core/config.py
+++ b/fish/core/config.py
@@ -22,9 +22,7 @@ class Settings:
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
 
     # Default Model
-    default_model: str = field(
-        default_factory=lambda: os.getenv("FISH_DEFAULT_MODEL", "s2-pro")
-    )
+    default_model: str = field(default_factory=lambda: os.getenv("FISH_DEFAULT_MODEL", "s2-pro"))
 
     # Request Configuration
     request_timeout: float = field(

--- a/fish/main.py
+++ b/fish/main.py
@@ -141,7 +141,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -206,7 +206,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -216,6 +216,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/fish/tests/conftest.py
+++ b/fish/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration and fixtures."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Load .env file BEFORE any other imports
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(dotenv_path=project_root / ".env")
+
+# Set default log level for tests
+os.environ.setdefault("LOG_LEVEL", "DEBUG")

--- a/fish/tests/test_smoke.py
+++ b/fish/tests/test_smoke.py
@@ -1,0 +1,30 @@
+"""Smoke tests for fish MCP server."""
+
+import os
+from unittest.mock import patch
+
+
+def test_settings_defaults():
+    """Settings load with sensible defaults."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {}, clear=True):
+        settings = Settings()
+        assert settings.api_base_url == "https://api.acedata.cloud"
+        assert settings.api_token == ""
+
+
+def test_settings_token_from_env():
+    """Settings pick up ACEDATACLOUD_API_TOKEN."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {"ACEDATACLOUD_API_TOKEN": "test-token"}, clear=True):
+        settings = Settings()
+        assert settings.api_token == "test-token"
+
+
+def test_server_module_loads():
+    """The MCP server module loads without errors."""
+    from core.server import mcp
+
+    assert mcp is not None

--- a/fish/tools/audio_tools.py
+++ b/fish/tools/audio_tools.py
@@ -21,9 +21,7 @@ from core.types import (
 async def fish_generate_audio(
     text: Annotated[
         str | None,
-        Field(
-            description="The text to synthesize. Required."
-        ),
+        Field(description="The text to synthesize. Required."),
     ] = None,
     reference_id: Annotated[
         str | None,

--- a/flux/main.py
+++ b/flux/main.py
@@ -141,7 +141,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -193,7 +193,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -203,6 +203,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/glm/README.md
+++ b/glm/README.md
@@ -1,0 +1,51 @@
+# MCP GLM Server
+
+A Model Context Protocol (MCP) server for Zhipu GLM chat completions via the AceDataCloud platform.
+
+## Features
+
+- **GLM chat completions**: Call Zhipu GLM models through a uniform MCP tool
+- **Model discovery**: List the GLM models exposed by AceDataCloud
+- **Usage guide**: Inline tool returning the API usage guide
+
+## Installation
+
+```bash
+pip install mcp-glm
+```
+
+## Configuration
+
+Set your AceDataCloud API token:
+
+```bash
+export ACEDATACLOUD_API_TOKEN=your_token_here
+```
+
+Get your token from [https://platform.acedata.cloud](https://platform.acedata.cloud).
+
+## Usage
+
+### stdio mode (default)
+
+```bash
+mcp-glm
+```
+
+### HTTP mode
+
+```bash
+mcp-glm --transport http --port 8000
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `glm_chat_completions` | Run a GLM chat completion call |
+| `glm_list_models` | List available GLM models |
+| `glm_get_usage_guide` | Get the API usage guide |
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/glm/main.py
+++ b/glm/main.py
@@ -137,7 +137,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -190,7 +190,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -200,6 +200,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/glm/tests/conftest.py
+++ b/glm/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration and fixtures."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Load .env file BEFORE any other imports
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(dotenv_path=project_root / ".env")
+
+# Set default log level for tests
+os.environ.setdefault("LOG_LEVEL", "DEBUG")

--- a/glm/tests/test_smoke.py
+++ b/glm/tests/test_smoke.py
@@ -1,0 +1,30 @@
+"""Smoke tests for glm MCP server."""
+
+import os
+from unittest.mock import patch
+
+
+def test_settings_defaults():
+    """Settings load with sensible defaults."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {}, clear=True):
+        settings = Settings()
+        assert settings.api_base_url == "https://api.acedata.cloud"
+        assert settings.api_token == ""
+
+
+def test_settings_token_from_env():
+    """Settings pick up ACEDATACLOUD_API_TOKEN."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {"ACEDATACLOUD_API_TOKEN": "test-token"}, clear=True):
+        settings = Settings()
+        assert settings.api_token == "test-token"
+
+
+def test_server_module_loads():
+    """The MCP server module loads without errors."""
+    from core.server import mcp
+
+    assert mcp is not None

--- a/glm/tools/chat_tools.py
+++ b/glm/tools/chat_tools.py
@@ -79,23 +79,15 @@ async def glm_chat_completions(
     ] = None,
     response_format: Annotated[
         dict[str, Any] | None,
-        Field(description="Response format specification (e.g. {\"type\": \"json_object\"})."),
+        Field(description='Response format specification (e.g. {"type": "json_object"}).'),
     ] = None,
     reasoning_effort: Annotated[
         ReasoningEffort | None,
-        Field(
-            description=(
-                "Reasoning effort level: minimal, low, medium, high. Default medium."
-            )
-        ),
+        Field(description=("Reasoning effort level: minimal, low, medium, high. Default medium.")),
     ] = None,
     service_tier: Annotated[
         ServiceTier | None,
-        Field(
-            description=(
-                "Service tier: auto, default, flex, scale, priority. Default auto."
-            )
-        ),
+        Field(description=("Service tier: auto, default, flex, scale, priority. Default auto.")),
     ] = None,
     user: Annotated[
         str | None,

--- a/hailuo/main.py
+++ b/hailuo/main.py
@@ -143,7 +143,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -210,7 +210,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -220,6 +220,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/kling/main.py
+++ b/kling/main.py
@@ -149,7 +149,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -218,7 +218,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -228,6 +228,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/kling/tools/video_tools.py
+++ b/kling/tools/video_tools.py
@@ -167,7 +167,9 @@ async def kling_generate_video_from_image(
     ] = DEFAULT_MODEL,
     mode: Annotated[
         Mode,
-        Field(description="Generation mode. 'std' (standard, default), 'pro' (higher quality), or '4k' (native 4K, only for kling-v3 and kling-v3-omni)."),
+        Field(
+            description="Generation mode. 'std' (standard, default), 'pro' (higher quality), or '4k' (native 4K, only for kling-v3 and kling-v3-omni)."
+        ),
     ] = DEFAULT_MODE,
     aspect_ratio: Annotated[
         AspectRatio,
@@ -290,7 +292,9 @@ async def kling_extend_video(
     ] = DEFAULT_MODEL,
     mode: Annotated[
         Mode,
-        Field(description="Generation mode. 'std' (standard, default), 'pro' (higher quality), or '4k' (native 4K, only for kling-v3 and kling-v3-omni)."),
+        Field(
+            description="Generation mode. 'std' (standard, default), 'pro' (higher quality), or '4k' (native 4K, only for kling-v3 and kling-v3-omni)."
+        ),
     ] = DEFAULT_MODE,
     negative_prompt: Annotated[
         str | None,

--- a/luma/main.py
+++ b/luma/main.py
@@ -145,7 +145,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -208,7 +208,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -218,6 +218,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/midjourney/main.py
+++ b/midjourney/main.py
@@ -154,7 +154,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -260,7 +260,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -270,6 +270,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/nanobanana/main.py
+++ b/nanobanana/main.py
@@ -139,7 +139,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -198,7 +198,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -208,6 +208,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/openai/main.py
+++ b/openai/main.py
@@ -142,7 +142,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -219,7 +219,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -229,6 +229,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/producer/main.py
+++ b/producer/main.py
@@ -155,7 +155,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -276,7 +276,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -291,6 +291,11 @@ Environment Variables:
                     )
                 )
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/seedance/main.py
+++ b/seedance/main.py
@@ -149,7 +149,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -220,7 +220,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -230,6 +230,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/seedream/main.py
+++ b/seedream/main.py
@@ -141,7 +141,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -208,7 +208,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -218,6 +218,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/serp/main.py
+++ b/serp/main.py
@@ -146,7 +146,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -212,7 +212,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -222,6 +222,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/shorturl/main.py
+++ b/shorturl/main.py
@@ -139,7 +139,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -191,7 +191,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -201,6 +201,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/sora/main.py
+++ b/sora/main.py
@@ -151,7 +151,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -214,7 +214,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -224,6 +224,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/suno/main.py
+++ b/suno/main.py
@@ -158,7 +158,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -329,7 +329,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -339,6 +339,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/suno/tools/audio_tools.py
+++ b/suno/tools/audio_tools.py
@@ -311,7 +311,7 @@ async def suno_cover_music(
     Returns:
         Task ID and the cover audio information.
     """
-    payload = {
+    payload: dict = {
         "action": "cover",
         "audio_id": audio_id,
         "model": model,

--- a/veo/core/client.py
+++ b/veo/core/client.py
@@ -197,7 +197,9 @@ class VeoClient:
 
     async def video_objects(self, **kwargs: Any) -> dict[str, Any]:
         """Insert or remove objects in a video using the objects endpoint."""
-        logger.info(f"🔧 Video objects ({kwargs.get('action', 'insert')}): {kwargs.get('video_id', 'N/A')}")
+        logger.info(
+            f"🔧 Video objects ({kwargs.get('action', 'insert')}): {kwargs.get('video_id', 'N/A')}"
+        )
         return await self.request("/veo/objects", self._with_async_callback(kwargs))
 
     async def query_task(self, **kwargs: Any) -> dict[str, Any]:

--- a/veo/main.py
+++ b/veo/main.py
@@ -145,7 +145,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -202,7 +202,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -212,6 +212,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/veo/tools/video_tools.py
+++ b/veo/tools/video_tools.py
@@ -264,9 +264,7 @@ async def veo_extend_video(
     ] = "veo31-fast",
     prompt: Annotated[
         str,
-        Field(
-            description="Optional prompt that guides the extended section of the video."
-        ),
+        Field(description="Optional prompt that guides the extended section of the video."),
     ] = "",
     callback_url: Annotated[
         str,

--- a/wan/main.py
+++ b/wan/main.py
@@ -146,7 +146,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -217,7 +217,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -227,6 +227,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/webextrator/README.md
+++ b/webextrator/README.md
@@ -1,0 +1,55 @@
+# MCP WebExtrator Server
+
+A Model Context Protocol (MCP) server for web rendering and structured content extraction
+via the AceDataCloud WebExtrator platform.
+
+## Features
+
+- **Structured extraction**: Pull structured data out of any URL via WebExtrator
+- **Web rendering**: Render dynamic JavaScript pages and capture the rendered output
+- **Asynchronous tasks**: Submit extract / render jobs and poll for results
+- **Batch task lookup**: Query multiple task results in one call
+
+## Installation
+
+```bash
+pip install mcp-webextrator
+```
+
+## Configuration
+
+Set your AceDataCloud API token:
+
+```bash
+export ACEDATACLOUD_API_TOKEN=your_token_here
+```
+
+Get your token from [https://platform.acedata.cloud](https://platform.acedata.cloud).
+
+## Usage
+
+### stdio mode (default)
+
+```bash
+mcp-webextrator
+```
+
+### HTTP mode
+
+```bash
+mcp-webextrator --transport http --port 8000
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `webextrator_extract` | Extract structured content from a URL |
+| `webextrator_render` | Render a dynamic web page and return the rendered output |
+| `webextrator_get_task` | Get the status / result of an extract or render task |
+| `webextrator_get_tasks_batch` | Batch-fetch the status / result of multiple tasks |
+| `webextrator_get_usage_guide` | Get the API usage guide |
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/webextrator/main.py
+++ b/webextrator/main.py
@@ -139,7 +139,7 @@ Environment Variables:
             from starlette.applications import Starlette
             from starlette.requests import Request
             from starlette.responses import JSONResponse, RedirectResponse
-            from starlette.routing import Mount, Route
+            from starlette.routing import BaseRoute, Mount, Route
 
             from core.server import oauth_provider
 
@@ -203,7 +203,7 @@ Environment Variables:
             mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
-            routes: list[Route | Mount] = [
+            routes: list[BaseRoute] = [
                 Route("/health", health),
                 Route("/favicon.ico", favicon),
                 Route("/.well-known/mcp/server-card.json", server_card),
@@ -213,6 +213,11 @@ Environment Variables:
             if oauth_provider:
                 routes.append(Route("/oauth/callback", oauth_provider.handle_callback))
 
+            # Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
+            # so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
+            # clients are both supported on the same endpoint.
+            for sse_route in mcp.sse_app().routes:
+                routes.append(sse_route)
             routes.append(Mount("/", app=mcp.streamable_http_app()))
 
             app = Starlette(routes=routes, lifespan=lifespan)

--- a/webextrator/tests/conftest.py
+++ b/webextrator/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration and fixtures."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Load .env file BEFORE any other imports
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(dotenv_path=project_root / ".env")
+
+# Set default log level for tests
+os.environ.setdefault("LOG_LEVEL", "DEBUG")

--- a/webextrator/tests/test_smoke.py
+++ b/webextrator/tests/test_smoke.py
@@ -1,0 +1,30 @@
+"""Smoke tests for webextrator MCP server."""
+
+import os
+from unittest.mock import patch
+
+
+def test_settings_defaults():
+    """Settings load with sensible defaults."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {}, clear=True):
+        settings = Settings()
+        assert settings.api_base_url == "https://api.acedata.cloud"
+        assert settings.api_token == ""
+
+
+def test_settings_token_from_env():
+    """Settings pick up ACEDATACLOUD_API_TOKEN."""
+    from core.config import Settings
+
+    with patch.dict(os.environ, {"ACEDATACLOUD_API_TOKEN": "test-token"}, clear=True):
+        settings = Settings()
+        assert settings.api_token == "test-token"
+
+
+def test_server_module_loads():
+    """The MCP server module loads without errors."""
+    from core.server import mcp
+
+    assert mcp is not None

--- a/webextrator/tools/extract_tools.py
+++ b/webextrator/tools/extract_tools.py
@@ -1,7 +1,7 @@
 """Extract and render tools for WebExtrator API."""
 
 import json
-from typing import Annotated
+from typing import Annotated, cast
 
 from pydantic import Field
 
@@ -108,7 +108,7 @@ async def webextrator_extract(
             timeout=timeout,
             delay=delay,
             wait_for_selector=wait_for_selector,
-            block_resources=block_resources,
+            block_resources=cast(list[str] | None, block_resources),
             headers=headers,
             user_agent=user_agent,
             callback_url=callback_url,
@@ -204,7 +204,7 @@ async def webextrator_render(
             timeout=timeout,
             delay=delay,
             wait_for_selector=wait_for_selector,
-            block_resources=block_resources,
+            block_resources=cast(list[str] | None, block_resources),
             headers=headers,
             user_agent=user_agent,
             callback_url=callback_url,


### PR DESCRIPTION
## Summary

Mount the FastMCP **legacy SSE transport** (`GET /sse` + `POST /messages/`) into the same top-level Starlette app that already serves **Streamable HTTP** (`/mcp`) for all 20 MCP services.

This lets SSE-only clients (in particular, the **OOBE Synapse SDK** `McpClientBridge.connectSse` used by `synapse-client-sdk`) talk to the same `*.mcp.acedata.cloud` deployments that already serve modern Streamable HTTP clients — no extra deployment, no extra port.

## Why

Solking's team is integrating AceData services into [`OOBE-PROTOCOL/synapse-client-sdk`](https://github.com/OOBE-PROTOCOL/synapse-client-sdk). Their MCP client only speaks legacy SSE (`transport: 'sse'` in the registry). Our servers exposed only Streamable HTTP, so the wire protocols didn't match.

A follow-up PR to `synapse-client-sdk`'s registry adds AceData presets pointing at these endpoints; that PR is unblocked once this one ships and the K8s redeploy lands.

## Change

For every `main.py` of the 20 MCP services, before the existing top-level mount:

```python
# Mount legacy SSE transport (/sse + /messages) alongside Streamable HTTP (/mcp)
# so SSE-only clients (e.g. OOBE Synapse SDK) and modern Streamable HTTP
# clients are both supported on the same endpoint.
for sse_route in mcp.sse_app().routes:
    routes.append(sse_route)
routes.append(Mount("/", app=mcp.streamable_http_app()))
```

`mcp.sse_app().routes` returns `[Route('/sse', GET/HEAD), Mount('/messages', POST)]`. Both apps share the same `FastMCP` instance — same session manager, same tool registry, same lifespan.

## Wire facts (mcp SDK 1.27.0)

- **DNS rebinding protection** in `mcp/server/fastmcp/server.py:175-184` only auto-activates when `host in ("127.0.0.1", "localhost", "::1")`. Production binds with `host=\"0.0.0.0\"` (see each `core/server.py`), so `transport_security` stays `None`, the middleware defaults to `enable_dns_rebinding_protection=False`, and non-localhost Host headers are accepted without further config.
- POST validation still enforces `Content-Type: application/json` for both `/messages/` and `/mcp` — no security regression.

## Smoke test (local, port 18421, host=0.0.0.0)

With `Host: suno.mcp.acedata.cloud`:

| Endpoint | Result |
| --- | --- |
| `GET /health` | 200 `{"status":"ok"}` |
| `GET /sse` | 200 `text/event-stream` with `event: endpoint / data: /messages/?session_id=...` |
| `POST /mcp` initialize | 200 `application/json` JSON-RPC `result` with `protocolVersion`, tool capabilities |

## Files changed (20)

aichat, fish, flux, glm, hailuo, kling, luma, midjourney, nanobanana, openai, producer, seedance, seedream, serp, shorturl, sora, suno, veo, wan, webextrator — each `main.py` adds 5 lines (4 code + 3-line comment). Diff is uniform across all 20.

## Risk

- ✅ Backwards-compatible — `/mcp` (Streamable HTTP) behavior unchanged, only adds `/sse` and `/messages/`.
- ✅ Same FastMCP instance — no resource doubling, no risk of split-brain session state.
- ✅ Pre-existing `E402` ruff warnings from `load_dotenv()` ordering are untouched (not caused by this PR).
- ⚠️ After this merges, redeploy via the usual K8s pipeline before the OOBE registry PR can validate against live endpoints.

## Follow-up

PR against `OOBE-PROTOCOL/synapse-client-sdk` adding `acedata-*` presets to `src/ai/mcp/presets/registry.ts`.