### PR TITLE
fix(vscode): use mcp-<alias> as marketplace extension id

### DIFF
--- a/flux/vscode/package.json
+++ b/flux/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcp-flux-pro",
+  "name": "mcp-flux",
   "displayName": "Flux MCP",
   "description": "Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing.",
   "version": "0.2.0",

--- a/nanobanana/vscode/package.json
+++ b/nanobanana/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcp-nanobanana-pro",
+  "name": "mcp-nanobanana",
   "displayName": "NanoBanana MCP",
   "description": "Gemini-powered NanoBanana — generate and edit images via natural language.",
   "version": "0.2.0",

--- a/scripts/build_vscode_extensions.py
+++ b/scripts/build_vscode_extensions.py
@@ -45,6 +45,7 @@ class Service:
     pricing_note: str
     domain: str
     pypi_pkg: str
+    ext_name: str
     publisher: str
     signup_url: str
     docs_url: str
@@ -94,6 +95,10 @@ def load_services() -> list[Service]:
             with pyproject.open("rb") as fh:
                 pkg_data = tomllib.load(fh)
             pypi_pkg = pkg_data["project"]["name"]
+        # VS Code extension id namespace is independent of PyPI. Default to
+        # `mcp-<alias>` to match the marketplace IDs we already own; allow an
+        # explicit override for future services whose alias diverges.
+        ext_name = cfg.get("ext_name") or f"mcp-{alias}"
         services.append(
             Service(
                 alias=alias,
@@ -107,6 +112,7 @@ def load_services() -> list[Service]:
                 pricing_note=cfg.get("pricing_note", "").strip(),
                 domain=cfg.get("domain", "general"),
                 pypi_pkg=pypi_pkg,
+                ext_name=ext_name,
                 publisher=defaults["publisher"],
                 signup_url=defaults["signup_url"],
                 docs_url=defaults["docs_url"],
@@ -143,7 +149,7 @@ def extract_tools(main_readme: Path) -> list[tuple[str, str]]:
 
 def render_package_json(svc: Service) -> str:
     pkg: dict[str, object] = {
-        "name": svc.pypi_pkg,
+        "name": svc.ext_name,
         "displayName": svc.display_name,
         "description": svc.tagline,
         "version": "0.2.0",

--- a/seedream/vscode/package.json
+++ b/seedream/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mcp-seedream-pro",
+  "name": "mcp-seedream",
   "displayName": "Seedream MCP",
   "description": "Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.",
   "version": "0.2.0",


### PR DESCRIPTION
## Why

After #356 merged, 12/15 VS Code extensions auto-republished to the marketplace on `2026.531.0`. Three did **not**: flux, nanobanana, seedream. The downstream `publish.yml` for each ran and failed at the `vsce publish` step with:

```
##[error]This extension display name is taken. Please try a different one.
```

Failing runs:
- [AceDataCloud/FluxMCP run 26720512678](https://github.com/AceDataCloud/FluxMCP/actions/runs/26720512678)
- [AceDataCloud/NanoBananaMCP run 26720503946](https://github.com/AceDataCloud/NanoBananaMCP/actions/runs/26720503946)
- [AceDataCloud/SeedreamMCP run 26720511565](https://github.com/AceDataCloud/SeedreamMCP/actions/runs/26720511565)

## Root cause

`scripts/build_vscode_extensions.py` was using the **PyPI package name** as the VS Code extension `name` (`pkg['name'] = svc.pypi_pkg`). The two namespaces aren't the same:

| Service | PyPI | Marketplace ID (already owned) |
|---|---|---|
| flux | `mcp-flux-pro` (the bare name was taken on PyPI) | `acedatacloud.mcp-flux` |
| nanobanana | `mcp-nanobanana-pro` | `acedatacloud.mcp-nanobanana` |
| seedream | `mcp-seedream-pro` | `acedatacloud.mcp-seedream` |

PR #356 changed these from the old `mcp-<alias>` to `mcp-<alias>-pro`, so `vsce publish` saw a brand-new extension id and tried to create it, but the displayName `Flux MCP` / `NanoBanana MCP` / `Seedream MCP` is already taken by the existing extension under the same publisher → 409.

## Fix

Decouple the two namespaces. Add `ext_name` to the `Service` dataclass, default it to `mcp-<alias>` (the convention already in marketplace), with an `ext_name:` yaml override available for any future service where they diverge.

Regenerated only the 3 affected `vscode/package.json` — diff is the `name` field only. The other 12 services already had `pypi == mcp-<alias>` so their codegen output is unchanged.

## Verification after merge

Once main triggers the sync, each of the three downstream repos will get a new push and their `publish.yml` should produce a fresh CalVer `2026.MMDD.0` on the marketplace. Will verify with marketplace API after merge.