### PR TITLE
feat(grok): expose 1080p and up-to-30s grok video

### DIFF
--- a/grok/README.md
+++ b/grok/README.md
@@ -46,8 +46,8 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 
 | Model | Text→Video | Image→Video | Notes |
 | --- | --- | --- | --- |
-| `grok-imagine-video` | ✅ | ✅ | Default. Lower price. |
-| `grok-imagine-video-1.5-preview` | ❌ | ✅ | Image-to-video only (requires `image_url`). |
+| `grok-imagine-video` | ✅ | ✅ | Default. Lower price. Up to 30s, duration-banded billing. |
+| `grok-imagine-video-1.5-preview` | ❌ | ✅ | Image-to-video only (requires `image_url`). Up to 15s, billed per second. |
 
 ## Parameters
 
@@ -57,8 +57,8 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 | `image_url` | image-to-video | Input image URL (required for `-1.5-preview`) |
 | `reference_image_urls` | image-to-video | Optional list of style/content reference images |
 | `aspect_ratio` | both | `1:1`, `16:9` (default), `9:16`, `4:3`, `3:4`, `3:2`, `2:3` |
-| `resolution` | both | `480p` (default), `720p` |
-| `duration` | both | `1`–`15` seconds (default `8`); billed per output second |
+| `resolution` | both | `480p` (default), `720p`, `1080p` |
+| `duration` | both | `grok-imagine-video`: `1`–`30`s; `grok-imagine-video-1.5-preview`: `1`–`15`s (default `8`) |
 | `callback_url` | both | Optional async webhook |
 
 ## Installation

--- a/grok/core/types.py
+++ b/grok/core/types.py
@@ -12,7 +12,7 @@ GrokVideoModel = Literal[
 AspectRatio = Literal["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
 
 # Output resolution options
-VideoResolution = Literal["480p", "720p"]
+VideoResolution = Literal["480p", "720p", "1080p"]
 
 # Default model
 DEFAULT_MODEL: GrokVideoModel = "grok-imagine-video"
@@ -23,7 +23,8 @@ DEFAULT_ASPECT_RATIO: AspectRatio = "16:9"
 # Default resolution
 DEFAULT_RESOLUTION: VideoResolution = "480p"
 
-# Default video duration (seconds); valid range 1-15
+# Default video duration (seconds); valid range 1-30 for grok-imagine-video,
+# 1-15 for grok-imagine-video-1.5-preview
 DEFAULT_DURATION: int = 8
 
 # Grok chat completion models

--- a/grok/tools/info_tools.py
+++ b/grok/tools/info_tools.py
@@ -31,8 +31,8 @@ Available Grok Imagine Video Models:
 
 | Model                            | Text2Video | Image2Video | Notes                              |
 |----------------------------------|------------|-------------|------------------------------------|
-| grok-imagine-video               | ✅         | ✅          | Default. Lower price.              |
-| grok-imagine-video-1.5-preview   | ❌         | ✅          | Image-to-video ONLY (image_url required). |
+| grok-imagine-video               | ✅         | ✅          | Default. Lower price. Up to 30s, duration-banded billing. |
+| grok-imagine-video-1.5-preview   | ❌         | ✅          | Image-to-video ONLY (image_url required). Up to 15s, billed per second. |
 
 Usage:
 - grok_chat_completions: chat/reason/vision/tool-calling with the chat models
@@ -47,10 +47,13 @@ Aspect Ratios:
 
 Resolution Options:
 - 480p: Default, cheaper
-- 720p: Higher quality, costs more credits per second
+- 720p: Higher quality
+- 1080p: Highest quality (grok-imagine-video-1.5-preview costs more per second)
 
 Duration:
-- 1-15 seconds (default 8). Billing is per output second.
+- grok-imagine-video: 1-30 seconds, billed in duration bands (1-10 / 11-20 / 21-30)
+- grok-imagine-video-1.5-preview: 1-15 seconds, billed per output second
+- Default 8 seconds
 """
 
 

--- a/grok/tools/video_tools.py
+++ b/grok/tools/video_tools.py
@@ -41,15 +41,15 @@ async def grok_text_to_video(
     resolution: Annotated[
         VideoResolution,
         Field(
-            description="Output resolution. '480p' (default, cheaper) or '720p' (higher quality, costs more credits per second)."
+            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p' (higher quality, costs more credits per second for grok-imagine-video-1.5-preview)."
         ),
     ] = DEFAULT_RESOLUTION,
     duration: Annotated[
         int,
         Field(
             ge=1,
-            le=15,
-            description="Video duration in seconds (1-15, default 8). Billing is per output second, so shorter clips cost less.",
+            le=30,
+            description="Video duration in seconds (default 8). grok-imagine-video supports 1-30; grok-imagine-video-1.5-preview supports 1-15.",
         ),
     ] = DEFAULT_DURATION,
     callback_url: Annotated[
@@ -125,15 +125,15 @@ async def grok_image_to_video(
     resolution: Annotated[
         VideoResolution,
         Field(
-            description="Output resolution. '480p' (default, cheaper) or '720p' (higher quality, costs more credits per second)."
+            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p' (higher quality, costs more credits per second for grok-imagine-video-1.5-preview)."
         ),
     ] = DEFAULT_RESOLUTION,
     duration: Annotated[
         int,
         Field(
             ge=1,
-            le=15,
-            description="Video duration in seconds (1-15, default 8). Billing is per output second.",
+            le=30,
+            description="Video duration in seconds (default 8). grok-imagine-video supports 1-30; grok-imagine-video-1.5-preview supports 1-15.",
         ),
     ] = DEFAULT_DURATION,
     callback_url: Annotated[


### PR DESCRIPTION
## What

Expose the new Grok video capabilities unlocked by the non-official TTAPI switch
(companion to AceDataCloud/PlatformService#1158).

- `VideoResolution`: add `1080p`.
- `grok_text_to_video` / `grok_image_to_video`: `duration` max 15 → 30
  (`grok-imagine-video` supports up to 30s; `grok-imagine-video-1.5-preview` stays ≤15s).
- `info_tools` + `README`: 1080p, per-model durations, banded 1.0 billing.

Public model names unchanged, so existing clients keep working.

## Tests

`pytest`: 15 passed, 3 skipped. `ruff check` / `ruff format` clean.