### PR TITLE
chore(deploy): scale mcp-sora replicas to 0

### DIFF
--- a/sora/deploy/production/deployment.yaml
+++ b/sora/deploy/production/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: mcp-sora
   namespace: acedatacloud
 spec:
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 5
   selector:
     matchLabels:


### PR DESCRIPTION
## What
Set  production deployment replicas from 1 to 0.\n\n## Why\nSora workloads are being fully offlined, so MCP Sora is also scaled down to zero.