### PR TITLE
feat(vscode): bring face + fish into hosted-HTTP codegen

### DIFF
--- a/face/README.md
+++ b/face/README.md
@@ -47,18 +47,18 @@ mcp-face-transform
 mcp-face-transform --transport http --port 8000
 ```
 
-## Available Tools
+## Tool Reference
 
-| Tool | Endpoint | Purpose |
-|------|----------|---------|
-| `face_detect_keypoints` | `POST /face/analyze` | Detect 90+ keypoints per face |
-| `face_beautify` | `POST /face/beautify` | Smoothing / whitening / slimming / eye enlarging |
-| `face_change_age` | `POST /face/change-age` | Age or de-age a portrait |
-| `face_change_gender` | `POST /face/change-gender` | Swap perceived facial gender characteristics |
-| `face_swap` | `POST /face/swap` | Move source face onto target image |
-| `face_cartoonize` | `POST /face/cartoon` | Convert portrait to cartoon style |
-| `face_detect_liveness` | `POST /face/detect-live` | Detect live vs printed/screen face |
-| `face_get_usage_guide` | _client-side_ | Concise tool usage reference |
+| Tool | Description |
+|------|-------------|
+| `face_detect_keypoints` | Detect 90+ keypoints per face (multi-face supported). |
+| `face_beautify` | Smoothing, whitening, face slimming, and eye enlarging. |
+| `face_change_age` | Age or de-age a portrait. |
+| `face_change_gender` | Swap perceived facial gender characteristics. |
+| `face_swap` | Move a source face onto a target image (with optional async webhook). |
+| `face_cartoonize` | Render a portrait in cartoon / animated style. |
+| `face_detect_liveness` | Distinguish a live capture from a printed / screen photo. |
+| `face_get_usage_guide` | Concise client-side tool usage reference. |
 
 ## Example
 

--- a/face/vscode/.vscodeignore
+++ b/face/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/face/vscode/README.md
+++ b/face/vscode/README.md
@@ -1,49 +1,119 @@
 # Face Transform MCP
 
-Face analysis & transformation — keypoints, beautify, age/gender, swap, cartoon, liveness — via the Ace Data Cloud Face API.
+Face analysis and transforms — keypoints, beautify, age/gender, swap, cartoon, liveness. (Alpha)
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to call the Face Transform API directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-face-transform?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-face-transform) [![PyPI](https://img.shields.io/pypi/v/mcp-face-transform.svg?label=PyPI)](https://pypi.org/project/mcp-face-transform/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://face.mcp.acedata.cloud/mcp)
 
-## Features
+Bring AceDataCloud's Face Transform APIs into Copilot Chat. Detect 90+ keypoints per face, beautify portraits, age or de-age, swap perceived gender, face-swap between photos, cartoonize, and detect liveness.
 
-- **8 tools** covering the full AceDataCloud Face API surface
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **face** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `face` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a image task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://face.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Detect every face in https://example.com/group.jpg and return their keypoints."
+- "Beautify https://example.com/me.jpg with smoothing 15 and whitening 25."
+- "Swap the face from https://example.com/headshot.jpg onto https://example.com/scene.jpg."
+
+---
+
+## Tool Reference
+
+**8 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `face_detect_keypoints` | Detect 90+ keypoints per face (multi-face supported). |
+| `face_beautify` | Smoothing, whitening, face slimming, and eye enlarging. |
+| `face_change_age` | Age or de-age a portrait. |
+| `face_change_gender` | Swap perceived facial gender characteristics. |
+| `face_swap` | Move a source face onto a target image (with optional async webhook). |
+| `face_cartoonize` | Render a portrait in cartoon / animated style. |
+| `face_detect_liveness` | Distinguish a live capture from a printed / screen photo. |
+| `face_get_usage_guide` | Concise client-side tool usage reference. |
+
+## Pricing
+
+All Face APIs are currently in Alpha. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "face": {
+      "type": "http",
+      "url": "https://face.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "face": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-face-transform"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-face-transform`](https://pypi.org/project/mcp-face-transform/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-face-transform/)
-- [Source Code](https://github.com/AceDataCloud/FaceTransformMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://face.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-face-transform`](https://pypi.org/project/mcp-face-transform/)
+- **Source repository:** https://github.com/AceDataCloud/FaceTransformMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/face/vscode/package.json
+++ b/face/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-face-transform",
   "displayName": "Face Transform MCP",
-  "description": "Face analysis & transformation (keypoints, beautify, age/gender, swap, cartoon, liveness) via Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Face analysis and transforms — keypoints, beautify, age/gender, swap, cartoon, liveness. (Alpha)",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -20,11 +20,21 @@
     "copilot",
     "ace data cloud",
     "face",
+    "face detection",
+    "keypoints",
     "face swap",
-    "face transform",
-    "liveness detection",
-    "beautify"
+    "beautify",
+    "cartoon",
+    "liveness",
+    "portrait",
+    "age",
+    "gender",
+    "transform"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/FaceTransformMCP",
   "repository": {
     "type": "git",
@@ -36,14 +46,20 @@
   "contributes": {
     "mcpServers": {
       "face": {
-        "command": "uvx",
-        "args": [
-          "mcp-face-transform"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://face.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/fish/README.md
+++ b/fish/README.md
@@ -40,7 +40,7 @@ mcp-fish
 mcp-fish --transport http --port 8000
 ```
 
-## Available Tools
+## Tool Reference
 
 | Tool | Description |
 |------|-------------|

--- a/fish/vscode/.vscodeignore
+++ b/fish/vscode/.vscodeignore
@@ -1,3 +1,11 @@
-.github/**
+.vscode/**
+.vscode-test/**
+node_modules/**
+*.vsix
 .git/**
 .gitignore
+.eslintrc.json
+.prettierrc
+**/*.map
+**/tsconfig.json
+**/.editorconfig

--- a/fish/vscode/README.md
+++ b/fish/vscode/README.md
@@ -1,49 +1,117 @@
 # Fish Audio MCP
 
-Text-to-speech with Fish Audio voice models, via the Ace Data Cloud Fish Audio API.
+Fish Audio TTS — generate natural speech and browse the Fish voice library.
 
-This extension provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for VS Code, enabling AI assistants like GitHub Copilot to synthesise audio with Fish Audio directly.
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-fish?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-fish) [![PyPI](https://img.shields.io/pypi/v/mcp-fish.svg?label=PyPI)](https://pypi.org/project/mcp-fish/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://fish.mcp.acedata.cloud/mcp)
 
-## Features
+Generate natural-sounding speech from text using Fish Audio voices via Ace Data Cloud. Browse and search the voice library, fetch model metadata, submit asynchronous generation tasks, and poll single or batched results.
 
-- **6 tools** — generate speech, browse voice models, poll TTS tasks
-- Zero-install: Uses `uvx` for automatic package management
-- Works with GitHub Copilot, Claude, and other MCP-compatible AI assistants
+This extension registers the **fish** MCP server with VS Code so GitHub
+Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)
+can call it directly from chat.
 
-## Prerequisites
+---
 
-1. **Python 3.10+** with `uvx` (from [uv](https://github.com/astral-sh/uv)) installed
-2. **Ace Data Cloud API Token** — Get one at [platform.acedata.cloud](https://platform.acedata.cloud)
+## Quick Start
 
-## Setup
+1. **Install this extension.** VS Code registers the `fish` MCP server automatically.
+2. **Get an API token** from [Ace Data Cloud](https://platform.acedata.cloud) → *API Keys*. New accounts include free trial credit.
+3. **Open Copilot Chat** in agent mode and ask for a audio task — VS Code will prompt for the token the first time and store it securely.
 
-1. Install this extension from the VS Code Marketplace
-2. When prompted, enter your Ace Data Cloud API token
-3. The MCP server will be available to AI assistants automatically
+> The default config talks to the **hosted streamable-HTTP endpoint** at
+> `https://fish.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
-You can also manually configure the token in your VS Code settings (`.vscode/mcp.json`):
+### Example prompts
 
-```json
+- "Generate audio for "Welcome to Ace Data Cloud" with a Fish voice and give me the URL."
+- "List 10 Fish voice models and show their language, gender, and any tags."
+- "Check the status of Fish task <id>."
+
+---
+
+## Tool Reference
+
+**6 tools** available via this server.
+
+| Tool | Description |
+| --- | --- |
+| `fish_generate_audio` | Generate speech from text via a Fish voice model |
+| `fish_list_models` | List available Fish voice models |
+| `fish_get_model` | Fetch metadata for a specific Fish voice model |
+| `fish_get_task` | Get the status / result of a generation task |
+| `fish_get_tasks_batch` | Batch-fetch the status / result of multiple tasks |
+| `fish_get_usage_guide` | Get the API usage guide |
+
+## Pricing
+
+Per-character billing. Free trial credit on sign-up. See full pricing at [https://docs.acedata.cloud](https://docs.acedata.cloud).
+
+---
+
+## Configuration
+
+This extension contributes the following entry to your VS Code MCP config:
+
+```jsonc
 {
   "servers": {
     "fish": {
+      "type": "http",
+      "url": "https://fish.mcp.acedata.cloud/mcp",
+      "headers": { "Authorization": "Bearer ${input:acedatacloud_api_token}" }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "acedatacloud_api_token",
+      "description": "Ace Data Cloud API token",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt for the token on first use and persist it in the OS
+secret store (Keychain / Credential Manager / libsecret).
+
+### Alternative: local stdio (no network roundtrip)
+
+If you prefer running the server locally — for offline dev, air-gapped
+environments, or to pin to a specific PyPI version — install
+[`uv`](https://docs.astral.sh/uv/) and replace your `mcp.json` entry with:
+
+```jsonc
+{
+  "servers": {
+    "fish": {
+      "type": "stdio",
       "command": "uvx",
       "args": ["mcp-fish"],
-      "env": {
-        "ACEDATACLOUD_API_TOKEN": "your-token-here"
-      }
+      "env": { "ACEDATACLOUD_API_TOKEN": "${input:acedatacloud_api_token}" }
     }
   }
 }
 ```
 
+`uvx` will download and run the latest [`mcp-fish`](https://pypi.org/project/mcp-fish/) on demand.
+
+### Alternative: OAuth via Dynamic Client Registration
+
+The hosted endpoint also accepts OAuth 2.1 with [DCR](https://datatracker.ietf.org/doc/html/rfc7591).
+Drop the `headers` and `inputs` blocks and VS Code will run the auth flow on
+first use (redirect URL `http://127.0.0.1:33418` or `https://vscode.dev/redirect`).
+
+---
+
 ## Links
 
-- [PyPI Package](https://pypi.org/project/mcp-fish/)
-- [Source Code](https://github.com/AceDataCloud/FishMCP)
-- [Ace Data Cloud Platform](https://platform.acedata.cloud)
-- [API Documentation](https://docs.acedata.cloud)
+- **Hosted endpoint:** https://fish.mcp.acedata.cloud/mcp
+- **PyPI package:** [`mcp-fish`](https://pypi.org/project/mcp-fish/)
+- **Source repository:** https://github.com/AceDataCloud/FishMCP
+- **Ace Data Cloud platform:** https://platform.acedata.cloud
+- **MCP documentation:** https://docs.acedata.cloud
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/fish/vscode/package.json
+++ b/fish/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp-fish",
   "displayName": "Fish Audio MCP",
-  "description": "Text-to-speech with Fish Audio voice models via the Ace Data Cloud API",
-  "version": "0.1.0",
+  "description": "Fish Audio TTS — generate natural speech and browse the Fish voice library.",
+  "version": "0.2.0",
   "publisher": "acedatacloud",
   "icon": "icon.png",
   "license": "MIT",
@@ -22,11 +22,15 @@
     "fish",
     "fish audio",
     "tts",
-    "text-to-speech",
-    "voice",
+    "text to speech",
+    "voice synthesis",
     "audio",
-    "speech synthesis"
+    "speech"
   ],
+  "galleryBanner": {
+    "color": "#0E1117",
+    "theme": "dark"
+  },
   "homepage": "https://github.com/AceDataCloud/FishMCP",
   "repository": {
     "type": "git",
@@ -38,14 +42,20 @@
   "contributes": {
     "mcpServers": {
       "fish": {
-        "command": "uvx",
-        "args": [
-          "mcp-fish"
-        ],
-        "env": {
-          "ACEDATACLOUD_API_TOKEN": ""
+        "type": "http",
+        "url": "https://fish.mcp.acedata.cloud/mcp",
+        "headers": {
+          "Authorization": "Bearer ${input:acedatacloud_api_token}"
         }
       }
-    }
+    },
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "acedatacloud_api_token",
+        "description": "Ace Data Cloud API token. Sign in at https://platform.acedata.cloud and create a token in 'API Keys'. Stored securely by VS Code.",
+        "password": true
+      }
+    ]
   }
 }

--- a/scripts/vscode_extensions.yaml
+++ b/scripts/vscode_extensions.yaml
@@ -250,3 +250,39 @@ services:
       - 'Shorten this URL: https://platform.acedata.cloud/documents/... with slug "ace-docs".'
       - 'Batch-shorten these 5 URLs (paste the list) and give me a markdown table.'
     pricing_note: "Free tier available. Higher quotas with paid plans."
+
+  face:
+    display_name: Face Transform MCP
+    repo: FaceTransformMCP
+    domain: image
+    # `mcp-face` is taken on PyPI and `acedatacloud.mcp-face-transform` is the
+    # marketplace id we already own — pin both to the existing names.
+    pypi_override: mcp-face-transform
+    ext_name: mcp-face-transform
+    tagline: "Face analysis and transforms — keypoints, beautify, age/gender, swap, cartoon, liveness. (Alpha)"
+    description: >
+      Bring AceDataCloud's Face Transform APIs into Copilot Chat. Detect 90+
+      keypoints per face, beautify portraits, age or de-age, swap perceived
+      gender, face-swap between photos, cartoonize, and detect liveness.
+    keywords: [face, face detection, keypoints, face swap, beautify, cartoon, liveness, portrait, age, gender, transform]
+    examples:
+      - 'Detect every face in https://example.com/group.jpg and return their keypoints.'
+      - 'Beautify https://example.com/me.jpg with smoothing 15 and whitening 25.'
+      - 'Swap the face from https://example.com/headshot.jpg onto https://example.com/scene.jpg.'
+    pricing_note: "All Face APIs are currently in Alpha. Free trial credit on sign-up."
+
+  fish:
+    display_name: Fish Audio MCP
+    repo: FishMCP
+    domain: audio
+    tagline: "Fish Audio TTS — generate natural speech and browse the Fish voice library."
+    description: >
+      Generate natural-sounding speech from text using Fish Audio voices via
+      Ace Data Cloud. Browse and search the voice library, fetch model metadata,
+      submit asynchronous generation tasks, and poll single or batched results.
+    keywords: [fish, fish audio, tts, text to speech, voice synthesis, audio, speech]
+    examples:
+      - 'Generate audio for "Welcome to Ace Data Cloud" with a Fish voice and give me the URL.'
+      - 'List 10 Fish voice models and show their language, gender, and any tags.'
+      - 'Check the status of Fish task <id>.'
+    pricing_note: "Per-character billing. Free trial credit on sign-up."


### PR DESCRIPTION
## Why

After #356 + #358, 15/17 MCP services have their VS Code extensions auto-generated by `scripts/build_vscode_extensions.py` and ship with the new **hosted streamable-HTTP** UX (Bearer-token input, no `uvx` install needed). The two stragglers — **face** and **fish** — were still hand-written with the old `uvx <pkg>` stdio launch config.

## What this changes

1. **`scripts/vscode_extensions.yaml`** — add curated entries for face and fish:
   - `face`: pinned to existing marketplace + PyPI IDs (`acedatacloud.mcp-face-transform` / `mcp-face-transform`) via the new `pypi_override` + `ext_name` overrides. Currently in Alpha.
   - `fish`: defaults are already correct (`mcp-fish` matches `mcp-<alias>`).
2. **`face/vscode/` + `fish/vscode/`** — regenerated from the codegen. Both now register an HTTP MCP server at `https://<alias>.mcp.acedata.cloud/mcp` with a password-protected token input, matching the other 15.
3. **`face/README.md` + `fish/README.md`** — normalize the tool table to `## Tool Reference` / `| Tool | Description |` so the codegen can parse it. face also collapses its old `Tool | Endpoint | Purpose` columns into a single Description column (endpoints aren't user-callable through MCP).

## Marketplace IDs are unchanged

| Service | ID (unchanged) | PyPI (unchanged) |
|---|---|---|
| face | `acedatacloud.mcp-face-transform` | `mcp-face-transform` |
| fish | `acedatacloud.mcp-fish` | `mcp-fish` |

Existing installs, ratings, and download counts carry over. Hardcoded `EXT_ID` in each downstream `publish.yml` already matches.

## Expected post-merge

Sync triggers downstream `FaceTransformMCP` and `FishMCP` → their `publish.yml` → fresh CalVer `2026.MMDD.<n>` published to marketplace with the new UX. Will verify with marketplace API after merge.