### PR TITLE
feat(vscode): revamp 15 MCP extensions around hosted HTTP endpoint

### DIFF
--- a/flux/vscode/.vscodeignore
+++ b/flux/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/flux/vscode/README.md
+++ b/flux/vscode/README.md
@@ -1,49 +1,120 @@
 # Flux MCP
 
-AI Image Generation with Flux - Generate and edit images with Flux models via Ace Data Cloud API
+Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Flux directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-flux-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-flux-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-flux-pro.svg?label=PyPI)](https://pypi.org/project/mcp-flux-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://flux.mcp.acedata.cloud/mcp)
 
-## Features
+Generate high-fidelity images with Flux from VS Code chat, or edit existing images via natural-language instructions using Flux Kontext.
 
-- **6 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **flux** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `flux` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a image task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://flux.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a hyperreal product shot of a matte-black ceramic mug, top-down. Use flux pro ultra."
+- "Take https://example.com/cup.jpg and replace the background with a sunlit kitchen."
+
+---
+
+## Tool Reference
+
+**6 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `flux_generate_image` | Generate AI images from a text prompt using Flux. |
+| `flux_edit_image` | Edit an existing image using Flux with a text prompt. |
+| `flux_list_models` | List all available Flux models and their capabilities. |
+| `flux_list_actions` | List all available Flux tools and their use cases. |
+| `flux_get_task` | Query the status and result of a Flux image generation task. |
+| `flux_get_tasks_batch` | Query multiple Flux image generation tasks at once. |
+
+## Supported Models
+
+`flux-dev`, `flux-pro`, `flux-pro-1.1`, `flux-pro-1.1-ultra`, `flux-kontext-pro`, `flux-kontext-max`
+
+## Pricing
+
+From $0.025 per image. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "flux": {
+      "type": "http",
+      "url": "https://flux.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "flux": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-flux-pro"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-flux-pro`](https://pypi.org/project/mcp-flux-pro/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-flux-pro/)
-- [Source Code](https://github.com/AceDataCloud/FluxMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://flux.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-flux-pro`](https://pypi.org/project/mcp-flux-pro/)
+- **Source repository:** https://github.com/AceDataCloud/FluxMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/flux/vscode/package.json
+++ b/flux/vscode/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "mcp-flux",
+  "name": "mcp-flux-pro",
   "displayName": "Flux MCP",
-  "description": "AI Image Generation with Flux - Generate and edit images with Flux models via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "copilot",
     "ace data cloud",
     "flux",
+    "black forest labs",
     "image generation",
-    "ai art",
-    "text to image"
+    "image editing",
+    "kontext"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/FluxMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "flux": {
-        "command": "uvx",
-        "args": [
-          "mcp-flux-pro"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://flux.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/hailuo/vscode/.vscodeignore
+++ b/hailuo/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/hailuo/vscode/README.md
+++ b/hailuo/vscode/README.md
@@ -1,49 +1,116 @@
 # Hailuo MCP
 
-AI Video Generation with Hailuo (MiniMax) - Generate videos from text and images via Ace Data Cloud API
+Hailuo (MiniMax) AI video — text-to-video and image-to-video with director mode.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Hailuo (MiniMax) directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-hailuo?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-hailuo) [![PyPI](https://img.shields.io/pypi/v/mcp-hailuo.svg?label=PyPI)](https://pypi.org/project/mcp-hailuo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://hailuo.mcp.acedata.cloud/mcp)
 
-## Features
+Generate AI video using MiniMax Hailuo. Includes director-mode camera control for precise framing.
 
-- **6 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **hailuo** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `hailuo` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://hailuo.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Hailuo video: a chef tossing a pizza in slow motion, dolly-in shot."
+- "Animate https://example.com/sketch.jpg into a 6-second Hailuo clip, pan-right."
+
+---
+
+## Tool Reference
+
+**6 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `hailuo_generate_video` | Generate AI video from a text prompt using Hailuo (MiniMax). |
+| `hailuo_generate_video_from_image` | Generate AI video from a reference image using Hailuo (MiniMax). |
+| `hailuo_get_task` | Query the status and result of a video generation task. |
+| `hailuo_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `hailuo_list_models` | List all available Hailuo models for video generation. |
+| `hailuo_list_actions` | List all available Hailuo API actions and corresponding tools. |
+
+## Pricing
+
+From $0.20 per clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "hailuo": {
+      "type": "http",
+      "url": "https://hailuo.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "hailuo": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-hailuo"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-hailuo`](https://pypi.org/project/mcp-hailuo/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-hailuo/)
-- [Source Code](https://github.com/AceDataCloud/HailuoMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://hailuo.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-hailuo`](https://pypi.org/project/mcp-hailuo/)
+- **Source repository:** https://github.com/AceDataCloud/HailuoMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/hailuo/vscode/package.json
+++ b/hailuo/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-hailuo",
   "displayName": "Hailuo MCP",
-  "description": "AI Video Generation with Hailuo (MiniMax) - Generate videos from text and images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Hailuo (MiniMax) AI video — text-to-video and image-to-video with director mode.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -22,8 +22,12 @@
     "hailuo",
     "minimax",
     "video generation",
-    "ai video"
+    "director mode"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/HailuoMCP",
   "repository": {
     "type": "git",
@@ -35,14 +39,20 @@
   "contributes": {
     "mcpServers": {
       "hailuo": {
-        "command": "uvx",
-        "args": [
-          "mcp-hailuo"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://hailuo.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/kling/vscode/.vscodeignore
+++ b/kling/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/kling/vscode/README.md
+++ b/kling/vscode/README.md
@@ -1,49 +1,118 @@
 # Kling MCP
 
-AI Video Generation with Kling - Generate, extend, and animate videos via Ace Data Cloud API
+Kuaishou Kling video generation — text-to-video, image-to-video, extend, motion.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Kling directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-kling?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-kling) [![PyPI](https://img.shields.io/pypi/v/mcp-kling.svg?label=PyPI)](https://pypi.org/project/mcp-kling/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://kling.mcp.acedata.cloud/mcp)
 
-## Features
+Generate Kling AI video from prompts or stills, extend existing clips, or apply motion control. Multiple model versions and quality modes.
 
-- **8 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **kling** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `kling` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://kling.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Kling video of a panda doing parkour through a bamboo forest."
+- "Extend Kling video task <id> with the panda landing and bowing."
+
+---
+
+## Tool Reference
+
+**8 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `kling_generate_video` | Generate AI video from a text prompt using Kling. |
+| `kling_generate_video_from_image` | Generate AI video using reference images as start and/or end frames. |
+| `kling_extend_video` | Extend an existing video with additional content. |
+| `kling_generate_motion` | Transfer motion from a reference video to a character image. |
+| `kling_get_task` | Query the status and result of a video generation task. |
+| `kling_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `kling_list_models` | List all available Kling models for video generation. |
+| `kling_list_actions` | List all available Kling API actions and corresponding tools. |
+
+## Pricing
+
+From $0.20 per 5s clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "kling": {
+      "type": "http",
+      "url": "https://kling.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "kling": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-kling"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-kling`](https://pypi.org/project/mcp-kling/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-kling/)
-- [Source Code](https://github.com/AceDataCloud/KlingMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://kling.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-kling`](https://pypi.org/project/mcp-kling/)
+- **Source repository:** https://github.com/AceDataCloud/KlingMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/kling/vscode/package.json
+++ b/kling/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-kling",
   "displayName": "Kling MCP",
-  "description": "AI Video Generation with Kling - Generate, extend, and animate videos via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Kuaishou Kling video generation — text-to-video, image-to-video, extend, motion.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,14 @@
     "copilot",
     "ace data cloud",
     "kling",
+    "kuaishou",
     "video generation",
-    "motion transfer",
-    "ai video"
+    "motion control"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/KlingMCP",
   "repository": {
     "type": "git",
@@ -35,14 +39,20 @@
   "contributes": {
     "mcpServers": {
       "kling": {
-        "command": "uvx",
-        "args": [
-          "mcp-kling"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://kling.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/luma/vscode/.vscodeignore
+++ b/luma/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/luma/vscode/README.md
+++ b/luma/vscode/README.md
@@ -1,49 +1,118 @@
 # Luma MCP
 
-AI Video Generation with Luma Dream Machine - Generate and extend videos via Ace Data Cloud API
+AI video generation with Luma Dream Machine — text-to-video, image-to-video, extend.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Luma Dream Machine directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-luma?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-luma) [![PyPI](https://img.shields.io/pypi/v/mcp-luma.svg?label=PyPI)](https://pypi.org/project/mcp-luma/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://luma.mcp.acedata.cloud/mcp)
 
-## Features
+Generate short cinematic videos from text or stills with Luma Dream Machine, or extend an existing clip — directly from chat.
 
-- **8 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **luma** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `luma` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://luma.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a 5-second video of a paper airplane drifting through neon clouds. Use luma."
+- "Animate https://example.com/cat.jpg into a 5-second video of the cat yawning."
+
+---
+
+## Tool Reference
+
+**8 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `luma_generate_video` | Generate AI video from a text prompt using Luma Dream Machine. |
+| `luma_generate_video_from_image` | Generate AI video using reference images as start and/or end frames. |
+| `luma_extend_video` | Extend an existing video with additional content. |
+| `luma_extend_video_from_url` | Extend an existing video using its URL. |
+| `luma_get_task` | Query the status and result of a video generation task. |
+| `luma_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `luma_list_aspect_ratios` | List all available aspect ratios for Luma video generation. |
+| `luma_list_actions` | List all available Luma API actions and corresponding tools. |
+
+## Pricing
+
+From $0.35 per 5s clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "luma": {
+      "type": "http",
+      "url": "https://luma.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "luma": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-luma"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-luma`](https://pypi.org/project/mcp-luma/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-luma/)
-- [Source Code](https://github.com/AceDataCloud/LumaMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://luma.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-luma`](https://pypi.org/project/mcp-luma/)
+- **Source repository:** https://github.com/AceDataCloud/LumaMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/luma/vscode/package.json
+++ b/luma/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-luma",
   "displayName": "Luma MCP",
-  "description": "AI Video Generation with Luma Dream Machine - Generate and extend videos via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "AI video generation with Luma Dream Machine — text-to-video, image-to-video, extend.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "copilot",
     "ace data cloud",
     "luma",
-    "video generation",
     "dream machine",
-    "ai video"
+    "video generation",
+    "text to video",
+    "image to video"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/LumaMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "luma": {
-        "command": "uvx",
-        "args": [
-          "mcp-luma"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://luma.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/midjourney/vscode/.vscodeignore
+++ b/midjourney/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/midjourney/vscode/README.md
+++ b/midjourney/vscode/README.md
@@ -1,49 +1,130 @@
 # Midjourney MCP
 
-AI Image Generation with Midjourney - Create, edit, blend and transform images via Ace Data Cloud API
+AI image generation with Midjourney — imagine, edit, blend, upscale, describe.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Midjourney directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-midjourney?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-midjourney) [![PyPI](https://img.shields.io/pypi/v/mcp-midjourney.svg?label=PyPI)](https://pypi.org/project/mcp-midjourney/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://midjourney.mcp.acedata.cloud/mcp)
 
-## Features
+Bring Midjourney into VS Code chat. Generate 2x2 grids from prompts, upscale or vary a tile, blend multiple references, describe an image back into a prompt, and animate stills into short video.
 
-- **15 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **midjourney** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `midjourney` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a image task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://midjourney.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate an isometric pixel-art illustration of a cozy cafe. Use midjourney."
+- "Upscale tile 3 of task <id>."
+- "Describe https://example.com/photo.jpg and give me a Midjourney prompt."
+
+---
+
+## Tool Reference
+
+**15 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `midjourney_imagine` | Generate AI images from a text prompt using Midjourney. |
+| `midjourney_transform` | Transform an existing Midjourney image with various operations. |
+| `midjourney_blend` | Blend multiple images together using Midjourney. |
+| `midjourney_with_reference` | Generate images using a reference image as inspiration. |
+| `midjourney_edit` | Edit an existing image using Midjourney. |
+| `midjourney_describe` | Get AI-generated descriptions of an image. |
+| `midjourney_generate_video` | Generate a video from text prompt and reference image using Midjourney. |
+| `midjourney_extend_video` | Extend an existing Midjourney video to make it longer. |
+| `midjourney_translate` | Translate Chinese text to English for use as Midjourney prompts. |
+| `midjourney_get_seed` | Get the seed value of a previously generated Midjourney image. |
+| `midjourney_get_task` | Query the status and result of a Midjourney generation task. |
+| `midjourney_get_tasks_batch` | Query multiple Midjourney generation tasks at once. |
+| `midjourney_list_actions` | List all available Midjourney API actions and corresponding tools. |
+| `midjourney_get_prompt_guide` | Get guidance on writing effective prompts for Midjourney. |
+| `midjourney_list_transform_actions` | List all available transformation actions for Midjourney images. |
+
+## Supported Models
+
+`5.2`, `6`, `6.1`, `7`, `8`
+
+## Pricing
+
+From $0.04 per /imagine job. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "midjourney": {
+      "type": "http",
+      "url": "https://midjourney.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "midjourney": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-midjourney"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-midjourney`](https://pypi.org/project/mcp-midjourney/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-midjourney/)
-- [Source Code](https://github.com/AceDataCloud/MidjourneyMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://midjourney.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-midjourney`](https://pypi.org/project/mcp-midjourney/)
+- **Source repository:** https://github.com/AceDataCloud/MidjourneyMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/midjourney/vscode/package.json
+++ b/midjourney/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-midjourney",
   "displayName": "Midjourney MCP",
-  "description": "AI Image Generation with Midjourney - Create, edit, blend and transform images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "AI image generation with Midjourney — imagine, edit, blend, upscale, describe.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -22,8 +22,13 @@
     "midjourney",
     "image generation",
     "ai art",
-    "text to image"
+    "text to image",
+    "image editing"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/MidjourneyMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "midjourney": {
-        "command": "uvx",
-        "args": [
-          "mcp-midjourney"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://midjourney.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/nanobanana/vscode/.vscodeignore
+++ b/nanobanana/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/nanobanana/vscode/README.md
+++ b/nanobanana/vscode/README.md
@@ -1,49 +1,118 @@
 # NanoBanana MCP
 
-AI Image Generation with NanoBanana (Gemini-based) - Generate and edit images via Ace Data Cloud API
+Gemini-powered NanoBanana — generate and edit images via natural language.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with NanoBanana (Gemini) directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-nanobanana-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-nanobanana-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-nanobanana-pro.svg?label=PyPI)](https://pypi.org/project/mcp-nanobanana-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://nanobanana.mcp.acedata.cloud/mcp)
 
-## Features
+Image generation and edit-by-instruction using NanoBanana, NanoBanana 2, and NanoBanana Pro (built on Gemini).
 
-- **4 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **nanobanana** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `nanobanana` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a image task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://nanobanana.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a watercolor postcard of Kyoto in cherry-blossom season. Use nanobanana pro."
+- "Edit https://example.com/desk.jpg — clear the desk and add a single houseplant."
+
+---
+
+## Tool Reference
+
+**4 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `nanobanana_generate_image` | Generate an AI image from a text prompt using Google's Nano Banana model. |
+| `nanobanana_edit_image` | Edit or combine images using AI based on a text prompt. |
+| `nanobanana_get_task` | Query the status and result of an image generation or edit task. |
+| `nanobanana_get_tasks_batch` | Query multiple image generation/edit tasks at once. |
+
+## Supported Models
+
+`nano-banana`, `nano-banana-2`, `nano-banana-pro`
+
+## Pricing
+
+From $0.015 per image. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "nanobanana": {
+      "type": "http",
+      "url": "https://nanobanana.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "nanobanana": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-nanobanana-pro"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-nanobanana-pro`](https://pypi.org/project/mcp-nanobanana-pro/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-nanobanana-pro/)
-- [Source Code](https://github.com/AceDataCloud/NanoBananaMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://nanobanana.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-nanobanana-pro`](https://pypi.org/project/mcp-nanobanana-pro/)
+- **Source repository:** https://github.com/AceDataCloud/NanoBananaMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/nanobanana/vscode/package.json
+++ b/nanobanana/vscode/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "mcp-nanobanana",
+  "name": "mcp-nanobanana-pro",
   "displayName": "NanoBanana MCP",
-  "description": "AI Image Generation with NanoBanana (Gemini-based) - Generate and edit images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Gemini-powered NanoBanana — generate and edit images via natural language.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "copilot",
     "ace data cloud",
     "nanobanana",
-    "image generation",
+    "nano banana",
     "gemini",
-    "ai art"
+    "image generation",
+    "image editing"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/NanoBananaMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "nanobanana": {
-        "command": "uvx",
-        "args": [
-          "mcp-nanobanana-pro"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://nanobanana.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/producer/vscode/.vscodeignore
+++ b/producer/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/producer/vscode/README.md
+++ b/producer/vscode/README.md
@@ -1,26 +1,132 @@
-# Producer MCP - VS Code Extension
+# Producer MCP
 
-AI Music Generation with Producer/Riffusion via Ace Data Cloud API.
+AI music with Producer (FUZZ) — songs, lyrics, covers, vocal/instrument swap, section replace.
 
-## Setup
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-producer?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-producer) [![PyPI](https://img.shields.io/pypi/v/mcp-producer.svg?label=PyPI)](https://pypi.org/project/mcp-producer/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://producer.mcp.acedata.cloud/mcp)
 
-1. Install this extension
-2. Set your `ACEDATACLOUD_API_TOKEN` in the MCP server configuration
-3. Start using Producer tools in VS Code Copilot
+Music generation, lyric writing, song extension, covers, vocal/instrumental swap, section replace, and reference audio upload — using the Producer (FUZZ) models.
 
-## Features
+This extension registers the **producer** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-- 18 AI tools for music generation, lyrics, media, and task management
-- Support for 8 FUZZ model versions
-- STDIO transport via uvx
+---
 
-## Requirements
+## Quick Start
 
-- [uv](https://github.com/astral-sh/uv) (Python package runner)
-- [AceDataCloud API Token](https://platform.acedata.cloud)
+1. **Install this extension.** VS Code registers the `producer` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a music task — VS Code will prompt for the token the first time and store it securely.
+
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://producer.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
+
+### Example prompts
+
+- "Generate a Producer track: dreamy synthwave instrumental, 90 BPM, A minor."
+- "Replace seconds 30–45 of song <id> with a guitar solo."
+
+---
+
+## Tool Reference
+
+**18 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `producer_generate_music` | Generate AI music from a text prompt. |
+| `producer_generate_custom_music` | Generate music with custom lyrics, title, and style. |
+| `producer_extend_music` | Extend an existing song from a specific timestamp. |
+| `producer_cover_music` | Create a cover/remix version in a different style. |
+| `producer_variation_music` | Create a variation of an existing song. |
+| `producer_swap_vocals` | Swap vocals between two songs. |
+| `producer_swap_instrumentals` | Swap instrumentals between two songs. |
+| `producer_replace_section` | Replace a specific time range with new content. |
+| `producer_stems_music` | Separate a song into vocal and instrumental stems. |
+| `producer_generate_lyrics` | Generate structured song lyrics from a prompt. |
+| `producer_upload_audio` | Upload external audio for processing. |
+| `producer_generate_video` | Generate a music video for a song. |
+| `producer_generate_wav` | Get lossless WAV format of a song. |
+| `producer_get_task` | Query the status of a generation task. |
+| `producer_get_tasks_batch` | Query multiple generation tasks at once. |
+| `producer_list_models` | List all available FUZZ models. |
+| `producer_list_actions` | List all available actions and tools. |
+| `producer_get_lyric_format_guide` | Get lyrics formatting guide. |
+
+## Supported Models
+
+`fuzz-1.0`, `fuzz-1.1`, `fuzz-1.5`, `fuzz-2.0`, `fuzz-2.5`, `fuzz-3.0`, `fuzz-3.5`, `fuzz-4.0`
+
+## Pricing
+
+From $0.05 per song. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
+{
+  "servers": {
+    "producer": {
+      "type": "http",
+      "url": "https://producer.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "producer": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mcp-producer"],
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
+    }
+  }
+}
+```
+
+`uvx` will download and run the latest [`mcp-producer`](https://pypi.org/project/mcp-producer/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
 
 ## Links
 
-- [AceDataCloud Platform](https://platform.acedata.cloud)
-- [Source Code](https://github.com/AceDataCloud/ProducerMCP)
-- [PyPI Package](https://pypi.org/project/mcp-producer/)
+- **Hosted endpoint:** https://producer.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-producer`](https://pypi.org/project/mcp-producer/)
+- **Source repository:** https://github.com/AceDataCloud/ProducerMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/producer/vscode/package.json
+++ b/producer/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-producer",
   "displayName": "Producer MCP",
-  "description": "AI Music Generation with Producer/Riffusion - Generate, extend, cover, and remix music via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "AI music with Producer (FUZZ) — songs, lyrics, covers, vocal/instrument swap, section replace.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,16 @@
     "copilot",
     "ace data cloud",
     "producer",
-    "riffusion",
-    "music generation",
-    "ai music"
+    "fuzz",
+    "music",
+    "ai music",
+    "lyrics",
+    "riffusion"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/ProducerMCP",
   "repository": {
     "type": "git",
@@ -35,14 +41,20 @@
   "contributes": {
     "mcpServers": {
       "producer": {
-        "command": "uvx",
-        "args": [
-          "mcp-producer"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://producer.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/scripts/build_vscode_extensions.py
+++ b/scripts/build_vscode_extensions.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Regenerate `<service>/vscode/{package.json, README.md, .vscodeignore}` for
+every MCP listed in `scripts/vscode_extensions.yaml`.
+
+Primary configuration is a hosted streamable-HTTP endpoint at
+`https://<alias>.mcp.acedata.cloud/mcp` with a Bearer token sourced from
+a VS Code `inputs` prompt (so the user gets a password field instead of a
+silent 401). README documents the local stdio fallback (`uvx mcp-<alias>`)
+and the manual mcp.json snippet for OAuth.
+
+Usage:
+  python3 scripts/build_vscode_extensions.py                 # all services
+  python3 scripts/build_vscode_extensions.py --only suno     # one service
+  python3 scripts/build_vscode_extensions.py --dry-run       # diff only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "scripts" / "vscode_extensions.yaml"
+
+
+@dataclass(frozen=True)
+class Service:
+    alias: str
+    display_name: str
+    repo: str
+    tagline: str
+    description: str
+    keywords: list[str]
+    examples: list[str]
+    models: list[str]
+    pricing_note: str
+    domain: str
+    pypi_pkg: str
+    publisher: str
+    signup_url: str
+    docs_url: str
+    vscode_engine: str
+    common_categories: list[str]
+    common_keywords: list[str]
+
+    @property
+    def hosted_url(self) -> str:
+        return f"https://{self.alias}.mcp.acedata.cloud/mcp"
+
+    @property
+    def repo_url(self) -> str:
+        return f"https://github.com/AceDataCloud/{self.repo}"
+
+    @property
+    def pypi_url(self) -> str:
+        return f"https://pypi.org/project/{self.pypi_pkg}/"
+
+    @property
+    def categories(self) -> list[str]:
+        return list(self.common_categories)
+
+    @property
+    def all_keywords(self) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for k in [*self.common_keywords, *self.keywords]:
+            if k not in seen:
+                seen.add(k)
+                out.append(k)
+        return out
+
+
+def load_services() -> list[Service]:
+    with CONFIG.open() as fh:
+        raw = yaml.safe_load(fh)
+    defaults = raw["defaults"]
+    services: list[Service] = []
+    for alias, cfg in raw["services"].items():
+        repo = cfg["repo"]
+        pypi_override = cfg.get("pypi_override")
+        if pypi_override:
+            pypi_pkg = pypi_override
+        else:
+            pyproject = ROOT / alias / "pyproject.toml"
+            with pyproject.open("rb") as fh:
+                pkg_data = tomllib.load(fh)
+            pypi_pkg = pkg_data["project"]["name"]
+        services.append(
+            Service(
+                alias=alias,
+                display_name=cfg["display_name"],
+                repo=repo,
+                tagline=cfg["tagline"].strip(),
+                description=" ".join(cfg["description"].split()),
+                keywords=list(cfg.get("keywords", [])),
+                examples=list(cfg.get("examples", [])),
+                models=list(cfg.get("models", [])),
+                pricing_note=cfg.get("pricing_note", "").strip(),
+                domain=cfg.get("domain", "general"),
+                pypi_pkg=pypi_pkg,
+                publisher=defaults["publisher"],
+                signup_url=defaults["signup_url"],
+                docs_url=defaults["docs_url"],
+                vscode_engine=defaults["vscode_engine"],
+                common_categories=list(defaults["common_categories"]),
+                common_keywords=list(defaults["common_keywords"]),
+            )
+        )
+    return services
+
+
+TOOL_TABLE_RE = re.compile(
+    r"^## Tool Reference\s*\n+\| Tool \| Description \|\s*\n\|[^\n]+\|\s*\n((?:\|[^\n]+\|\s*\n)+)",
+    re.MULTILINE,
+)
+
+
+def extract_tools(main_readme: Path) -> list[tuple[str, str]]:
+    """Parse the first `## Tool Reference` table out of the main README."""
+    text = main_readme.read_text(encoding="utf-8")
+    m = TOOL_TABLE_RE.search(text)
+    if not m:
+        return []
+    rows: list[tuple[str, str]] = []
+    for line in m.group(1).strip().splitlines():
+        parts = [p.strip() for p in line.strip().strip("|").split("|")]
+        if len(parts) < 2:
+            continue
+        tool, desc = parts[0], parts[1]
+        tool = tool.strip("`")
+        rows.append((tool, desc))
+    return rows
+
+
+def render_package_json(svc: Service) -> str:
+    pkg: dict[str, object] = {
+        "name": svc.pypi_pkg,
+        "displayName": svc.display_name,
+        "description": svc.tagline,
+        "version": "0.2.0",
+        "publisher": svc.publisher,
+        "icon": "icon.png",
+        "license": "MIT",
+        "engines": {"vscode": svc.vscode_engine},
+        "categories": svc.categories,
+        "keywords": svc.all_keywords,
+        "galleryBanner": {"color": "#0E1117", "theme": "dark"},
+        "homepage": svc.repo_url,
+        "repository": {"type": "git", "url": svc.repo_url},
+        "bugs": {"url": f"{svc.repo_url}/issues"},
+        "contributes": {
+            "mcpServers": {
+                svc.alias: {
+                    "type": "http",
+                    "url": svc.hosted_url,
+                    "headers": {
+                        "Authorization": "Bearer ${input:acedatacloud_api_token}"
+                    },
+                },
+            },
+            "inputs": [
+                {
+                    "type": "promptString",
+                    "id": "acedatacloud_api_token",
+                    "description": (
+                        f"Ace Data Cloud API token. Sign in at {svc.signup_url} "
+                        "and create a token in 'API Keys'. Stored securely by VS Code."
+                    ),
+                    "password": True,
+                },
+            ],
+        },
+    }
+    # Pretty + trailing newline.
+    return json.dumps(pkg, indent=2, ensure_ascii=False) + "\n"
+
+
+def render_readme(svc: Service, tools: list[tuple[str, str]]) -> str:
+    badge_line = (
+        f"[![VS Code Marketplace]"
+        f"(https://img.shields.io/visual-studio-marketplace/v/{svc.publisher}.{svc.pypi_pkg}?label=VS%20Code)]"
+        f"(https://marketplace.visualstudio.com/items?itemName={svc.publisher}.{svc.pypi_pkg}) "
+        f"[![PyPI]"
+        f"(https://img.shields.io/pypi/v/{svc.pypi_pkg}.svg?label=PyPI)]"
+        f"({svc.pypi_url}) "
+        f"[![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)]({svc.hosted_url})"
+    )
+
+    examples_md = "\n".join(f'- "{ex}"' for ex in svc.examples) or "_(see Tool Reference below)_"
+
+    if tools:
+        tool_table = ["| Tool | Description |", "| --- | --- |"]
+        for name, desc in tools:
+            tool_table.append(f"| `{name}` | {desc} |")
+        tool_table_md = "\n".join(tool_table)
+        tool_count_line = f"**{len(tools)} tools** available via this server."
+    else:
+        tool_table_md = "_Tool list is dynamically loaded from the server. Run a query to discover available tools._"
+        tool_count_line = ""
+
+    models_section = ""
+    if svc.models:
+        models_section = (
+            "## Supported Models\n\n"
+            + ", ".join(f"`{m}`" for m in svc.models)
+            + "\n\n"
+        )
+
+    pricing = svc.pricing_note or "See Ace Data Cloud pricing for details."
+
+    return f"""# {svc.display_name}
+
+{svc.tagline}
+
+{badge_line}
+
+{svc.description}
+
+This extension registers the **{svc.alias}** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
+
+---
+
+## Quick Start
+
+1. **Install this extension.** VS Code registers the `{svc.alias}` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud]({svc.signup_url}) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a {svc.domain} task — VS Code will prompt for the token the first time and store it securely.
+
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `{svc.hosted_url}` — no Python, no `uvx`, no local install needed.
+
+### Example prompts
+
+{examples_md}
+
+---
+
+## Tool Reference
+
+{tool_count_line}
+
+{tool_table_md}
+
+{models_section}## Pricing
+
+{pricing} See full pricing at [{svc.docs_url}]({svc.docs_url}).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
+{{
+  "servers": {{
+    "{svc.alias}": {{
+      "type": "http",
+      "url": "{svc.hosted_url}",
+      "headers": {{ "Authorization": "Bearer ${{input:acedatacloud_api_token}}" }}
+    }}
+  }},
+  "inputs": [
+    {{
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }}
+  ]
+}}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{{
+  "servers": {{
+    "{svc.alias}": {{
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["{svc.pypi_pkg}"],
+      "env": {{ "ACEDATACLOUD_API_TOKEN": "${{input:acedatacloud_api_token}}" }}
+    }}
+  }}
+}}
+```
+
+`uvx` will download and run the latest [`{svc.pypi_pkg}`]({svc.pypi_url}) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
+## Links
+
+- **Hosted endpoint:** {svc.hosted_url}
+- **PyPI package:** [`{svc.pypi_pkg}`]({svc.pypi_url})
+- **Source repository:** {svc.repo_url}
+- **Ace Data Cloud platform:** {svc.signup_url}
+- **MCP documentation:** {svc.docs_url}
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+"""
+
+
+VSCODEIGNORE = """.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
+.git/**
+.gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig
+"""
+
+
+def write_if_changed(path: Path, content: str, *, dry_run: bool) -> bool:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if existing == content:
+        return False
+    if not dry_run:
+        path.write_text(content, encoding="utf-8")
+    return True
+
+
+def process(svc: Service, *, dry_run: bool) -> list[str]:
+    changes: list[str] = []
+    vscode_dir = ROOT / svc.alias / "vscode"
+    vscode_dir.mkdir(parents=True, exist_ok=True)
+
+    tools = extract_tools(ROOT / svc.alias / "README.md")
+    pkg_text = render_package_json(svc)
+    readme_text = render_readme(svc, tools)
+
+    if write_if_changed(vscode_dir / "package.json", pkg_text, dry_run=dry_run):
+        changes.append(f"  {svc.alias}/vscode/package.json")
+    if write_if_changed(vscode_dir / "README.md", readme_text, dry_run=dry_run):
+        changes.append(f"  {svc.alias}/vscode/README.md")
+    if write_if_changed(vscode_dir / ".vscodeignore", VSCODEIGNORE, dry_run=dry_run):
+        changes.append(f"  {svc.alias}/vscode/.vscodeignore")
+    return changes
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", help="Comma-separated service aliases to regenerate.")
+    parser.add_argument("--dry-run", action="store_true", help="Don't write; just list changes.")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    selected: set[str] | None = None
+    if args.only:
+        selected = {s.strip() for s in args.only.split(",") if s.strip()}
+
+    services = load_services()
+    total_changes = 0
+    for svc in services:
+        if selected and svc.alias not in selected:
+            continue
+        changes = process(svc, dry_run=args.dry_run)
+        if changes:
+            total_changes += len(changes)
+            print(f"[{svc.alias}] {len(changes)} file(s) {'would change' if args.dry_run else 'updated'}:")
+            for c in changes:
+                print(c)
+        else:
+            print(f"[{svc.alias}] up-to-date")
+
+    print()
+    verb = "would change" if args.dry_run else "changed"
+    print(f"{total_changes} file(s) {verb} across {len(services) if selected is None else len(selected)} service(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vscode_extensions.yaml
+++ b/scripts/vscode_extensions.yaml
@@ -1,0 +1,252 @@
+# Per-service config for the vscode/ extension codegen.
+#
+# Used by scripts/build_vscode_extensions.py to regenerate each
+# <service>/vscode/{package.json, README.md, .vscodeignore}.
+#
+# Defaults (resolved per service):
+#   hosted_url   = https://<alias>.mcp.acedata.cloud/mcp
+#   github_repo  = https://github.com/AceDataCloud/<RepoName>
+#   pypi_pkg     = <pkg-name from pyproject.toml>
+#
+# Per-service overrides go below. `display_name`, `tagline`, `description`,
+# `categories`, `keywords`, `examples`, `pricing_note`, and `extras` are
+# all hand-curated for quality.
+
+defaults:
+  publisher: acedatacloud
+  signup_url: https://platform.acedata.cloud
+  docs_url: https://docs.acedata.cloud
+  vscode_engine: "^1.99.0"
+  common_categories: ["AI", "Chat"]
+  common_keywords:
+    - mcp
+    - model context protocol
+    - ai
+    - copilot
+    - ace data cloud
+
+services:
+  suno:
+    display_name: Suno MCP
+    repo: SunoMCP
+    domain: music
+    tagline: "AI music generation with Suno — songs, lyrics, covers, stems, and more."
+    description: >
+      Connect VS Code's AI agents to Suno through Ace Data Cloud. Generate songs from
+      text prompts, write custom lyrics with full musical control, extend tracks,
+      remix or cover, separate stems, export MP4/WAV/MIDI — all from chat.
+    keywords: [suno, music, ai music, song generation, lyrics, audio]
+    examples:
+      - 'Generate a lofi hip-hop track about late-night coding. Use suno.'
+      - 'Write lyrics for a punk song about deadline pressure, then turn them into a song.'
+      - 'Cover the song with task id <id> in a jazz piano style.'
+    models: ["v3.5", "v4", "v4.5", "v5"]
+    pricing_note: "From $0.05 per song. New users get free trial credit at sign-up."
+
+  midjourney:
+    display_name: Midjourney MCP
+    repo: MidjourneyMCP
+    domain: image
+    tagline: "AI image generation with Midjourney — imagine, edit, blend, upscale, describe."
+    description: >
+      Bring Midjourney into VS Code chat. Generate 2x2 grids from prompts,
+      upscale or vary a tile, blend multiple references, describe an image
+      back into a prompt, and animate stills into short video.
+    keywords: [midjourney, image generation, ai art, text to image, image editing]
+    examples:
+      - 'Generate an isometric pixel-art illustration of a cozy cafe. Use midjourney.'
+      - 'Upscale tile 3 of task <id>.'
+      - 'Describe https://example.com/photo.jpg and give me a Midjourney prompt.'
+    models: ["5.2", "6", "6.1", "7", "8"]
+    pricing_note: "From $0.04 per /imagine job. Free trial credit on sign-up."
+
+  flux:
+    display_name: Flux MCP
+    repo: FluxMCP
+    domain: image
+    tagline: "Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing."
+    description: >
+      Generate high-fidelity images with Flux from VS Code chat, or edit existing
+      images via natural-language instructions using Flux Kontext.
+    keywords: [flux, black forest labs, image generation, image editing, kontext]
+    examples:
+      - 'Generate a hyperreal product shot of a matte-black ceramic mug, top-down. Use flux pro ultra.'
+      - 'Take https://example.com/cup.jpg and replace the background with a sunlit kitchen.'
+    models: ["flux-dev", "flux-pro", "flux-pro-1.1", "flux-pro-1.1-ultra", "flux-kontext-pro", "flux-kontext-max"]
+    pricing_note: "From $0.025 per image. Free trial credit on sign-up."
+
+  seedream:
+    display_name: Seedream MCP
+    repo: SeedreamMCP
+    pypi_override: mcp-seedream-pro
+    domain: image
+    tagline: "Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing."
+    description: >
+      High-resolution image generation and edit-by-instruction with ByteDance
+      Seedream (3.0 / 4.0 / 4.5 / 5.0) and SeedEdit 3.0.
+    keywords: [seedream, bytedance, image generation, seededit, image editing]
+    examples:
+      - 'Generate a 2K cinematic poster of a samurai in neon Tokyo rain. Use seedream 5.0.'
+      - 'Edit https://example.com/cat.jpg — make the cat wear sunglasses.'
+    models: ["seedream-3.0", "seedream-4.0", "seedream-4.5", "seedream-5.0", "seededit-3.0"]
+    pricing_note: "From $0.02 per image. Free trial credit on sign-up."
+
+  nanobanana:
+    display_name: NanoBanana MCP
+    repo: NanoBananaMCP
+    pypi_override: mcp-nanobanana-pro
+    domain: image
+    tagline: "Gemini-powered NanoBanana — generate and edit images via natural language."
+    description: >
+      Image generation and edit-by-instruction using NanoBanana, NanoBanana 2,
+      and NanoBanana Pro (built on Gemini).
+    keywords: [nanobanana, nano banana, gemini, image generation, image editing]
+    examples:
+      - 'Generate a watercolor postcard of Kyoto in cherry-blossom season. Use nanobanana pro.'
+      - 'Edit https://example.com/desk.jpg — clear the desk and add a single houseplant.'
+    models: ["nano-banana", "nano-banana-2", "nano-banana-pro"]
+    pricing_note: "From $0.015 per image. Free trial credit on sign-up."
+
+  luma:
+    display_name: Luma MCP
+    repo: LumaMCP
+    domain: video
+    tagline: "AI video generation with Luma Dream Machine — text-to-video, image-to-video, extend."
+    description: >
+      Generate short cinematic videos from text or stills with Luma Dream Machine,
+      or extend an existing clip — directly from chat.
+    keywords: [luma, dream machine, video generation, text to video, image to video]
+    examples:
+      - 'Generate a 5-second video of a paper airplane drifting through neon clouds. Use luma.'
+      - 'Animate https://example.com/cat.jpg into a 5-second video of the cat yawning.'
+    pricing_note: "From $0.35 per 5s clip. Free trial credit on sign-up."
+
+  sora:
+    display_name: Sora MCP
+    repo: SoraMCP
+    domain: video
+    tagline: "OpenAI Sora video generation — text-to-video, image-to-video, character references."
+    description: >
+      Generate short Sora videos from text prompts, animate stills, or carry a
+      character reference across clips. Sora 1 and Sora 2 models supported.
+    keywords: [sora, openai, video generation, text to video]
+    examples:
+      - 'Generate a Sora video: time-lapse of a coffee being poured in slow motion. Use sora 2 portrait.'
+      - 'Animate https://example.com/dog.jpg into a Sora clip of the dog walking through a meadow.'
+    models: ["sora-1", "sora-2"]
+    pricing_note: "From $0.50 per clip. Free trial credit on sign-up."
+
+  veo:
+    display_name: Veo MCP
+    repo: VeoMCP
+    domain: video
+    tagline: "Google Veo video generation — Veo 2, Veo 3, Veo 3.1 (incl. fast variants and upscale)."
+    description: >
+      Generate AI video with Google Veo from text or images, including high-quality
+      Veo 3.1 and the fast variants. Supports 1080p upscale.
+    keywords: [veo, google veo, video generation, text to video]
+    examples:
+      - 'Generate a Veo 3.1 video of a vintage train pulling into a snowy station at dusk.'
+      - 'Animate https://example.com/portrait.jpg into a Veo Fast clip with subtle head turn.'
+    models: ["veo-2", "veo-2-fast", "veo-3", "veo-3-fast", "veo-3.1", "veo-3.1-fast"]
+    pricing_note: "From $0.30 per clip. Free trial credit on sign-up."
+
+  kling:
+    display_name: Kling MCP
+    repo: KlingMCP
+    domain: video
+    tagline: "Kuaishou Kling video generation — text-to-video, image-to-video, extend, motion."
+    description: >
+      Generate Kling AI video from prompts or stills, extend existing clips, or
+      apply motion control. Multiple model versions and quality modes.
+    keywords: [kling, kuaishou, video generation, motion control]
+    examples:
+      - 'Generate a Kling video of a panda doing parkour through a bamboo forest.'
+      - 'Extend Kling video task <id> with the panda landing and bowing.'
+    pricing_note: "From $0.20 per 5s clip. Free trial credit on sign-up."
+
+  hailuo:
+    display_name: Hailuo MCP
+    repo: HailuoMCP
+    domain: video
+    tagline: "Hailuo (MiniMax) AI video — text-to-video and image-to-video with director mode."
+    description: >
+      Generate AI video using MiniMax Hailuo. Includes director-mode camera control
+      for precise framing.
+    keywords: [hailuo, minimax, video generation, director mode]
+    examples:
+      - 'Generate a Hailuo video: a chef tossing a pizza in slow motion, dolly-in shot.'
+      - 'Animate https://example.com/sketch.jpg into a 6-second Hailuo clip, pan-right.'
+    pricing_note: "From $0.20 per clip. Free trial credit on sign-up."
+
+  wan:
+    display_name: Wan MCP
+    repo: WanMCP
+    domain: video
+    tagline: "Alibaba Wan video generation — text-to-video, image-to-video, reference video transfer."
+    description: >
+      Generate AI video with Alibaba Wan in 480P/720P/1080P, with optional audio
+      and reference-video transfer.
+    keywords: [wan, alibaba, video generation, reference video, audio]
+    examples:
+      - 'Generate a Wan 1080P video of waves crashing on a black-sand beach, with ambient audio.'
+      - 'Transfer the motion of reference video <id> onto https://example.com/character.png.'
+    pricing_note: "From $0.18 per clip. Free trial credit on sign-up."
+
+  seedance:
+    display_name: Seedance MCP
+    repo: SeedanceMCP
+    domain: video
+    tagline: "ByteDance Seedance — dance and motion video generation from text or image."
+    description: >
+      Generate Seedance AI dance/motion videos. Configurable resolution, aspect
+      ratio, duration, and optional audio.
+    keywords: [seedance, bytedance, video generation, dance, motion]
+    examples:
+      - 'Generate a Seedance video of a stylized robot dancing breakdance on a rooftop.'
+      - 'Animate https://example.com/character.png into a Seedance clip, vertical 9:16, 8 seconds.'
+    pricing_note: "From $0.15 per clip. Free trial credit on sign-up."
+
+  producer:
+    display_name: Producer MCP
+    repo: ProducerMCP
+    domain: music
+    tagline: "AI music with Producer (FUZZ) — songs, lyrics, covers, vocal/instrument swap, section replace."
+    description: >
+      Music generation, lyric writing, song extension, covers, vocal/instrumental
+      swap, section replace, and reference audio upload — using the Producer (FUZZ) models.
+    keywords: [producer, fuzz, music, ai music, lyrics, riffusion]
+    examples:
+      - 'Generate a Producer track: dreamy synthwave instrumental, 90 BPM, A minor.'
+      - 'Replace seconds 30–45 of song <id> with a guitar solo.'
+    models: ["fuzz-1.0", "fuzz-1.1", "fuzz-1.5", "fuzz-2.0", "fuzz-2.5", "fuzz-3.0", "fuzz-3.5", "fuzz-4.0"]
+    pricing_note: "From $0.05 per song. Free trial credit on sign-up."
+
+  serp:
+    display_name: Serp MCP
+    repo: SerpMCP
+    domain: search
+    tagline: "Google Search via Ace Data Cloud — web, images, news, maps, local, video."
+    description: >
+      Give Copilot live Google search results — web pages, images, news, maps,
+      local places, and videos — with localization and time filters.
+    keywords: [serp, google, search, web search, news, images]
+    examples:
+      - 'Search Google for the most recent news on the EU AI Act and summarize it.'
+      - 'Find image results for "mid-century modern living room", give me 10 URLs.'
+      - 'Search Google Maps for coffee shops near "1 Infinite Loop, Cupertino".'
+    pricing_note: "From $0.003 per query. Free trial credit on sign-up."
+
+  shorturl:
+    display_name: Short URL MCP
+    repo: ShortURLMCP
+    domain: utility
+    tagline: "Create short URLs (surl.id) — single or batch, with custom slugs and expiration."
+    description: >
+      Shorten long URLs into surl.id links, optionally with a custom slug or
+      expiration. Supports batch creation.
+    keywords: [shorturl, url shortener, surl, link]
+    examples:
+      - 'Shorten this URL: https://platform.acedata.cloud/documents/... with slug "ace-docs".'
+      - 'Batch-shorten these 5 URLs (paste the list) and give me a markdown table.'
+    pricing_note: "Free tier available. Higher quotas with paid plans."

--- a/seedance/vscode/.vscodeignore
+++ b/seedance/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/seedance/vscode/README.md
+++ b/seedance/vscode/README.md
@@ -1,49 +1,117 @@
 # Seedance MCP
 
-AI Video Generation with ByteDance Seedance - Generate videos from text and images via Ace Data Cloud API
+ByteDance Seedance — dance and motion video generation from text or image.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with ByteDance Seedance directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedance?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedance) [![PyPI](https://img.shields.io/pypi/v/mcp-seedance.svg?label=PyPI)](https://pypi.org/project/mcp-seedance/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedance.mcp.acedata.cloud/mcp)
 
-## Features
+Generate Seedance AI dance/motion videos. Configurable resolution, aspect ratio, duration, and optional audio.
 
-- **7 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **seedance** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `seedance` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://seedance.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Seedance video of a stylized robot dancing breakdance on a rooftop."
+- "Animate https://example.com/character.png into a Seedance clip, vertical 9:16, 8 seconds."
+
+---
+
+## Tool Reference
+
+**7 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `seedance_generate_video` | Generate AI video from a text prompt using ByteDance Seedance. |
+| `seedance_generate_video_from_image` | Generate AI video using reference images with ByteDance Seedance. |
+| `seedance_get_task` | Query the status and result of a video generation task. |
+| `seedance_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `seedance_list_models` | List all available Seedance models with their capabilities and pricing. |
+| `seedance_list_resolutions` | List all available resolutions and aspect ratios for Seedance. |
+| `seedance_list_actions` | List all available Seedance API actions and corresponding tools. |
+
+## Pricing
+
+From $0.15 per clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "seedance": {
+      "type": "http",
+      "url": "https://seedance.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "seedance": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-seedance"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-seedance`](https://pypi.org/project/mcp-seedance/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-seedance/)
-- [Source Code](https://github.com/AceDataCloud/SeedanceMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://seedance.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-seedance`](https://pypi.org/project/mcp-seedance/)
+- **Source repository:** https://github.com/AceDataCloud/SeedanceMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/seedance/vscode/package.json
+++ b/seedance/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-seedance",
   "displayName": "Seedance MCP",
-  "description": "AI Video Generation with ByteDance Seedance - Generate videos from text and images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "ByteDance Seedance — dance and motion video generation from text or image.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "copilot",
     "ace data cloud",
     "seedance",
-    "video generation",
     "bytedance",
-    "ai video"
+    "video generation",
+    "dance",
+    "motion"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/SeedanceMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "seedance": {
-        "command": "uvx",
-        "args": [
-          "mcp-seedance"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://seedance.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/seedream/vscode/.vscodeignore
+++ b/seedream/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/seedream/vscode/README.md
+++ b/seedream/vscode/README.md
@@ -1,49 +1,120 @@
 # Seedream MCP
 
-AI Image Generation with ByteDance Seedream - Generate and edit images via Ace Data Cloud API
+Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with ByteDance Seedream directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedream-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
 
-## Features
+High-resolution image generation and edit-by-instruction with ByteDance Seedream (3.0 / 4.0 / 4.5 / 5.0) and SeedEdit 3.0.
 
-- **6 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **seedream** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `seedream` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a image task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://seedream.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a 2K cinematic poster of a samurai in neon Tokyo rain. Use seedream 5.0."
+- "Edit https://example.com/cat.jpg — make the cat wear sunglasses."
+
+---
+
+## Tool Reference
+
+**6 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `seedream_generate_image` | Generate an AI image from a text prompt using ByteDance's Seedream model. |
+| `seedream_edit_image` | Edit or modify existing images using ByteDance's Seedream/SeedEdit model. |
+| `seedream_get_task` | Query the status and result of a Seedream image generation or edit task. |
+| `seedream_get_tasks_batch` | Query multiple Seedream image tasks at once. |
+| `seedream_list_models` | List all available Seedream models with their capabilities and pricing. |
+| `seedream_list_sizes` | List all available image sizes and resolution options for Seedream. |
+
+## Supported Models
+
+`seedream-3.0`, `seedream-4.0`, `seedream-4.5`, `seedream-5.0`, `seededit-3.0`
+
+## Pricing
+
+From $0.02 per image. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "seedream": {
+      "type": "http",
+      "url": "https://seedream.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "seedream": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-seedream-pro"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-seedream-pro`](https://pypi.org/project/mcp-seedream-pro/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-seedream-pro/)
-- [Source Code](https://github.com/AceDataCloud/SeedreamMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://seedream.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-seedream-pro`](https://pypi.org/project/mcp-seedream-pro/)
+- **Source repository:** https://github.com/AceDataCloud/SeedreamMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/seedream/vscode/package.json
+++ b/seedream/vscode/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "mcp-seedream",
+  "name": "mcp-seedream-pro",
   "displayName": "Seedream MCP",
-  "description": "AI Image Generation with ByteDance Seedream - Generate and edit images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,15 @@
     "copilot",
     "ace data cloud",
     "seedream",
-    "image generation",
     "bytedance",
-    "ai art"
+    "image generation",
+    "seededit",
+    "image editing"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/SeedreamMCP",
   "repository": {
     "type": "git",
@@ -35,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "seedream": {
-        "command": "uvx",
-        "args": [
-          "mcp-seedream-pro"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://seedream.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/serp/vscode/.vscodeignore
+++ b/serp/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/serp/vscode/README.md
+++ b/serp/vscode/README.md
@@ -1,49 +1,122 @@
 # Serp MCP
 
-Google Search via SERP API - Web, Images, News, Videos, Maps and more via Ace Data Cloud API
+Google Search via Ace Data Cloud — web, images, news, maps, local, video.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Google Search directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-serp?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-serp) [![PyPI](https://img.shields.io/pypi/v/mcp-serp.svg?label=PyPI)](https://pypi.org/project/mcp-serp/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://serp.mcp.acedata.cloud/mcp)
 
-## Features
+Give Copilot live Google search results — web pages, images, news, maps, local places, and videos — with localization and time filters.
 
-- **11 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **serp** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `serp` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a search task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://serp.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Search Google for the most recent news on the EU AI Act and summarize it."
+- "Find image results for "mid-century modern living room", give me 10 URLs."
+- "Search Google Maps for coffee shops near "1 Infinite Loop, Cupertino"."
+
+---
+
+## Tool Reference
+
+**11 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `serp_google_search` | Search Google and get structured results using the SERP API. |
+| `serp_google_images` | Search Google Images and get image results. |
+| `serp_google_news` | Search Google News and get news article results. |
+| `serp_google_videos` | Search Google Videos and get video results. |
+| `serp_google_places` | Search Google for local places and businesses. |
+| `serp_google_maps` | Search Google Maps for locations. |
+| `serp_list_search_types` | List all available Google search types. |
+| `serp_list_countries` | List commonly used country codes for Google search. |
+| `serp_list_languages` | List commonly used language codes for Google search. |
+| `serp_list_time_ranges` | List available time range filters for Google search. |
+| `serp_get_usage_guide` | Get a comprehensive guide for using the Google SERP tools. |
+
+## Pricing
+
+From $0.003 per query. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "serp": {
+      "type": "http",
+      "url": "https://serp.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "serp": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-serp"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-serp`](https://pypi.org/project/mcp-serp/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-serp/)
-- [Source Code](https://github.com/AceDataCloud/SerpMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://serp.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-serp`](https://pypi.org/project/mcp-serp/)
+- **Source repository:** https://github.com/AceDataCloud/SerpMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/serp/vscode/package.json
+++ b/serp/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-serp",
   "displayName": "Serp MCP",
-  "description": "Google Search via SERP API - Web, Images, News, Videos, Maps and more via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Google Search via Ace Data Cloud — web, images, news, maps, local, video.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,11 +20,16 @@
     "copilot",
     "ace data cloud",
     "serp",
-    "google search",
+    "google",
+    "search",
     "web search",
-    "images",
-    "news"
+    "news",
+    "images"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/SerpMCP",
   "repository": {
     "type": "git",
@@ -36,14 +41,20 @@
   "contributes": {
     "mcpServers": {
       "serp": {
-        "command": "uvx",
-        "args": [
-          "mcp-serp"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://serp.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/shorturl/vscode/.vscodeignore
+++ b/shorturl/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/shorturl/vscode/README.md
+++ b/shorturl/vscode/README.md
@@ -1,49 +1,114 @@
-# ShortURL MCP
+# Short URL MCP
 
-URL Shortening - Create and manage short URLs via Ace Data Cloud API
+Create short URLs (surl.id) — single or batch, with custom slugs and expiration.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with URL Shortening directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-shorturl?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-shorturl) [![PyPI](https://img.shields.io/pypi/v/mcp-shorturl.svg?label=PyPI)](https://pypi.org/project/mcp-shorturl/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://shorturl.mcp.acedata.cloud/mcp)
 
-## Features
+Shorten long URLs into surl.id links, optionally with a custom slug or expiration. Supports batch creation.
 
-- **4 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **shorturl** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `shorturl` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a utility task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://shorturl.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Shorten this URL: https://platform.acedata.cloud/documents/... with slug "ace-docs"."
+- "Batch-shorten these 5 URLs (paste the list) and give me a markdown table."
+
+---
+
+## Tool Reference
+
+**4 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `shorturl_create` | Create a short URL from a long URL. |
+| `shorturl_batch_create` | Create short URLs for multiple long URLs in a single batch. |
+| `shorturl_get_usage_guide` | Get a comprehensive guide for using the ShortURL tools. |
+| `shorturl_get_api_info` | Get information about the ShortURL API service. |
+
+## Pricing
+
+Free tier available. Higher quotas with paid plans. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "shorturl": {
+      "type": "http",
+      "url": "https://shorturl.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "shorturl": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-shorturl"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-shorturl`](https://pypi.org/project/mcp-shorturl/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-shorturl/)
-- [Source Code](https://github.com/AceDataCloud/ShortURLMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://shorturl.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-shorturl`](https://pypi.org/project/mcp-shorturl/)
+- **Source repository:** https://github.com/AceDataCloud/ShortURLMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/shorturl/vscode/package.json
+++ b/shorturl/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-shorturl",
-  "displayName": "ShortURL MCP",
-  "description": "URL Shortening - Create and manage short URLs via Ace Data Cloud API",
-  "version": "0.1.0",
+  "displayName": "Short URL MCP",
+  "description": "Create short URLs (surl.id) — single or batch, with custom slugs and expiration.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -21,8 +21,13 @@
     "ace data cloud",
     "shorturl",
     "url shortener",
-    "short link"
+    "surl",
+    "link"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/ShortURLMCP",
   "repository": {
     "type": "git",
@@ -34,14 +39,20 @@
   "contributes": {
     "mcpServers": {
       "shorturl": {
-        "command": "uvx",
-        "args": [
-          "mcp-shorturl"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://shorturl.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/sora/vscode/.vscodeignore
+++ b/sora/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/sora/vscode/README.md
+++ b/sora/vscode/README.md
@@ -1,49 +1,124 @@
 # Sora MCP
 
-AI Video Generation with OpenAI Sora - Generate videos from text and images via Ace Data Cloud API
+OpenAI Sora video generation — text-to-video, image-to-video, character references.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with OpenAI Sora directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-sora?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-sora) [![PyPI](https://img.shields.io/pypi/v/mcp-sora.svg?label=PyPI)](https://pypi.org/project/mcp-sora/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://sora.mcp.acedata.cloud/mcp)
 
-## Features
+Generate short Sora videos from text prompts, animate stills, or carry a character reference across clips. Sora 1 and Sora 2 models supported.
 
-- **10 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **sora** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `sora` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://sora.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Sora video: time-lapse of a coffee being poured in slow motion. Use sora 2 portrait."
+- "Animate https://example.com/dog.jpg into a Sora clip of the dog walking through a meadow."
+
+---
+
+## Tool Reference
+
+**10 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `sora_generate_video` | Generate an AI video from a text prompt using Sora. |
+| `sora_generate_video_from_image` | Generate an AI video from reference images using Sora (Image-to-Video). |
+| `sora_generate_video_with_character` | Generate an AI video featuring a character from a reference video. |
+| `sora_generate_video_async` | Generate an AI video asynchronously with callback notification. |
+| `sora_generate_video_v2` | Generate an AI video using Sora Version 2 (partner channel). |
+| `sora_generate_video_v2_async` | Generate an AI video asynchronously using Sora Version 2 with callback. |
+| `sora_get_task` | Query the status and result of a video generation task. |
+| `sora_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `sora_list_models` | List all available Sora models and their capabilities. |
+| `sora_list_actions` | List all available Sora API actions and corresponding tools. |
+
+## Supported Models
+
+`sora-1`, `sora-2`
+
+## Pricing
+
+From $0.50 per clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "sora": {
+      "type": "http",
+      "url": "https://sora.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "sora": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-sora"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-sora`](https://pypi.org/project/mcp-sora/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-sora/)
-- [Source Code](https://github.com/AceDataCloud/SoraMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://sora.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-sora`](https://pypi.org/project/mcp-sora/)
+- **Source repository:** https://github.com/AceDataCloud/SoraMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/sora/vscode/package.json
+++ b/sora/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-sora",
   "displayName": "Sora MCP",
-  "description": "AI Video Generation with OpenAI Sora - Generate videos from text and images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "OpenAI Sora video generation — text-to-video, image-to-video, character references.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,14 @@
     "copilot",
     "ace data cloud",
     "sora",
+    "openai",
     "video generation",
-    "openai sora",
-    "ai video"
+    "text to video"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/SoraMCP",
   "repository": {
     "type": "git",
@@ -35,14 +39,20 @@
   "contributes": {
     "mcpServers": {
       "sora": {
-        "command": "uvx",
-        "args": [
-          "mcp-sora"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://sora.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/suno/vscode/.vscodeignore
+++ b/suno/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/suno/vscode/README.md
+++ b/suno/vscode/README.md
@@ -1,49 +1,142 @@
 # Suno MCP
 
-AI Music Generation with Suno - Generate songs, lyrics, covers, and more via Ace Data Cloud API
+AI music generation with Suno — songs, lyrics, covers, stems, and more.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Suno AI directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-suno?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-suno) [![PyPI](https://img.shields.io/pypi/v/mcp-suno.svg?label=PyPI)](https://pypi.org/project/mcp-suno/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://suno.mcp.acedata.cloud/mcp)
 
-## Features
+Connect VS Code's AI agents to Suno through Ace Data Cloud. Generate songs from text prompts, write custom lyrics with full musical control, extend tracks, remix or cover, separate stems, export MP4/WAV/MIDI — all from chat.
 
-- **21 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **suno** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `suno` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a music task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://suno.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a lofi hip-hop track about late-night coding. Use suno."
+- "Write lyrics for a punk song about deadline pressure, then turn them into a song."
+- "Cover the song with task id <id> in a jazz piano style."
+
+---
+
+## Tool Reference
+
+**27 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `suno_generate_music` | Generate AI music from a text prompt using Suno's Inspiration Mode. |
+| `suno_generate_custom_music` | Generate AI music with full control over lyrics, title, and style (Custom Mode). |
+| `suno_extend_music` | Extend an existing song from a specific timestamp with new lyrics. |
+| `suno_cover_music` | Create a cover or remix version of an existing song in a different style. |
+| `suno_concat_music` | Concatenate extended song segments into a single complete audio file. |
+| `suno_generate_with_persona` | Generate music using a saved artist persona for consistent vocal style. |
+| `suno_remaster_music` | Remaster an existing song to improve audio quality. |
+| `suno_stems_music` | Separate a song into individual stems (vocals and instruments). |
+| `suno_replace_section` | Replace a specific time range in a song with new generated content. |
+| `suno_upload_extend` | Extend an uploaded audio (your own music) with new AI-generated content. |
+| `suno_upload_cover` | Create an AI cover of an uploaded audio (your own music). |
+| `suno_mashup_music` | Create a musical mashup by blending multiple songs together. |
+| `suno_generate_lyrics` | Generate song lyrics from a text prompt. |
+| `suno_get_mp4` | Get an MP4 video version of a generated song. |
+| `suno_get_timing` | Get timing and subtitle data for a generated song. |
+| `suno_extract_vocals` | Extract the vocal track from a generated song (stem separation). |
+| `suno_get_wav` | Get the lossless WAV format of a generated song. |
+| `suno_get_midi` | Get MIDI data extracted from a generated song. |
+| `suno_create_persona` | Create a new artist persona from an existing audio's vocal style. |
+| `suno_optimize_style` | Optimize a music style description for better generation results. |
+| `suno_mashup_lyrics` | Generate mashup lyrics by combining two sets of lyrics. |
+| `suno_upload_audio` | Upload an external audio file to Suno for use in subsequent operations. |
+| `suno_get_task` | Query the status and result of a music generation task. |
+| `suno_get_tasks_batch` | Query multiple music generation tasks at once. |
+| `suno_list_models` | List all available Suno models and their capabilities. |
+| `suno_list_actions` | List all available Suno API actions and corresponding tools. |
+| `suno_get_lyric_format_guide` | Get guidance on formatting lyrics for Suno music generation. |
+
+## Supported Models
+
+`v3.5`, `v4`, `v4.5`, `v5`
+
+## Pricing
+
+From $0.05 per song. New users get free trial credit at sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "suno": {
+      "type": "http",
+      "url": "https://suno.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "suno": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-suno"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-suno`](https://pypi.org/project/mcp-suno/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-suno/)
-- [Source Code](https://github.com/AceDataCloud/SunoMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://suno.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-suno`](https://pypi.org/project/mcp-suno/)
+- **Source repository:** https://github.com/AceDataCloud/SunoMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/suno/vscode/package.json
+++ b/suno/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-suno",
   "displayName": "Suno MCP",
-  "description": "AI Music Generation with Suno - Generate songs, lyrics, covers, and more via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "AI music generation with Suno — songs, lyrics, covers, stems, and more.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -23,8 +23,13 @@
     "music",
     "ai music",
     "song generation",
-    "lyrics"
+    "lyrics",
+    "audio"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/SunoMCP",
   "repository": {
     "type": "git",
@@ -36,14 +41,20 @@
   "contributes": {
     "mcpServers": {
       "suno": {
-        "command": "uvx",
-        "args": [
-          "mcp-suno"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://suno.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/veo/vscode/.vscodeignore
+++ b/veo/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/veo/vscode/README.md
+++ b/veo/vscode/README.md
@@ -1,49 +1,122 @@
 # Veo MCP
 
-AI Video Generation with Google Veo - Generate videos from text and images via Ace Data Cloud API
+Google Veo video generation — Veo 2, Veo 3, Veo 3.1 (incl. fast variants and upscale).
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Google Veo directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-veo?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-veo) [![PyPI](https://img.shields.io/pypi/v/mcp-veo.svg?label=PyPI)](https://pypi.org/project/mcp-veo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://veo.mcp.acedata.cloud/mcp)
 
-## Features
+Generate AI video with Google Veo from text or images, including high-quality Veo 3.1 and the fast variants. Supports 1080p upscale.
 
-- **8 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **veo** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `veo` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://veo.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Veo 3.1 video of a vintage train pulling into a snowy station at dusk."
+- "Animate https://example.com/portrait.jpg into a Veo Fast clip with subtle head turn."
+
+---
+
+## Tool Reference
+
+**8 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `veo_text_to_video` | Generate AI video from a text prompt using Veo. |
+| `veo_image_to_video` | Generate AI video from one or more reference images using Veo. |
+| `veo_get_1080p` | Get the 1080p high-resolution version of a generated video. |
+| `veo_get_task` | Query the status and result of a video generation task. |
+| `veo_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `veo_list_models` | List all available Veo models and their capabilities. |
+| `veo_list_actions` | List all available Veo API actions and corresponding tools. |
+| `veo_get_prompt_guide` | Get guidance on writing effective prompts for Veo video generation. |
+
+## Supported Models
+
+`veo-2`, `veo-2-fast`, `veo-3`, `veo-3-fast`, `veo-3.1`, `veo-3.1-fast`
+
+## Pricing
+
+From $0.30 per clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "veo": {
+      "type": "http",
+      "url": "https://veo.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "veo": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-veo"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-veo`](https://pypi.org/project/mcp-veo/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-veo/)
-- [Source Code](https://github.com/AceDataCloud/VeoMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://veo.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-veo`](https://pypi.org/project/mcp-veo/)
+- **Source repository:** https://github.com/AceDataCloud/VeoMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/veo/vscode/package.json
+++ b/veo/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-veo",
   "displayName": "Veo MCP",
-  "description": "AI Video Generation with Google Veo - Generate videos from text and images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Google Veo video generation — Veo 2, Veo 3, Veo 3.1 (incl. fast variants and upscale).",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,10 +20,14 @@
     "copilot",
     "ace data cloud",
     "veo",
-    "video generation",
     "google veo",
-    "ai video"
+    "video generation",
+    "text to video"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/VeoMCP",
   "repository": {
     "type": "git",
@@ -35,14 +39,20 @@
   "contributes": {
     "mcpServers": {
       "veo": {
-        "command": "uvx",
-        "args": [
-          "mcp-veo"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://veo.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/wan/vscode/.vscodeignore
+++ b/wan/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/wan/vscode/README.md
+++ b/wan/vscode/README.md
@@ -1,49 +1,117 @@
 # Wan MCP
 
-AI Video Generation with Wan - Generate videos from text or images via Ace Data Cloud API
+Alibaba Wan video generation — text-to-video, image-to-video, reference video transfer.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to interact with Wan directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-wan?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-wan) [![PyPI](https://img.shields.io/pypi/v/mcp-wan.svg?label=PyPI)](https://pypi.org/project/mcp-wan/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://wan.mcp.acedata.cloud/mcp)
 
-## Features
+Generate AI video with Alibaba Wan in 480P/720P/1080P, with optional audio and reference-video transfer.
 
-- **7 tools** available for AI assistants
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **wan** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `wan` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a video task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://wan.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate a Wan 1080P video of waves crashing on a black-sand beach, with ambient audio."
+- "Transfer the motion of reference video <id> onto https://example.com/character.png."
+
+---
+
+## Tool Reference
+
+**7 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `wan_generate_video` | Generate AI video from a text prompt using Wan. |
+| `wan_generate_video_from_image` | Generate AI video using a reference image as the starting frame. |
+| `wan_get_task` | Query the status and result of a video generation task. |
+| `wan_get_tasks_batch` | Query multiple video generation tasks at once. |
+| `wan_list_models` | List all available Wan models for video generation. |
+| `wan_list_resolutions` | List all available resolution options. |
+| `wan_list_actions` | List all available Wan API actions and corresponding tools. |
+
+## Pricing
+
+From $0.18 per clip. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "wan": {
+      "type": "http",
+      "url": "https://wan.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "wan": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-wan"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-wan`](https://pypi.org/project/mcp-wan/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-wan/)
-- [Source Code](https://github.com/AceDataCloud/WanMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://wan.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-wan`](https://pypi.org/project/mcp-wan/)
+- **Source repository:** https://github.com/AceDataCloud/WanMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/wan/vscode/package.json
+++ b/wan/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-wan",
   "displayName": "Wan MCP",
-  "description": "AI Video Generation with Wan - Generate videos from text or images via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Alibaba Wan video generation — text-to-video, image-to-video, reference video transfer.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,11 +20,15 @@
     "copilot",
     "ace data cloud",
     "wan",
+    "alibaba",
     "video generation",
-    "text-to-video",
-    "image-to-video",
-    "ai video"
+    "reference video",
+    "audio"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/WanMCP",
   "repository": {
     "type": "git",
@@ -36,14 +40,20 @@
   "contributes": {
     "mcpServers": {
       "wan": {
-        "command": "uvx",
-        "args": [
-          "mcp-wan"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://wan.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Every `<service>/vscode/` extension in the MCPs monorepo was using the same broken clone-template. Three concrete user-visible issues:

1. **READMEs lied about prompting for an API token.** The package.json had `env: { ACEDATACLOUD_API_TOKEN: "" }` and no `inputs` block, so VS Code never asked. First call → silent 401 → 1-star review.
2. **The hosted streamable-HTTP endpoint was never mentioned**, even though it's the recommended zero-install path. Suno's main README documents `https://suno.mcp.acedata.cloud/mcp` + Claude.ai OAuth, but `suno/vscode/README.md` only knew about `uvx mcp-suno`.
3. **"Zero-install setup"** was false — `uvx` itself requires `uv` to be installed.

Plus duplicate-clone READMEs across 15 services with zero per-service tool list, examples, or pricing info.

## What's in this PR

A small codegen tool — `scripts/build_vscode_extensions.py` + `scripts/vscode_extensions.yaml` — and the 45 files (15 × 3) it regenerated:

- **`<service>/vscode/package.json`**
  - Contributed MCP server is now `type: "http"` pointing at `https://<alias>.mcp.acedata.cloud/mcp`
  - `headers.Authorization: "Bearer ${input:acedatacloud_api_token}"` references a `contributes.inputs` `promptString` (password = true), so VS Code shows a secure prompt on first use and stores the token in the OS secret store
  - Version bumped `0.1.0` → `0.2.0`, adds `galleryBanner`, per-service keywords/categories
- **`<service>/vscode/README.md`**
  - Hosted-endpoint-first quick start (3 steps)
  - Per-service example prompts (hand-curated, 2–3 each)
  - **Tool reference table imported automatically from each service's main README** — no more drift between docs and marketplace
  - Supported models list (where applicable), pricing/free-credit note
  - Documents the two alternatives clearly: local stdio via `uvx <pypi-pkg>`, and OAuth 2.1 via DCR
- **`<service>/vscode/.vscodeignore`** — standardised

15 services covered: `suno`, `midjourney`, `flux`, `seedream`, `nanobanana`, `luma`, `sora`, `veo`, `kling`, `hailuo`, `wan`, `seedance`, `producer`, `serp`, `shorturl`.

## Why a codegen script instead of 15 hand edits

So the next person editing the marketplace listing for one MCP doesn't accidentally let it drift from the other 14, and so adding a new MCP is a one-line YAML entry. Tool counts and descriptions are parsed straight out of each main `README.md`'s "## Tool Reference" table, so updates to upstream READMEs propagate.

## Sanity checks

- `python3 -c "import json; json.load(open('<svc>/vscode/package.json'))"` — all 15 valid
- Tool counts per service:

  | Service | Tools | | Service | Tools |
  | --- | --- | --- | --- | --- |
  | suno | 27 | | luma | 8 |
  | midjourney | 15 | | sora | 10 |
  | producer | 18 | | kling | 8 |
  | serp | 11 | | hailuo | 6 |
  | flux | 6 | | wan | 7 |
  | seedream | 6 | | seedance | 7 |
  | nanobanana | 4 | | veo | 8 |
  | shorturl | 4 | | | |

## Out of scope (follow-ups)

- **Duplicate `icon.png`** across flux/kling/producer/wan (md5 `f3551b1e…`) and hailuo/luma (md5 `2d8f5e5e…`) — needs design assets.
- **Missing extensions for `aichat` and `openai`** — these are the highest-traffic services and have no `vscode/` folder. Worth a separate PR.

## Test

Locally:

```bash
python3 scripts/build_vscode_extensions.py --dry-run     # diff-only mode
python3 scripts/build_vscode_extensions.py --only suno   # regenerate one
```

Marketplace install: install the published `acedatacloud.mcp-suno` 0.2.0, open Copilot Chat, ask "generate a lofi track about late-night coding, use suno" → VS Code prompts for the API token → first call to the hosted endpoint succeeds.
