### PR TITLE
chore(face,fish): wire production OAuth client IDs

### DIFF
--- a/face/deploy/production/deployment.yaml
+++ b/face/deploy/production/deployment.yaml
@@ -31,10 +31,8 @@ spec:
           env:
             - name: MCP_SERVER_URL
               value: "https://face.mcp.acedata.cloud"
-            # TODO: replace with the OAuth client ID created for face.mcp.acedata.cloud
-            # in AuthBackend (Application → Application list).
             - name: ACEDATACLOUD_OAUTH_CLIENT_ID
-              value: "REPLACE_WITH_FACE_OAUTH_CLIENT_ID"
+              value: "1orvKZ2eLxRZDugAFqeDSJcs5Qukfp6BP1rg2X0lVBo"
           resources:
             limits:
               cpu: 500m

--- a/fish/deploy/production/deployment.yaml
+++ b/fish/deploy/production/deployment.yaml
@@ -31,10 +31,8 @@ spec:
           env:
             - name: MCP_SERVER_URL
               value: "https://fish.mcp.acedata.cloud"
-            # TODO: replace with the OAuth client ID created for fish.mcp.acedata.cloud
-            # in AuthBackend (Application → Application list).
             - name: ACEDATACLOUD_OAUTH_CLIENT_ID
-              value: "REPLACE_WITH_FISH_OAUTH_CLIENT_ID"
+              value: "_y6Yaa_8HvvMQwEfGl6U1p-DfjnDnhz8P8BAZUX73Gs"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## Summary

Replaces the `REPLACE_WITH_*_OAUTH_CLIENT_ID` placeholders in the production deployment manifests with the real OAuth client IDs that were just provisioned in the AuthBackend prod database for both new MCP servers.

## OAuth applications (created via `kubectl exec` on auth-backend prod pod)

| MCP  | client_id                                       | redirect_uri                                  |
| ---- | ----------------------------------------------- | --------------------------------------------- |
| face | `1orvKZ2eLxRZDugAFqeDSJcs5Qukfp6BP1rg2X0lVBo` | https://face.mcp.acedata.cloud/oauth/callback |
| fish | `_y6Yaa_8HvvMQwEfGl6U1p-DfjnDnhz8P8BAZUX73Gs` | https://fish.mcp.acedata.cloud/oauth/callback |

Both clients are PKCE public clients (`client_type=public`, no secret) with scopes `profile` and `platform`, matching every other `mcp.acedata.cloud` server (Hailuo, Kling, Flux, Luma, Midjourney, …).

## Why

Without these IDs the pods reject every `oauth_dcr` connector handshake from AuthFrontend / Nexior / Claude Desktop, so the new MCP servers are unusable end-to-end.

## Impact

- Manifest-only change, no code touched.
- Next image deploy picks up the new env var; no migration or restart sequencing required.
- Idempotent — the same OAuth rows are reused if the deployment is re-applied.