### PR TITLE
fix(docs): catalog model source + reliable service resolution (post-deploy test fixes)

### DIFF
--- a/docs/core/client.py
+++ b/docs/core/client.py
@@ -86,8 +86,10 @@ class DocsClient:
         return await self.get(f"/api/v1/documents/{ref}", lang=lang)
 
     # --- catalog -----------------------------------------------------------
-    async def list_services(self, service_type: str | None = None) -> Any:
-        params: dict[str, Any] = {"private": "false"}
+    async def list_services(self, service_type: str | None = None, limit: int = 200) -> Any:
+        # limit=200 pulls all services in one page (the list paginates at 10),
+        # so alias→id resolution and the services tool see the full set.
+        params: dict[str, Any] = {"private": "false", "limit": limit}
         if service_type:
             params["type"] = service_type
         return _unwrap(await self.get("/api/v1/services/", params=params))
@@ -109,8 +111,14 @@ class DocsClient:
 
     # --- models ------------------------------------------------------------
     async def list_models(self, with_pricing: bool = True) -> Any:
+        # /api/v1/models/ is chat-only (OpenAI-compatible) with USD pricing.
         params = {"with_pricing": "1"} if with_pricing else {}
         return await self.get("/api/v1/models/", params=params)
+
+    async def get_catalog(self) -> Any:
+        # The full model directory across ALL modalities (chat/image/video/music/
+        # search/embedding) with credit pricing + conversion rates.
+        return await self.get("/api/v1/models/catalog/")
 
 
 client = DocsClient()

--- a/docs/tools/catalog_tools.py
+++ b/docs/tools/catalog_tools.py
@@ -15,16 +15,19 @@ def _dump(data: object) -> str:
 
 async def _resolve_service_id(service: str) -> str | None:
     """Map a Service alias (or id) to its id, client-side, so service filtering
-    is correct even if the backend ignores the `service` query param."""
+    is correct even if the backend ignores the `service` query param.
+
+    Returns ``None`` if the service can't be resolved (e.g. beyond the fetched
+    page) — the caller then trusts the backend `service` filter rather than
+    over-filtering every result to empty.
+    """
     if not service:
         return None
     services = await client.list_services()
     for s in services:
         if isinstance(s, dict) and (s.get("alias") == service or str(s.get("id")) == service):
             return str(s.get("id"))
-    # Unknown alias → no match; treat the raw value as an id so we don't silently
-    # widen the result to every service.
-    return service
+    return None
 
 
 def _filter_public(apis: list, service_id: str | None = None) -> list:

--- a/docs/tools/model_tools.py
+++ b/docs/tools/model_tools.py
@@ -19,30 +19,42 @@ def _models_list(data: object) -> list:
     return data if isinstance(data, list) else []
 
 
+def _catalog_items(data: object) -> list:
+    if isinstance(data, dict) and isinstance(data.get("items"), list):
+        return [m for m in data["items"] if isinstance(m, dict)]
+    return []
+
+
 @mcp.tool()
 async def acedata_list_models(modality: str = "", with_pricing: bool = True) -> str:
-    """List the LLM / image / video / music / embedding models AceData Cloud offers.
+    """List the LLM / image / video / music / search / embedding models AceData Cloud offers.
+
+    Sourced from the full catalog (all modalities), with credit pricing and the
+    credit→USD conversion rate.
 
     Args:
         modality: Optional filter — chat, image, video, music, search, embedding.
-        with_pricing: Include USD pricing computed from billing rules (default True).
+        with_pricing: Include pricing on each model (default True).
     """
     try:
-        data = await client.list_models(with_pricing=with_pricing)
-        models = [m for m in _models_list(data) if isinstance(m, dict)]
+        data = await client.get_catalog()
+        models = _catalog_items(data)
         if modality:
-            models = [m for m in models if modality in (m.get("type"), m.get("modality"))]
-        slim = [
-            {
+            models = [m for m in models if m.get("modality") == modality]
+        slim = []
+        for m in models:
+            entry = {
                 "id": m.get("id"),
-                "type": m.get("type") or m.get("modality"),
-                "owned_by": m.get("owned_by"),
-                "pricing": m.get("pricing"),
+                "name": m.get("name"),
+                "modality": m.get("modality"),
+                "provider": m.get("provider"),
+                "unit": m.get("unit"),
             }
-            for m in models
-            if isinstance(m, dict)
-        ]
-        return _dump(slim)
+            if with_pricing:
+                entry["pricing"] = m.get("pricing")
+            slim.append(entry)
+        rates = data.get("rates") if isinstance(data, dict) else None
+        return _dump({"count": len(slim), "rates": rates, "models": slim})
     except DocsError as e:
         return f"Failed to list models: {e.message}"
 
@@ -55,8 +67,15 @@ async def acedata_get_model(model_id: str) -> str:
         model_id: The model id, e.g. "gpt-5.1", "claude-opus-4-8", "doubao-seedream-5-0-260128".
     """
     try:
-        data = await client.list_models(with_pricing=True)
-        for m in _models_list(data):
+        # Catalog covers all modalities; the chat /models/ endpoint adds USD detail.
+        data = await client.get_catalog()
+        item = next((m for m in _catalog_items(data) if m.get("id") == model_id), None)
+        if item is not None:
+            out = dict(item)
+            out["rates"] = data.get("rates") if isinstance(data, dict) else None
+            return _dump(out)
+        chat = await client.list_models(with_pricing=True)
+        for m in _models_list(chat):
             if isinstance(m, dict) and m.get("id") == model_id:
                 return _dump(m)
         return f'Model "{model_id}" not found. Use acedata_list_models to see available ids.'


### PR DESCRIPTION
Follow-up to #397. Post-deploy multi-tool testing of the live docs MCP found two bugs; both fixed and already running live (image 2026.6.23.3), all 11 tools re-verified.

| Bug | Cause | Fix |
|---|---|---|
| `list_apis(service)` / `get_pricing(service)` → `[]` | `list_services` paginates (10/page, 70 total) → alias→id resolve missed services past page 1 → client-side `service_id` filter rejected everything | `list_services` now `limit=200`; `_resolve_service_id` returns `None` when unresolved → caller trusts the backend `service` filter instead of over-filtering |
| `list_models(modality=image/video/music/…)` → `[]` | `/api/v1/models/` is chat-only (76 chat) | `list_models`/`get_model` use `/api/v1/models/catalog/` (all 6 modalities, 155 models, credit pricing + rates) |

Verified live across all 11 tools: search_docs, list/fetch_doc, list_services, list_apis(suno)→suno APIs, get_spec(/suno/audios)→correct spec, list_models(image)→22 models, get_model, get_pricing(suno), get_code_example, list_mcp_servers.

## 🤖 对抗评审
Codex (`codex exec --sandbox read-only`) → `VERDICT: CLEAN`. Confirmed `_filter_public` skips service filtering when `service_id is None`, catalog helpers guard non-dict shapes, `get_model` falls back to chat endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)