### PR TITLE
feat(suno): add suno_generate_inspo MCP tool

### DIFF
--- a/suno/tests/test_audio_tools.py
+++ b/suno/tests/test_audio_tools.py
@@ -1,0 +1,51 @@
+"""Unit tests for audio tools (mocked client, no network)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.audio_tools import suno_generate_inspo
+
+
+class TestInspoTool:
+    """Tests for the suno_generate_inspo tool."""
+
+    @pytest.mark.asyncio
+    async def test_inspo_builds_expected_payload(self, mock_audio_response):
+        """Inspo tool should send action=inspo with audio_urls and optional params."""
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            result = await suno_generate_inspo(
+                audio_urls=["https://cdn1.suno.ai/ref.mp3"],
+                prompt="warm acoustic folk",
+                style="acoustic, folk, warm",
+                title="Inspo Demo",
+                model="chirp-v5",
+                audio_weight=0.6,
+            )
+
+        mock_generate.assert_awaited_once()
+        payload = mock_generate.await_args.kwargs
+        assert payload["action"] == "inspo"
+        assert payload["audio_urls"] == ["https://cdn1.suno.ai/ref.mp3"]
+        assert payload["model"] == "chirp-v5"
+        assert payload["audio_weight"] == 0.6
+        assert payload["style"] == "acoustic, folk, warm"
+        assert "test-task-123" in result
+
+    @pytest.mark.asyncio
+    async def test_inspo_omits_unset_optional_params(self, mock_audio_response):
+        """Optional params left empty should not be sent in the payload."""
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            await suno_generate_inspo(audio_urls=["https://cdn1.suno.ai/ref.mp3"])
+
+        payload = mock_generate.await_args.kwargs
+        assert payload["action"] == "inspo"
+        assert "audio_weight" not in payload
+        assert "style" not in payload
+        assert "prompt" not in payload

--- a/suno/tools/audio_tools.py
+++ b/suno/tools/audio_tools.py
@@ -956,3 +956,76 @@ async def suno_samples_music(
 
     result = await client.generate_audio(**payload)
     return format_audio_result(result)
+
+
+@mcp.tool()
+async def suno_generate_inspo(
+    audio_urls: Annotated[
+        list[str],
+        Field(
+            description="1 to 4 publicly accessible reference audio URLs used as inspiration. Suno extracts stylistic ideas from these tracks (rather than copying them) to create a brand-new song. Tip: avoid well-known catalog recordings, which may be rejected by Suno's copyright check."
+        ),
+    ],
+    prompt: Annotated[
+        str,
+        Field(
+            description="Optional lyrics or creative brief for the new song. Leave empty to let Suno write its own lyrics."
+        ),
+    ] = "",
+    title: Annotated[
+        str,
+        Field(description="Optional title of the song."),
+    ] = "",
+    style: Annotated[
+        str,
+        Field(
+            description="Optional music style tags. Examples: 'acoustic, folk, warm', 'lo-fi, chill, instrumental'"
+        ),
+    ] = "",
+    model: Annotated[
+        SunoModel,
+        Field(description="Suno model version to use for the inspired generation."),
+    ] = DEFAULT_MODEL,
+    audio_weight: Annotated[
+        float | None,
+        Field(
+            description="How strongly the reference audios influence the result, 0 to 1. Higher means closer to the references' vibe."
+        ),
+    ] = None,
+    callback_url: Annotated[
+        str | None,
+        Field(
+            description="Webhook callback URL for asynchronous notifications. When provided, the API will call this URL when generation completes."
+        ),
+    ] = None,
+) -> str:
+    """Generate brand-new music inspired by 1 to 4 reference audios (Suno Inspo / 灵感创作).
+
+    Unlike a cover, inspo does not reproduce the source tracks - it draws stylistic
+    inspiration from them and composes a fresh song guided by your prompt and style tags.
+
+    Use this when:
+    - You have reference tracks whose vibe you want to riff on
+    - You want a new song "in the style of" some audio you provide
+
+    Returns:
+        Task ID and generated audio information including URLs, title, lyrics, and duration.
+    """
+    payload: dict = {
+        "action": "inspo",
+        "audio_urls": audio_urls,
+        "model": model,
+        "callback_url": callback_url,
+    }
+
+    if prompt:
+        payload["prompt"] = prompt
+    if title:
+        payload["title"] = title
+    if style:
+        payload["style"] = style
+    if audio_weight is not None:
+        payload["audio_weight"] = audio_weight
+
+    result = await client.generate_audio(**payload)
+    return format_audio_result(result)


### PR DESCRIPTION
Adds a `suno_generate_inspo` tool to the Suno MCP server. It calls `/suno/audios` with `action=inspo` and `audio_urls` (1–4 public reference URLs) to generate new music inspired by them (Suno 灵感创作). Reuses `format_audio_result`; includes mocked unit tests (2 passed, ruff + mypy clean).

Pairs with PlatformService#1032 (worker) and PlatformBackend#692 (API spec/cost/docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)