### PR TITLE
refactor(clients): use async:true instead of dummy health callback

### DIFF
--- a/fish/core/client.py
+++ b/fish/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import FishAPIError, FishAuthError, FishError, FishTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class FishClient:
         """Ensure long-running operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/flux/core/client.py
+++ b/flux/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import FluxAPIError, FluxAuthError, FluxError, FluxTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class FluxClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/flux/tests/test_client.py
+++ b/flux/tests/test_client.py
@@ -7,7 +7,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Flux operations should default to async submission."""
     client = FluxClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"action": "generate"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 def test_with_async_callback_preserves_explicit_callback() -> None:

--- a/grok/core/client.py
+++ b/grok/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import GrokAPIError, GrokAuthError, GrokError, GrokTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class GrokClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/grok/tests/test_client.py
+++ b/grok/tests/test_client.py
@@ -35,7 +35,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Grok operations should default to async submission."""
     client = GrokClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"model": "grok-imagine-video"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 def test_with_async_callback_preserves_explicit_callback() -> None:

--- a/hailuo/core/client.py
+++ b/hailuo/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import HailuoAPIError, HailuoAuthError, HailuoError, HailuoTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class HailuoClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/hailuo/tests/test_client.py
+++ b/hailuo/tests/test_client.py
@@ -40,7 +40,7 @@ class TestHailuoClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"action": "generate"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/kling/core/client.py
+++ b/kling/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import KlingAPIError, KlingAuthError, KlingError, KlingTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class KlingClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/kling/tests/test_client.py
+++ b/kling/tests/test_client.py
@@ -40,7 +40,7 @@ class TestKlingClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"action": "text2video"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/luma/core/client.py
+++ b/luma/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import LumaAPIError, LumaAuthError, LumaError, LumaTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class LumaClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/luma/tests/test_client.py
+++ b/luma/tests/test_client.py
@@ -40,7 +40,7 @@ class TestLumaClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"action": "generate"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/midjourney/core/client.py
+++ b/midjourney/core/client.py
@@ -15,12 +15,6 @@ from core.exceptions import (
     MidjourneyTimeoutError,
 )
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -72,7 +66,7 @@ class MidjourneyClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/midjourney/tests/test_client.py
+++ b/midjourney/tests/test_client.py
@@ -7,7 +7,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Midjourney operations should default to async submission."""
     client = MidjourneyClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"action": "generate"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 def test_with_async_callback_preserves_explicit_callback() -> None:

--- a/nanobanana/core/client.py
+++ b/nanobanana/core/client.py
@@ -15,12 +15,6 @@ from core.exceptions import (
     NanoBananaTimeoutError,
 )
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -72,7 +66,7 @@ class NanoBananaClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/nanobanana/tests/test_client.py
+++ b/nanobanana/tests/test_client.py
@@ -11,7 +11,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running NanoBanana operations should default to async submission."""
     client = NanoBananaClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"action": "generate"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 @pytest.mark.asyncio

--- a/producer/core/client.py
+++ b/producer/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import ProducerAPIError, ProducerAuthError, ProducerError, ProducerTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class ProducerClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/producer/tests/test_client.py
+++ b/producer/tests/test_client.py
@@ -44,7 +44,7 @@ class TestProducerClient:
     def test_with_async_callback_injects_default(self, client):
         """Test async submission injects an internal callback."""
         payload = client._with_async_callback({"action": "generate"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/seedance/core/client.py
+++ b/seedance/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import SeedanceAPIError, SeedanceAuthError, SeedanceError, SeedanceTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class SeedanceClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/seedance/tests/test_client.py
+++ b/seedance/tests/test_client.py
@@ -42,7 +42,7 @@ class TestSeedanceClient:
     ) -> None:
         """Test async submission injects an internal callback when missing."""
         payload = test_client._with_async_callback({"model": "doubao-seedance-1-0-pro-250528"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(
         self, test_client: SeedanceClient

--- a/seedream/core/client.py
+++ b/seedream/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import SeedreamAPIError, SeedreamAuthError, SeedreamError, SeedreamTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class SeedreamClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/seedream/tests/test_client.py
+++ b/seedream/tests/test_client.py
@@ -7,7 +7,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Seedream operations should default to async submission."""
     client = SeedreamClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"prompt": "test"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 def test_with_async_callback_preserves_explicit_callback() -> None:

--- a/sora/core/client.py
+++ b/sora/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import SoraAPIError, SoraAuthError, SoraError, SoraTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class SoraClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/sora/tests/test_client.py
+++ b/sora/tests/test_client.py
@@ -40,7 +40,7 @@ class TestSoraClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"prompt": "test"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/suno/core/client.py
+++ b/suno/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import SunoAPIError, SunoAuthError, SunoError, SunoTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class SunoClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/suno/tests/test_client.py
+++ b/suno/tests/test_client.py
@@ -40,7 +40,7 @@ class TestSunoClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"action": "generate"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""

--- a/veo/core/client.py
+++ b/veo/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import VeoAPIError, VeoAuthError, VeoError, VeoTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class VeoClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/veo/tests/test_client.py
+++ b/veo/tests/test_client.py
@@ -7,7 +7,7 @@ def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Veo operations should default to async submission."""
     client = VeoClient(api_token="test-token", base_url="https://api.test.com")
     payload = client._with_async_callback({"action": "text2video"})
-    assert payload["callback_url"] == "https://api.acedata.cloud/health"
+    assert payload["async"] is True
 
 
 def test_with_async_callback_preserves_explicit_callback() -> None:

--- a/wan/core/client.py
+++ b/wan/core/client.py
@@ -10,12 +10,6 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import WanAPIError, WanAuthError, WanError, WanTimeoutError
 
-# Dummy callback URL used to force the upstream API into async mode.
-# When present, the API returns immediately with a task_id instead of blocking
-# until generation completes. The health endpoint simply returns 200 OK and
-# discards the callback payload — it is never actually processed.
-_ASYNC_CALLBACK_URL = "https://api.acedata.cloud/health"
-
 # Context variable for per-request API token (used in HTTP/remote mode)
 _request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_api_token", default=None
@@ -67,7 +61,7 @@ class WanClient:
         """Ensure long-running media operations are submitted asynchronously."""
         request_payload = dict(payload)
         if not request_payload.get("callback_url"):
-            request_payload["callback_url"] = _ASYNC_CALLBACK_URL
+            request_payload["async"] = True
         return request_payload
 
     def _handle_error_response(self, response: httpx.Response) -> None:

--- a/wan/tests/test_client.py
+++ b/wan/tests/test_client.py
@@ -40,7 +40,7 @@ class TestWanClient:
     def test_with_async_callback_injects_default_callback(self, client):
         """Test async submission injects an internal callback when missing."""
         payload = client._with_async_callback({"action": "generate"})
-        assert payload["callback_url"] == "https://api.acedata.cloud/health"
+        assert payload["async"] is True
 
     def test_with_async_callback_preserves_explicit_callback(self, client):
         """Test async submission preserves a user-provided callback."""


### PR DESCRIPTION
## What

All 15 media MCP servers (suno, veo, sora, midjourney, luma, kling, hailuo, flux, seedream, seedance, nanobanana, grok, fish, producer, wan) forced async submission by injecting a **dummy** `callback_url = https://api.acedata.cloud/health` whenever the caller didn't supply one — so the API returns a `task_id` immediately instead of blocking, and the server polls `get_task`.

The API now supports an explicit `async: true` flag (workers PS#1019, openapi PB#662). This switches the injection to `async: true`, which is exactly what the hack was emulating — and stops firing a useless POST to the health endpoint for every single task.

## Changes (29 files)

- `_with_async_callback`: inject `{"async": true}` when no `callback_url` is provided (15 `core/client.py`)
- Remove the now-unused `_ASYNC_CALLBACK_URL` constant + comment
- Update the inject assertion in 14 `tests/test_client.py` (`async is True`); the explicit-callback preserve test is unchanged

Verified: py_compile, ruff, and the `_with_async_callback` tests pass.

## Ordering

Depends on worker async:true support (PS#1019, merged and deploying). Workers go live before this publishes to PyPI, so there's no window where async:true hits an old worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)