### PR TITLE
chore: right-size MCP cpu requests 100m → 30m

### DIFF
--- a/flux/deploy/production/deployment.yaml
+++ b/flux/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/hailuo/deploy/production/deployment.yaml
+++ b/hailuo/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/kling/deploy/production/deployment.yaml
+++ b/kling/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/luma/deploy/production/deployment.yaml
+++ b/luma/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/midjourney/deploy/production/deployment.yaml
+++ b/midjourney/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/nanobanana/deploy/production/deployment.yaml
+++ b/nanobanana/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/producer/deploy/production/deployment.yaml
+++ b/producer/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/seedance/deploy/production/deployment.yaml
+++ b/seedance/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/seedream/deploy/production/deployment.yaml
+++ b/seedream/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/serp/deploy/production/deployment.yaml
+++ b/serp/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/shorturl/deploy/production/deployment.yaml
+++ b/shorturl/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/sora/deploy/production/deployment.yaml
+++ b/sora/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/suno/deploy/production/deployment.yaml
+++ b/suno/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/veo/deploy/production/deployment.yaml
+++ b/veo/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:

--- a/wan/deploy/production/deployment.yaml
+++ b/wan/deploy/production/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 500m
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 30m
               memory: 128Mi
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Summary

All 15 MCP services (flux, hailuo, kling, luma, midjourney, nanobanana, producer, seedance, seedream, serp, shorturl, sora, suno, veo, wan) had `requests.cpu: 100m` but their **measured steady-state CPU use is ~1 mcore/pod** (kubectl top, K8s metrics-server). That's wasting ~1.05 cores of cluster CPU request budget today.

## Change

```diff
            requests:
-              cpu: 100m
+              cpu: 30m
              memory: 128Mi
```

Applied uniformly to all 15 `<svc>/deploy/production/deployment.yaml`.

## Why 30m

- ~30× burst headroom over observed usage (1m → 30m)
- Matches K8s recommendation to keep `request ≈ p95-p99 usage`
- `limits.cpu: 500m` is unchanged, so any one pod can still burst hard during traffic spikes
- HPA (where present) targets CPU, so lower request makes scale-up triggers more responsive

## Cluster-wide impact

| | Before | After |
|---|---|---|
| MCP CPU requests (sum) | 1500m | 450m |
| Saved | — | **1050m** |

This unlocks scheduler room for other workloads on the same nodes.

## Risk

Low. Memory unchanged, limits unchanged, real usage is two orders of magnitude below the new request, so no throttling. If a particular MCP turns out to be CPU-bound under burst (none observed), we can revert per-service.

## Verification

After rollout:
```sh
kubectl top pods -n acedatacloud -l 'app in (mcp-flux,mcp-suno,mcp-sora,...)'
kubectl describe pod -n acedatacloud mcp-suno-... | grep -A3 Requests
```
