### PR TITLE
feat(acedatacloud): host the platform MCP at mcp.acedata.cloud (deploy + registry)

### DIFF
--- a/acedatacloud/.github/workflows/deploy.yaml
+++ b/acedatacloud/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/ISSUE_TEMPLATE/**"
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Build Number
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.github_token }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+
+      - name: Get Build Number
+        run: |
+          echo $BUILD_NUMBER
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Build Docker images
+        run: docker-compose build
+
+      - name: Push Docker images
+        run: docker-compose push
+
+      - name: Deploy
+        run: sh ./deploy/run.sh

--- a/acedatacloud/.github/workflows/publish.yml
+++ b/acedatacloud/.github/workflows/publish.yml
@@ -1,0 +1,172 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          # 版本格式: YYYY.MM.DD.BUILD
+          # BUILD 是当天的构建序号，从 PyPI 获取已发布版本来确定
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+
+          # 获取当天已发布的最高版本号
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          import re
+          try:
+              resp = requests.get('https://pypi.org/pypi/mcp-acedatacloud/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+          cat pyproject.toml | grep -m1 "version"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-acedatacloud/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0,<6.1"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.build.outputs.version }}" dist/* \
+            --title "v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/acedatacloud/deploy/production/deployment.yaml
+++ b/acedatacloud/deploy/production/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mcp-acedatacloud
+  name: mcp-acedatacloud
+  namespace: acedatacloud
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: mcp-acedatacloud
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: mcp-acedatacloud
+    spec:
+      containers:
+        - name: mcp-acedatacloud
+          image: ghcr.io/acedatacloud/mcp-acedatacloud:${TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 30m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/acedatacloud/deploy/production/ingress.yaml
+++ b/acedatacloud/deploy/production/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-acedatacloud
+  namespace: acedatacloud
+  labels:
+    app: mcp-acedatacloud
+  annotations:
+    kubernetes.io/ingress.class: "nginx-router"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+spec:
+  ingressClassName: nginx-router
+  tls:
+    - hosts:
+        - mcp.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: mcp.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-acedatacloud
+                port:
+                  number: 8000

--- a/acedatacloud/deploy/production/service.yaml
+++ b/acedatacloud/deploy/production/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mcp-acedatacloud
+  name: mcp-acedatacloud
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: mcp-acedatacloud

--- a/acedatacloud/deploy/run.sh
+++ b/acedatacloud/deploy/run.sh
@@ -1,0 +1,3 @@
+cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/service.yaml || true
+kubectl apply -f deploy/production/ingress.yaml || true

--- a/acedatacloud/docker-compose.yaml
+++ b/acedatacloud/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  mcp-acedatacloud:
+    platform: linux/amd64
+    container_name: "mcp-acedatacloud"
+    build: ./
+    image: "ghcr.io/acedatacloud/mcp-acedatacloud:${BUILD_NUMBER}"
+    ports:
+      - "8000:8000"

--- a/acedatacloud/glama.json
+++ b/acedatacloud/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "Germey"
+  ]
+}

--- a/acedatacloud/server.json
+++ b/acedatacloud/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.AceDataCloud/mcp-acedatacloud",
+  "description": "MCP server for managing your AceData Cloud account — services, pricing, APIs, docs, models, balance, usage, API keys, orders & announcements",
+  "version": "2026.6.28.0",
+  "repository": {
+    "url": "https://github.com/AceDataCloud/AceDataCloudMCP",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "identifier": "mcp-acedatacloud",
+      "version": "2026.6.28.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "registryType": "pypi",
+      "runtimeHint": "uvx",
+      "environmentVariables": [
+        {
+          "name": "ACEDATACLOUD_PLATFORM_TOKEN",
+          "description": "Platform token from Ace Data Cloud (https://platform.acedata.cloud/console/platform-tokens)",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
+  "websiteUrl": "https://mcp.acedata.cloud",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.acedata.cloud/mcp"
+    }
+  ]
+}

--- a/acedatacloud/smithery.yaml
+++ b/acedatacloud/smithery.yaml
@@ -1,0 +1,23 @@
+# Smithery configuration file: https://smithery.ai/docs/build/publish
+# Defines how this MCP server is built and configured on Smithery
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      ACEDATACLOUD_PLATFORM_TOKEN:
+        type: string
+        description: "Platform token from Ace Data Cloud (https://platform.acedata.cloud/console/platform-tokens)"
+    required:
+      - ACEDATACLOUD_PLATFORM_TOKEN
+  commandFunction:
+    # Installs from PyPI and runs via uvx
+    - |-
+      (config) => ({
+        command: 'uvx',
+        args: ['mcp-acedatacloud'],
+        env: {
+          ACEDATACLOUD_PLATFORM_TOKEN: config.ACEDATACLOUD_PLATFORM_TOKEN
+        }
+      })


### PR DESCRIPTION
## What

Make **https://mcp.acedata.cloud/mcp** a real, hosted remote endpoint for the unified `acedatacloud` platform-management MCP — the apex `mcp.acedata.cloud` host (per-service MCPs keep their `<name>.mcp.acedata.cloud` prefix).

This started as the one-line docs/endpoint rename and now also wires up the hosting + publishing infra the folder was missing (it had no `deploy/`, no `server.json`, no `.github/workflows`), mirroring the deployed `shorturl` MCP.

## Changes

**Docs**
- `README.md` — `mcpServers.acedatacloud.url` → `https://mcp.acedata.cloud/mcp`

**Hosting (synced to `AceDataCloud/AceDataCloudMCP`, where these workflows run)**
- `deploy/production/deployment.yaml` — `mcp-acedatacloud`, image `ghcr.io/acedatacloud/mcp-acedatacloud`, `/health` probes on 8000
- `deploy/production/service.yaml` — ClusterIP :8000
- `deploy/production/ingress.yaml` — host `mcp.acedata.cloud`, `ingressClassName: nginx-router`, TLS `tls-wildcard-acedata-cloud`
- `deploy/run.sh` — `kubectl apply` of the three manifests
- `docker-compose.yaml` — image build for the deploy workflow
- `.github/workflows/deploy.yaml` — build → push to GHCR → `kubectl apply` (same as siblings)
- `.github/workflows/publish.yml` — date-based version → PyPI (`mcp-acedatacloud`) → GitHub Release → MCP Registry

**Registry**
- `server.json` — remote `https://mcp.acedata.cloud/mcp`, stdio pkg `mcp-acedatacloud`
- `smithery.yaml`, `glama.json`

## Verification

- TLS: live `tls-wildcard-acedata-cloud` cert SANs include `*.acedata.cloud`, which **covers the one-level `mcp.acedata.cloud`** (confirmed via `openssl s_client` against a live sibling).
- `main.py` HTTP mode serves `/health` + `/mcp` on `0.0.0.0:8000` with per-request bearer tokens (hosted multi-tenant) — matches the probes/ingress.
- All new JSON/YAML parse cleanly; package lint/test/build unaffected (no code change).

## Operational follow-ups (outside this repo)

1. **DNS** — already covered. DNSPod has a `*` CNAME → `lb-b6jjm97w-…clb.ap-hongkong.tencentclb.com` (the HK shared `nginx-router` CLB) and **no records under `mcp`**, so `mcp.acedata.cloud` resolves to that CLB via the wildcard (same path the live `suno.mcp.acedata.cloud` already uses). No DNS change required.
2. **Secrets** — the sub-repo deploy/publish need org-level `KUBE_CONFIG` / `PYPI_TOKEN` (same as `ShortURLMCP`, which has no per-repo secrets). If the org secrets are "selected repositories" scoped, an admin must add `AceDataCloudMCP`.

## 🤖 对抗评审

Self-review (Codex unavailable in this environment). Findings:
- **RISK (TLS apex coverage)** — `mcp.acedata.cloud` is one level under `acedata.cloud`, not covered by `*.mcp.acedata.cloud`. **Resolved**: live cert SAN list contains `*.acedata.cloud`, so the apex host is covered by the existing `tls-wildcard-acedata-cloud` secret.
- **RISK (DNS apex)** — would the apex `mcp` resolve? **Resolved**: DNSPod `*` CNAME → HK shared CLB and there are no child records under `mcp`, so the wildcard covers `mcp.acedata.cloud` (verified against the authoritative DNSPod zone; same mechanism the live `suno.mcp` uses). No DNS change needed.
- **RISK (sub-repo secrets)** — deploy/publish depend on org secrets. **Acknowledged**: mirrors the proven `ShortURLMCP` setup; flagged for admin verification.
- IDE-extension publish jobs (`vscode`/`jetbrains`) intentionally dropped — no such scaffolding for this server.

VERDICT: CLEAN after resolution — config mirrors the deployed `shorturl` MCP; the only non-repo dependencies (DNS, org secrets) are called out explicitly.
