### PR TITLE
docs(vscode): link platform VS Code guides and fix tool tables

### DIFF
--- a/aichat/vscode/README.md
+++ b/aichat/vscode/README.md
@@ -21,6 +21,10 @@ can call it directly from chat.
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://aichat.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ---
 
 ## Tool Reference

--- a/face/vscode/README.md
+++ b/face/vscode/README.md
@@ -21,6 +21,10 @@ can call it directly from chat.
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://face.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Detect every face in https://example.com/group.jpg and return their keypoints."

--- a/fish/vscode/README.md
+++ b/fish/vscode/README.md
@@ -21,6 +21,10 @@ can call it directly from chat.
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://fish.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Generate audio for "Welcome to Ace Data Cloud" with a Fish voice and give me the URL."

--- a/flux/README.md
+++ b/flux/README.md
@@ -114,7 +114,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/flux/vscode/README.md
+++ b/flux/vscode/README.md
@@ -2,7 +2,7 @@
 
 Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-flux-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-flux-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-flux-pro.svg?label=PyPI)](https://pypi.org/project/mcp-flux-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://flux.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-flux?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-flux) [![PyPI](https://img.shields.io/pypi/v/mcp-flux-pro.svg?label=PyPI)](https://pypi.org/project/mcp-flux-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://flux.mcp.acedata.cloud/mcp)
 
 Generate high-fidelity images with Flux from VS Code chat, or edit existing images via natural-language instructions using Flux Kontext.
 
@@ -25,6 +25,13 @@ You can rotate or remove the API key any time from the command palette:
 
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://flux.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
+
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Flux MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_flux_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
 
 ### Example prompts
 
@@ -89,7 +96,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/hailuo/README.md
+++ b/hailuo/README.md
@@ -111,7 +111,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/hailuo/vscode/README.md
+++ b/hailuo/vscode/README.md
@@ -26,6 +26,10 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://hailuo.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Generate a Hailuo video: a chef tossing a pizza in slow motion, dolly-in shot."
@@ -85,7 +89,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/kling/README.md
+++ b/kling/README.md
@@ -115,7 +115,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/kling/vscode/README.md
+++ b/kling/vscode/README.md
@@ -26,6 +26,10 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://kling.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Generate a Kling video of a panda doing parkour through a bamboo forest."
@@ -87,7 +91,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/luma/README.md
+++ b/luma/README.md
@@ -115,7 +115,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/luma/vscode/README.md
+++ b/luma/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://luma.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Luma MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_luma_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate a 5-second video of a paper airplane drifting through neon clouds. Use luma."
@@ -87,7 +94,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/midjourney/README.md
+++ b/midjourney/README.md
@@ -125,7 +125,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/midjourney/vscode/README.md
+++ b/midjourney/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://midjourney.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Midjourney MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_midjourney_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate an isometric pixel-art illustration of a cozy cafe. Use midjourney."
@@ -36,7 +43,7 @@ You can rotate or remove the API key any time from the command palette:
 
 ## Tool Reference
 
-**15 tools** available via this server.
+**16 tools** available via this server.
 
 | Tool | Description |
 | --- | --- |
@@ -49,6 +56,7 @@ You can rotate or remove the API key any time from the command palette:
 | `midjourney_generate_video` | Generate a video from text prompt and reference image using Midjourney. |
 | `midjourney_extend_video` | Extend an existing Midjourney video to make it longer. |
 | `midjourney_translate` | Translate Chinese text to English for use as Midjourney prompts. |
+| `midjourney_shorten` | Analyze and shorten long Midjourney prompts while preserving key ideas. |
 | `midjourney_get_seed` | Get the seed value of a previously generated Midjourney image. |
 | `midjourney_get_task` | Query the status and result of a Midjourney generation task. |
 | `midjourney_get_tasks_batch` | Query multiple Midjourney generation tasks at once. |
@@ -99,7 +107,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/nanobanana/README.md
+++ b/nanobanana/README.md
@@ -109,7 +109,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/nanobanana/vscode/README.md
+++ b/nanobanana/vscode/README.md
@@ -2,7 +2,7 @@
 
 Gemini-powered NanoBanana — generate and edit images via natural language.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-nanobanana-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-nanobanana-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-nanobanana-pro.svg?label=PyPI)](https://pypi.org/project/mcp-nanobanana-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://nanobanana.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-nanobanana?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-nanobanana) [![PyPI](https://img.shields.io/pypi/v/mcp-nanobanana-pro.svg?label=PyPI)](https://pypi.org/project/mcp-nanobanana-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://nanobanana.mcp.acedata.cloud/mcp)
 
 Image generation and edit-by-instruction using NanoBanana, NanoBanana 2, and NanoBanana Pro (built on Gemini).
 
@@ -25,6 +25,13 @@ You can rotate or remove the API key any time from the command palette:
 
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://nanobanana.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
+
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [NanoBanana MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_nanobanana_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
 
 ### Example prompts
 
@@ -87,7 +94,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/openai/vscode/README.md
+++ b/openai/vscode/README.md
@@ -21,6 +21,10 @@ can call it directly from chat.
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://openai.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ---
 
 ## Tool Reference

--- a/producer/README.md
+++ b/producer/README.md
@@ -130,7 +130,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/producer/vscode/README.md
+++ b/producer/vscode/README.md
@@ -26,6 +26,10 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://producer.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Generate a Producer track: dreamy synthwave instrumental, 90 BPM, A minor."
@@ -101,7 +105,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/seedance/README.md
+++ b/seedance/README.md
@@ -115,7 +115,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/seedance/vscode/README.md
+++ b/seedance/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://seedance.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Seedance MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_seedance_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate a Seedance video of a stylized robot dancing breakdance on a rooftop."
@@ -86,7 +93,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/seedream/README.md
+++ b/seedream/README.md
@@ -114,7 +114,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/seedream/vscode/README.md
+++ b/seedream/vscode/README.md
@@ -2,7 +2,7 @@
 
 Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedream-pro?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream-pro) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedream?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
 
 High-resolution image generation and edit-by-instruction with ByteDance Seedream (3.0 / 4.0 / 4.5 / 5.0) and SeedEdit 3.0.
 
@@ -25,6 +25,13 @@ You can rotate or remove the API key any time from the command palette:
 
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://seedream.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
+
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Seedream MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_seedream_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
 
 ### Example prompts
 
@@ -89,7 +96,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/serp/README.md
+++ b/serp/README.md
@@ -120,7 +120,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/serp/vscode/README.md
+++ b/serp/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://serp.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Google Search MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_serp_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Search Google for the most recent news on the EU AI Act and summarize it."
@@ -91,7 +98,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/shorturl/README.md
+++ b/shorturl/README.md
@@ -110,7 +110,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/shorturl/vscode/README.md
+++ b/shorturl/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://shorturl.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [ShortURL MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_shorturl_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Shorten this URL: https://platform.acedata.cloud/documents/... with slug "ace-docs"."
@@ -83,7 +90,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/sora/README.md
+++ b/sora/README.md
@@ -116,7 +116,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/sora/vscode/README.md
+++ b/sora/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://sora.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Sora MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_sora_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate a Sora video: time-lapse of a coffee being poured in slow motion. Use sora 2 portrait."
@@ -93,7 +100,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/suno/README.md
+++ b/suno/README.md
@@ -134,7 +134,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/suno/vscode/README.md
+++ b/suno/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://suno.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Suno MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_suno_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate a lofi hip-hop track about late-night coding. Use suno."
@@ -36,7 +43,7 @@ You can rotate or remove the API key any time from the command palette:
 
 ## Tool Reference
 
-**27 tools** available via this server.
+**35 tools** available via this server.
 
 | Tool | Description |
 | --- | --- |
@@ -46,8 +53,10 @@ You can rotate or remove the API key any time from the command palette:
 | `suno_cover_music` | Create a cover or remix version of an existing song in a different style. |
 | `suno_concat_music` | Concatenate extended song segments into a single complete audio file. |
 | `suno_generate_with_persona` | Generate music using a saved artist persona for consistent vocal style. |
+| `suno_generate_with_persona_vox` | Generate music with stronger vocal consistency from a saved persona. |
 | `suno_remaster_music` | Remaster an existing song to improve audio quality. |
 | `suno_stems_music` | Separate a song into individual stems (vocals and instruments). |
+| `suno_all_stems_music` | Separate a song into vocals, bass, drums, and other instrument stems. |
 | `suno_replace_section` | Replace a specific time range in a song with new generated content. |
 | `suno_upload_extend` | Extend an uploaded audio (your own music) with new AI-generated content. |
 | `suno_upload_cover` | Create an AI cover of an uploaded audio (your own music). |
@@ -59,9 +68,15 @@ You can rotate or remove the API key any time from the command palette:
 | `suno_get_wav` | Get the lossless WAV format of a generated song. |
 | `suno_get_midi` | Get MIDI data extracted from a generated song. |
 | `suno_create_persona` | Create a new artist persona from an existing audio's vocal style. |
+| `suno_create_voice` | Create a custom voice persona from an external audio URL. |
+| `suno_list_personas` | List saved artist personas and voice IDs. |
+| `suno_delete_persona` | Delete a saved artist persona. |
 | `suno_optimize_style` | Optimize a music style description for better generation results. |
 | `suno_mashup_lyrics` | Generate mashup lyrics by combining two sets of lyrics. |
 | `suno_upload_audio` | Upload an external audio file to Suno for use in subsequent operations. |
+| `suno_underpainting` | Add AI-generated accompaniment under uploaded vocals. |
+| `suno_overpainting` | Add AI-generated vocals over uploaded instrumental audio. |
+| `suno_samples_music` | Add AI-generated samples to uploaded audio. |
 | `suno_get_task` | Query the status and result of a music generation task. |
 | `suno_get_tasks_batch` | Query multiple music generation tasks at once. |
 | `suno_list_models` | List all available Suno models and their capabilities. |
@@ -111,7 +126,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/veo/README.md
+++ b/veo/README.md
@@ -114,7 +114,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all 15 MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/veo/vscode/README.md
+++ b/veo/vscode/README.md
@@ -26,6 +26,13 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://veo.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For screenshots, token setup, project-level and user-level `mcp.json`, and Copilot Agent Mode examples, see:
+
+- [Veo MCP VS Code guide](https://platform.acedata.cloud/documents/promotion_article_mcp_veo_vscode)
+- [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode)
+
 ### Example prompts
 
 - "Generate a Veo 3.1 video of a vintage train pulling into a snowy station at dusk."
@@ -35,13 +42,17 @@ You can rotate or remove the API key any time from the command palette:
 
 ## Tool Reference
 
-**8 tools** available via this server.
+**12 tools** available via this server.
 
 | Tool | Description |
 | --- | --- |
 | `veo_text_to_video` | Generate AI video from a text prompt using Veo. |
 | `veo_image_to_video` | Generate AI video from one or more reference images using Veo. |
 | `veo_get_1080p` | Get the 1080p high-resolution version of a generated video. |
+| `veo_upsample` | Upsample a generated video to 1080p, 4K, or GIF. |
+| `veo_extend_video` | Extend a Veo 3.1 video with additional content. |
+| `veo_reshoot` | Re-render an existing video with a different camera motion. |
+| `veo_video_objects` | Insert or remove objects in a generated video. |
 | `veo_get_task` | Query the status and result of a video generation task. |
 | `veo_get_tasks_batch` | Query multiple video generation tasks at once. |
 | `veo_list_models` | List all available Veo models and their capabilities. |
@@ -91,7 +102,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]

--- a/wan/README.md
+++ b/wan/README.md
@@ -114,7 +114,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
 }
 ```
 
-Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which bundles all MCP servers with one-click setup.
+Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.com/items?itemName=acedatacloud.acedatacloud-mcp) for VS Code, which registers the hosted MCP servers with one-click setup.
 
 #### JetBrains IDEs
 

--- a/wan/vscode/README.md
+++ b/wan/vscode/README.md
@@ -26,6 +26,10 @@ You can rotate or remove the API key any time from the command palette:
 > The default config talks to the **hosted streamable-HTTP endpoint** at
 > `https://wan.mcp.acedata.cloud/mcp` — no Python, no `uvx`, no local install needed.
 
+## VS Code Setup Guide
+
+For the full VS Code walkthrough, see [All Ace Data Cloud MCP servers in VS Code](https://platform.acedata.cloud/documents/promotion_article_mcp_all_vscode). It covers token setup, project-level and user-level `mcp.json`, Copilot Agent Mode, and using one Ace Data Cloud token across hosted MCP servers.
+
 ### Example prompts
 
 - "Generate a Wan 1080P video of waves crashing on a black-sand beach, with ambient audio."
@@ -86,7 +90,7 @@ this extension.
     {
       "type": "promptString",
       "id": "acedatacloud_api_token",
-    "description": "Ace Data Cloud API key",
+      "description": "Ace Data Cloud API key",
       "password": true
     }
   ]


### PR DESCRIPTION
## What

Improve the VS Code extension READMEs so they match the hosted-HTTP marketplace experience and point users to the platform's VS Code tutorials.

## Changes

- Add a visible **VS Code Setup Guide** section to all 19 extension READMEs, linking to the platform's `promotion_article_mcp_all_vscode` overview. Services that already have a dedicated article (Flux, Luma, Midjourney, NanoBanana, Seedance, Seedream, Serp, ShortURL, Sora, Suno, Veo) also link their service-specific guide.
- Fix drifted tool tables: Suno `27 -> 35`, Veo `8 -> 12`, Midjourney `15 -> 16`, with the missing tool rows added. Counts now match the `@mcp.tool()` definitions in source.
- Align VS Code Marketplace badges/links with the extension `package.json` names (Flux, NanoBanana, Seedream no longer point at the PyPI `-pro` slug).
- Replace stale "bundles all 15 MCP servers" wording in root READMEs with "registers the hosted MCP servers".
- Fix indentation in the manual `mcp.json` snippets.

README-only changes.