### PR TITLE
feat(acedatacloud): host the platform MCP at mcp.acedata.cloud

### DIFF
--- a/acedatacloud/README.md
+++ b/acedatacloud/README.md
@@ -96,7 +96,7 @@ pip install mcp-acedatacloud
 {
   "mcpServers": {
     "acedatacloud": {
-      "url": "https://acedatacloud.mcp.acedata.cloud/mcp",
+      "url": "https://mcp.acedata.cloud/mcp",
       "headers": { "Authorization": "Bearer platform-v1-xxxxxxxx" }
     }
   }


### PR DESCRIPTION
## What

Make **https://mcp.acedata.cloud/mcp** a real, hosted remote endpoint for the unified `acedatacloud` platform-management MCP — the apex `mcp.acedata.cloud` host (per-service MCPs keep their `<name>.mcp.acedata.cloud` prefix).

This started as the one-line docs/endpoint rename and now also wires up the hosting + publishing infra the folder was missing (it had no `deploy/`, no `server.json`, no `.github/workflows`), mirroring the deployed `shorturl` MCP.

## Changes

**Docs**
- `README.md` — `mcpServers.acedatacloud.url` → `https://mcp.acedata.cloud/mcp`

**Hosting (synced to `AceDataCloud/AceDataCloudMCP`, where these workflows run)**
- `deploy/production/deployment.yaml` — `mcp-acedatacloud`, image `ghcr.io/acedatacloud/mcp-acedatacloud`, `/health` probes on 8000
- `deploy/production/service.yaml` — ClusterIP :8000
- `deploy/production/ingress.yaml` — host `mcp.acedata.cloud`, `ingressClassName: nginx-router`, TLS `tls-wildcard-acedata-cloud`
- `deploy/run.sh` — `kubectl apply` of the three manifests
- `docker-compose.yaml` — image build for the deploy workflow
- `.github/workflows/deploy.yaml` — build → push to GHCR → `kubectl apply` (same as siblings)
- `.github/workflows/publish.yml` — date-based version → PyPI (`mcp-acedatacloud`) → GitHub Release → MCP Registry

**Registry**
- `server.json` — remote `https://mcp.acedata.cloud/mcp`, stdio pkg `mcp-acedatacloud`
- `smithery.yaml`, `glama.json`

## Verification

- TLS: live `tls-wildcard-acedata-cloud` cert SANs include `*.acedata.cloud`, which **covers the one-level `mcp.acedata.cloud`** (confirmed via `openssl s_client` against a live sibling).
- `main.py` HTTP mode serves `/health` + `/mcp` on `0.0.0.0:8000` with per-request bearer tokens (hosted multi-tenant) — matches the probes/ingress.
- All new JSON/YAML parse cleanly; package lint/test/build unaffected (no code change).

## Operational follow-ups (outside this repo)

1. **DNS** — already covered. DNSPod has a `*` CNAME → `lb-b6jjm97w-…clb.ap-hongkong.tencentclb.com` (the HK shared `nginx-router` CLB) and **no records under `mcp`**, so `mcp.acedata.cloud` resolves to that CLB via the wildcard (same path the live `suno.mcp.acedata.cloud` already uses). No DNS change required.
2. **Secrets** — the sub-repo deploy/publish need org-level `KUBE_CONFIG` / `PYPI_TOKEN` (same as `ShortURLMCP`, which has no per-repo secrets). If the org secrets are "selected repositories" scoped, an admin must add `AceDataCloudMCP`.

## 🤖 对抗评审

Self-review (Codex unavailable in this environment). Findings:
- **RISK (TLS apex coverage)** — `mcp.acedata.cloud` is one level under `acedata.cloud`, not covered by `*.mcp.acedata.cloud`. **Resolved**: live cert SAN list contains `*.acedata.cloud`, so the apex host is covered by the existing `tls-wildcard-acedata-cloud` secret.
- **RISK (DNS apex)** — would the apex `mcp` resolve? **Resolved**: DNSPod `*` CNAME → HK shared CLB and there are no child records under `mcp`, so the wildcard covers `mcp.acedata.cloud` (verified against the authoritative DNSPod zone; same mechanism the live `suno.mcp` uses). No DNS change needed.
- **RISK (sub-repo secrets)** — deploy/publish depend on org secrets. **Acknowledged**: mirrors the proven `ShortURLMCP` setup; flagged for admin verification.
- IDE-extension publish jobs (`vscode`/`jetbrains`) intentionally dropped — no such scaffolding for this server.

VERDICT: CLEAN after resolution — config mirrors the deployed `shorturl` MCP; the only non-repo dependencies (DNS, org secrets) are called out explicitly.
