### PR TITLE
refactor(docs)!: rename acedata_* tools → acedatacloud_* (brand consistency)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.6.23.4
+- Rename all tools `acedata_*` → `acedatacloud_*`, connector slug `acedata-docs`
+  → `acedatacloud-docs`, and product name "AceData Docs" → "AceDataCloud Docs"
+  for brand consistency. (Domains, env vars, package, and org names unchanged.)
+- Use the catalog endpoint for models (all modalities) + reliable service resolution.
+
 ## 2026.6.23.1
 - Initial release: public, zero-install MCP for AceData Cloud docs, API specs,
   models, pricing, and code examples. Remote at https://docs.mcp.acedata.cloud/mcp.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# AceData Docs MCP
+# AceDataCloud Docs MCP
 
 A **public, zero-install** [Model Context Protocol](https://modelcontextprotocol.io) server that
 exposes the entire [AceData Cloud](https://platform.acedata.cloud) catalog — documentation, API
@@ -13,7 +13,7 @@ Add one URL to your MCP client:
 ```json
 {
   "mcpServers": {
-    "acedata-docs": {
+    "acedatacloud-docs": {
       "url": "https://docs.mcp.acedata.cloud/mcp"
     }
   }
@@ -23,7 +23,7 @@ Add one URL to your MCP client:
 Claude Code:
 
 ```bash
-claude mcp add --transport http acedata-docs https://docs.mcp.acedata.cloud/mcp
+claude mcp add --transport http acedatacloud-docs https://docs.mcp.acedata.cloud/mcp
 ```
 
 ## Use it (local — stdio via PyPI)
@@ -36,15 +36,15 @@ uvx mcp-docs            # or: pip install mcp-docs && mcp-docs
 
 | Tool | What it does |
 |---|---|
-| `acedata_search_docs` | Search the docs by keyword/question → snippets + URLs |
-| `acedata_list_docs` / `acedata_fetch_doc` | Browse and read full documentation pages |
-| `acedata_list_services` | List services (logical API groupings) |
-| `acedata_list_apis` | List public API endpoints (optionally per service) |
-| `acedata_get_spec` | Get the OpenAPI spec for an API (filtered by path/service) |
-| `acedata_list_models` / `acedata_get_model` | Model catalog + USD pricing |
-| `acedata_get_pricing` | Display pricing for a service |
-| `acedata_get_code_example` | A runnable curl / python / javascript snippet |
-| `acedata_list_mcp_servers` | AceData Cloud's other MCP servers + how to connect |
+| `acedatacloud_search_docs` | Search the docs by keyword/question → snippets + URLs |
+| `acedatacloud_list_docs` / `acedatacloud_fetch_doc` | Browse and read full documentation pages |
+| `acedatacloud_list_services` | List services (logical API groupings) |
+| `acedatacloud_list_apis` | List public API endpoints (optionally per service) |
+| `acedatacloud_get_spec` | Get the OpenAPI spec for an API (filtered by path/service) |
+| `acedatacloud_list_models` / `acedatacloud_get_model` | Model catalog + USD pricing |
+| `acedatacloud_get_pricing` | Display pricing for a service |
+| `acedatacloud_get_code_example` | A runnable curl / python / javascript snippet |
+| `acedatacloud_list_mcp_servers` | AceData Cloud's other MCP servers + how to connect |
 
 ## Development
 
@@ -55,7 +55,7 @@ python main.py --transport http # remote (port 8000)
 pytest
 ```
 
-`acedata_list_mcp_servers` is backed by `core/data/mcp_servers.json`, generated from the sibling
+`acedatacloud_list_mcp_servers` is backed by `core/data/mcp_servers.json`, generated from the sibling
 `MCPs/*/server.json` files via `python scripts/gen_mcp_servers.py`.
 
 ## License

--- a/docs/core/__init__.py
+++ b/docs/core/__init__.py
@@ -1,4 +1,4 @@
-"""Core module for the AceData Docs MCP server."""
+"""Core module for the AceDataCloud Docs MCP server."""
 
 from core.client import DocsClient
 from core.config import settings

--- a/docs/core/config.py
+++ b/docs/core/config.py
@@ -1,4 +1,4 @@
-"""Configuration management for the AceData Docs MCP server."""
+"""Configuration management for the AceDataCloud Docs MCP server."""
 
 import os
 from dataclasses import dataclass, field
@@ -30,7 +30,9 @@ class Settings:
         default_factory=lambda: float(os.getenv("DOCS_REQUEST_TIMEOUT", "30"))
     )
 
-    server_name: str = field(default_factory=lambda: os.getenv("MCP_SERVER_NAME", "AceData Docs"))
+    server_name: str = field(
+        default_factory=lambda: os.getenv("MCP_SERVER_NAME", "AceDataCloud Docs")
+    )
     transport: str = field(default_factory=lambda: os.getenv("MCP_TRANSPORT", "stdio"))
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
 

--- a/docs/core/exceptions.py
+++ b/docs/core/exceptions.py
@@ -1,4 +1,4 @@
-"""Custom exceptions for the AceData Docs MCP server."""
+"""Custom exceptions for the AceDataCloud Docs MCP server."""
 
 
 class DocsError(Exception):

--- a/docs/main.py
+++ b/docs/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""AceData Docs MCP Server.
+"""AceDataCloud Docs MCP Server.
 
 A public, zero-install MCP server that exposes the AceData Cloud documentation,
 API catalog, OpenAPI specs, model list, pricing, and runnable code examples as
@@ -33,7 +33,7 @@ def get_version() -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="AceData Docs MCP Server")
+    parser = argparse.ArgumentParser(description="AceDataCloud Docs MCP Server")
     parser.add_argument("--version", action="version", version=f"mcp-docs {get_version()}")
     parser.add_argument(
         "--transport", choices=["stdio", "http"], default="stdio", help="Transport (default stdio)"
@@ -41,7 +41,9 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8000, help="Port for HTTP transport")
     args = parser.parse_args()
 
-    logger.info(f"AceData Docs MCP {get_version()} — transport={args.transport} (public, no-auth)")
+    logger.info(
+        f"AceDataCloud Docs MCP {get_version()} — transport={args.transport} (public, no-auth)"
+    )
 
     # Register tools + prompts.
     import prompts  # noqa: F401
@@ -66,7 +68,7 @@ def main() -> None:
             async def server_card(_request: Request) -> JSONResponse:
                 return JSONResponse(
                     {
-                        "serverInfo": {"name": "AceData Docs"},
+                        "serverInfo": {"name": "AceDataCloud Docs"},
                         "authentication": {"required": False},
                         "resources": [],
                     }

--- a/docs/prompts/__init__.py
+++ b/docs/prompts/__init__.py
@@ -1,18 +1,18 @@
-"""Prompts module for the AceData Docs MCP server."""
+"""Prompts module for the AceDataCloud Docs MCP server."""
 
 from core.server import mcp
 
 
 @mcp.prompt()
-def acedata_docs_guide() -> str:
-    """How to use the AceData Docs MCP to answer questions about AceData Cloud."""
+def acedatacloud_docs_guide() -> str:
+    """How to use the AceDataCloud Docs MCP to answer questions about AceData Cloud."""
     return (
         "You can answer questions about AceData Cloud (api.acedata.cloud) using these tools:\n"
-        "- acedata_search_docs(query): find docs by keyword — start here.\n"
-        "- acedata_list_docs / acedata_fetch_doc(ref): browse and read full pages.\n"
-        "- acedata_list_services / acedata_list_apis / acedata_get_spec(api_path): API catalog + OpenAPI.\n"
-        "- acedata_list_models / acedata_get_model / acedata_get_pricing: model catalog + USD pricing.\n"
-        "- acedata_get_code_example(api_path): a runnable curl/python/js snippet.\n"
-        "- acedata_list_mcp_servers: AceData's other MCP servers.\n\n"
+        "- acedatacloud_search_docs(query): find docs by keyword — start here.\n"
+        "- acedatacloud_list_docs / acedatacloud_fetch_doc(ref): browse and read full pages.\n"
+        "- acedatacloud_list_services / acedatacloud_list_apis / acedatacloud_get_spec(api_path): API catalog + OpenAPI.\n"
+        "- acedatacloud_list_models / acedatacloud_get_model / acedatacloud_get_pricing: model catalog + USD pricing.\n"
+        "- acedatacloud_get_code_example(api_path): a runnable curl/python/js snippet.\n"
+        "- acedatacloud_list_mcp_servers: AceData's other MCP servers.\n\n"
         "Prefer fetching the real spec/pricing over guessing. All data is live from the platform."
     )

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docs"
-version = "2026.6.23.1"
+version = "2026.6.23.4"
 description = "Public MCP server for AceData Cloud documentation, API specs, models, pricing & code examples"
 readme = "README.md"
 license = { text = "MIT" }

--- a/docs/scripts/gen_mcp_servers.py
+++ b/docs/scripts/gen_mcp_servers.py
@@ -2,7 +2,7 @@
 """Regenerate core/data/mcp_servers.json from the sibling MCPs/*/server.json files.
 
 Run from the MCPs monorepo root:  python docs/scripts/gen_mcp_servers.py
-Keeps `acedata_list_mcp_servers` accurate without hand-maintaining a list.
+Keeps `acedatacloud_list_mcp_servers` accurate without hand-maintaining a list.
 """
 
 import glob

--- a/docs/server.json
+++ b/docs/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.AceDataCloud/mcp-docs",
   "description": "Public MCP server for AceData Cloud documentation, API specs, models, pricing & code examples",
-  "version": "2026.6.23.1",
+  "version": "2026.6.23.4",
   "repository": {
     "url": "https://github.com/AceDataCloud/DocsMCP",
     "source": "github"
@@ -10,7 +10,7 @@
   "packages": [
     {
       "identifier": "mcp-docs",
-      "version": "2026.6.23.1",
+      "version": "2026.6.23.4",
       "transport": {
         "type": "stdio"
       },

--- a/docs/tools/__init__.py
+++ b/docs/tools/__init__.py
@@ -1,4 +1,4 @@
-"""Tools module for the AceData Docs MCP server."""
+"""Tools module for the AceDataCloud Docs MCP server."""
 
 # Import all tool modules so their @mcp.tool() functions register.
 from tools import catalog_tools, doc_tools, example_tools, meta_tools, model_tools

--- a/docs/tools/catalog_tools.py
+++ b/docs/tools/catalog_tools.py
@@ -46,7 +46,7 @@ def _filter_public(apis: list, service_id: str | None = None) -> list:
 
 
 @mcp.tool()
-async def acedata_list_services(service_type: str = "") -> str:
+async def acedatacloud_list_services(service_type: str = "") -> str:
     """List AceData Cloud services (logical API groupings).
 
     Args:
@@ -70,7 +70,7 @@ async def acedata_list_services(service_type: str = "") -> str:
 
 
 @mcp.tool()
-async def acedata_list_apis(service: str = "") -> str:
+async def acedatacloud_list_apis(service: str = "") -> str:
     """List public API endpoints (Beta/Production), optionally for one service.
 
     Args:
@@ -95,7 +95,7 @@ async def acedata_list_apis(service: str = "") -> str:
 
 
 @mcp.tool()
-async def acedata_get_spec(api_path: str = "", service: str = "") -> str:
+async def acedatacloud_get_spec(api_path: str = "", service: str = "") -> str:
     """Get the OpenAPI specification for an API.
 
     You MUST provide `api_path` or `service` — the full spec is never returned

--- a/docs/tools/doc_tools.py
+++ b/docs/tools/doc_tools.py
@@ -32,7 +32,7 @@ def _doc_ref(ref: str) -> str:
 
 
 @mcp.tool()
-async def acedata_search_docs(query: str, lang: str = "zh-cn", limit: int = 10) -> str:
+async def acedatacloud_search_docs(query: str, lang: str = "zh-cn", limit: int = 10) -> str:
     """Search the AceData Cloud documentation for a topic, API, or keyword.
 
     Use this first when you don't know the exact API or doc page. Returns
@@ -48,19 +48,19 @@ async def acedata_search_docs(query: str, lang: str = "zh-cn", limit: int = 10) 
         data = await client.search_docs(query=query, lang=lang, limit=limit)
         results = data.get("results", []) if isinstance(data, dict) else data
         if not results:
-            return f'No documentation found for "{query}". Try acedata_list_docs to browse.'
+            return f'No documentation found for "{query}". Try acedatacloud_list_docs to browse.'
         return _dump(results)
     except DocsNotFoundError:
         return (
             "The documentation search index is not available yet. "
-            "Use acedata_list_docs to browse pages, or acedata_fetch_doc with a known alias."
+            "Use acedatacloud_list_docs to browse pages, or acedatacloud_fetch_doc with a known alias."
         )
     except DocsError as e:
         return f"Search failed: {e.message}"
 
 
 @mcp.tool()
-async def acedata_list_docs(limit: int = 20, offset: int = 0, doc_type: str = "") -> str:
+async def acedatacloud_list_docs(limit: int = 20, offset: int = 0, doc_type: str = "") -> str:
     """List available documentation pages (paginated).
 
     Args:
@@ -90,7 +90,7 @@ async def acedata_list_docs(limit: int = 20, offset: int = 0, doc_type: str = ""
 
 
 @mcp.tool()
-async def acedata_fetch_doc(ref: str, lang: str = "zh-cn") -> str:
+async def acedatacloud_fetch_doc(ref: str, lang: str = "zh-cn") -> str:
     """Fetch the full content of a documentation page.
 
     Args:
@@ -116,6 +116,6 @@ async def acedata_fetch_doc(ref: str, lang: str = "zh-cn") -> str:
             }
         )
     except DocsNotFoundError:
-        return f'Document "{ref}" not found. Try acedata_search_docs to locate it.'
+        return f'Document "{ref}" not found. Try acedatacloud_search_docs to locate it.'
     except DocsError as e:
         return f"Failed to fetch doc: {e.message}"

--- a/docs/tools/example_tools.py
+++ b/docs/tools/example_tools.py
@@ -63,7 +63,7 @@ def _snippets(method: str, url: str, body: dict) -> dict[str, str]:
 
 
 @mcp.tool()
-async def acedata_get_code_example(api_path: str, lang: str = "all") -> str:
+async def acedatacloud_get_code_example(api_path: str, lang: str = "all") -> str:
     """Generate a runnable code snippet for calling an AceData Cloud API.
 
     Args:

--- a/docs/tools/meta_tools.py
+++ b/docs/tools/meta_tools.py
@@ -20,7 +20,7 @@ def _servers() -> dict:
 
 
 @mcp.tool()
-async def acedata_list_mcp_servers() -> str:
+async def acedatacloud_list_mcp_servers() -> str:
     """List AceData Cloud's other MCP servers and how to connect to them.
 
     Each entry includes the remote streamable-http URL (zero-install) and the

--- a/docs/tools/model_tools.py
+++ b/docs/tools/model_tools.py
@@ -26,7 +26,7 @@ def _catalog_items(data: object) -> list:
 
 
 @mcp.tool()
-async def acedata_list_models(modality: str = "", with_pricing: bool = True) -> str:
+async def acedatacloud_list_models(modality: str = "", with_pricing: bool = True) -> str:
     """List the LLM / image / video / music / search / embedding models AceData Cloud offers.
 
     Sourced from the full catalog (all modalities), with credit pricing and the
@@ -60,7 +60,7 @@ async def acedata_list_models(modality: str = "", with_pricing: bool = True) -> 
 
 
 @mcp.tool()
-async def acedata_get_model(model_id: str) -> str:
+async def acedatacloud_get_model(model_id: str) -> str:
     """Get full details (and pricing) for one model by id.
 
     Args:
@@ -78,13 +78,13 @@ async def acedata_get_model(model_id: str) -> str:
         for m in _models_list(chat):
             if isinstance(m, dict) and m.get("id") == model_id:
                 return _dump(m)
-        return f'Model "{model_id}" not found. Use acedata_list_models to see available ids.'
+        return f'Model "{model_id}" not found. Use acedatacloud_list_models to see available ids.'
     except DocsError as e:
         return f"Failed to get model: {e.message}"
 
 
 @mcp.tool()
-async def acedata_get_pricing(service: str = "") -> str:
+async def acedatacloud_get_pricing(service: str = "") -> str:
     """Get display pricing for a service (or all services).
 
     Args:
@@ -108,7 +108,7 @@ async def acedata_get_pricing(service: str = "") -> str:
                 }
             )
         if service and not items:
-            return f'Service "{service}" not found. Use acedata_list_services to see aliases.'
+            return f'Service "{service}" not found. Use acedatacloud_list_services to see aliases.'
         return _dump(items)
     except DocsError as e:
         return f"Failed to get pricing: {e.message}"


### PR DESCRIPTION
应需求把 docs MCP 里所有 `acedata` 标识符改名为 `acedatacloud`。

## 改了什么
- **工具名**(11 个):`acedata_*` → `acedatacloud_*`(search_docs / list_docs / fetch_doc / list_services / list_apis / get_spec / list_models / get_model / get_pricing / get_code_example / list_mcp_servers)
- **MCP prompt**:`acedata_docs_guide` → `acedatacloud_docs_guide`
- **连接器 slug**:`acedata-docs` → `acedatacloud-docs`(README 示例)
- **产品名**:"AceData Docs" → "AceDataCloud Docs"(serverInfo / README / banner)
- 版本 → `2026.6.23.4`

## 刻意保留(并核对未被误改)
- 域名 `*.acedata.cloud`(含线上 `https://docs.mcp.acedata.cloud/mcp` —— URL 不变)
- 环境变量 `ACEDATACLOUD_*`、镜像 `ghcr.io/acedatacloud/mcp-docs`、PyPI `mcp-docs`、K8s 资源名 `mcp-docs`
- 公司品牌散文 "AceData Cloud"

⚠️ BREAKING:工具名变化 → 已注册此 MCP 的客户端需改用新名;URL 不变。本仓库 = 源,镜像在 cutover 时重建部署。本地 5/5 测试通过,容器内确认 11 个 `acedatacloud_*` 工具正常注册。

## 🤖 对抗评审
Codex(read-only,实读两仓 diff)→ 修了 2 处遗漏(平台文档标题、search.py docstring),rebut 1 处(prompt 改名属用户「方法名」明确范围内)。详见配套 PlatformBackend PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)