### PR TITLE
refactor(acedatacloud): prefix MCP tools/prompt with acedatacloud_

### DIFF
--- a/acedatacloud/CHANGELOG.md
+++ b/acedatacloud/CHANGELOG.md
@@ -10,16 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of the AceDataCloud Platform management MCP server.
-- Read tools: `platform_get_balance`, `platform_list_applications`,
-  `platform_list_services`, `platform_list_usage`, `platform_usage_summary`,
-  `platform_list_credentials`, `platform_list_orders`,
-  `platform_list_platform_tokens`, `platform_list_models`,
-  `platform_list_announcements`.
-- Write tools (gated by `confirm=true`): `platform_create_credential`,
-  `platform_delete_credential`, `platform_create_order`, `platform_pay_order`,
-  `platform_create_platform_token`, `platform_delete_platform_token`.
-- Admin tool (superuser): `platform_create_announcement`.
-- Informational tool `platform_get_usage_guide` and the `platform_guide` prompt.
+- Read tools: `acedatacloud_get_balance`, `acedatacloud_list_applications`,
+  `acedatacloud_list_services`, `acedatacloud_list_usage`, `acedatacloud_usage_summary`,
+  `acedatacloud_list_credentials`, `acedatacloud_list_orders`,
+  `acedatacloud_list_platform_tokens`, `acedatacloud_list_models`,
+  `acedatacloud_list_announcements`.
+- Write tools (gated by `confirm=true`): `acedatacloud_create_credential`,
+  `acedatacloud_delete_credential`, `acedatacloud_create_order`, `acedatacloud_pay_order`,
+  `acedatacloud_create_platform_token`, `acedatacloud_delete_platform_token`.
+- Admin tool (superuser): `acedatacloud_create_announcement`.
+- Informational tool `acedatacloud_get_usage_guide` and the `acedatacloud_guide` prompt.
 - Secret masking for token/password fields in read output.
 - Bearer-token authentication; stdio and HTTP transport modes.
 - Docker support.

--- a/acedatacloud/README.md
+++ b/acedatacloud/README.md
@@ -26,33 +26,33 @@ MCP-compatible client.
 
 | Tool | Description |
 |------|-------------|
-| `platform_get_balance` | Remaining credits per subscription, plus a total. |
-| `platform_list_applications` | Your subscriptions with balance/spend. |
-| `platform_list_services` | List or search available services. |
-| `platform_list_usage` | Recent API call records (status, latency, credits). |
-| `platform_usage_summary` | Spend aggregated by API over N days. |
-| `platform_list_credentials` | Your API keys (token values masked). |
-| `platform_list_orders` | Recharge orders. |
-| `platform_list_platform_tokens` | Platform tokens (masked). |
-| `platform_list_models` | Available chat models. |
-| `platform_list_announcements` | Published announcements. |
+| `acedatacloud_get_balance` | Remaining credits per subscription, plus a total. |
+| `acedatacloud_list_applications` | Your subscriptions with balance/spend. |
+| `acedatacloud_list_services` | List or search available services. |
+| `acedatacloud_list_usage` | Recent API call records (status, latency, credits). |
+| `acedatacloud_usage_summary` | Spend aggregated by API over N days. |
+| `acedatacloud_list_credentials` | Your API keys (token values masked). |
+| `acedatacloud_list_orders` | Recharge orders. |
+| `acedatacloud_list_platform_tokens` | Platform tokens (masked). |
+| `acedatacloud_list_models` | Available chat models. |
+| `acedatacloud_list_announcements` | Published announcements. |
 
 ### Write (require `confirm=true`)
 
 | Tool | Description |
 |------|-------------|
-| `platform_create_credential` | Create an API key on an application. |
-| `platform_delete_credential` | Revoke an API key. |
-| `platform_create_order` | Create a recharge order. |
-| `platform_pay_order` | Create a payment session and return `pay_url`. |
-| `platform_create_platform_token` | Create a new platform token. |
-| `platform_delete_platform_token` | Revoke a platform token. |
+| `acedatacloud_create_credential` | Create an API key on an application. |
+| `acedatacloud_delete_credential` | Revoke an API key. |
+| `acedatacloud_create_order` | Create a recharge order. |
+| `acedatacloud_pay_order` | Create a payment session and return `pay_url`. |
+| `acedatacloud_create_platform_token` | Create a new platform token. |
+| `acedatacloud_delete_platform_token` | Revoke a platform token. |
 
 ### Admin (superuser token)
 
 | Tool | Description |
 |------|-------------|
-| `platform_create_announcement` | Publish a platform announcement (`confirm=true`). |
+| `acedatacloud_create_announcement` | Publish a platform announcement (`confirm=true`). |
 
 Calling a write/admin tool **without** `confirm=true` returns a dry-run preview
 and changes nothing.

--- a/acedatacloud/prompts/__init__.py
+++ b/acedatacloud/prompts/__init__.py
@@ -7,7 +7,7 @@ from core.server import mcp
 
 
 @mcp.prompt()
-def platform_guide() -> str:
+def acedatacloud_guide() -> str:
     """Guide for managing an AceDataCloud account via the platform tools."""
     return """# AceDataCloud Platform Management Guide
 
@@ -16,28 +16,28 @@ console API. Authentication is a **platform token** (ACEDATACLOUD_PLATFORM_TOKEN
 distinct from the api.acedata.cloud service token.
 
 ## Checking money / usage (read, always safe)
-- "How much balance / credits do I have?" → `platform_get_balance`
-- "Show my subscriptions" → `platform_list_applications`
-- "What did I spend this month?" → `platform_usage_summary` (days=30)
-- "Show my recent API calls / errors" → `platform_list_usage` (status_code to filter)
-- "List my orders" → `platform_list_orders`
+- "How much balance / credits do I have?" → `acedatacloud_get_balance`
+- "Show my subscriptions" → `acedatacloud_list_applications`
+- "What did I spend this month?" → `acedatacloud_usage_summary` (days=30)
+- "Show my recent API calls / errors" → `acedatacloud_list_usage` (status_code to filter)
+- "List my orders" → `acedatacloud_list_orders`
 
 ## Keys, services, models (read)
-- "List / find a service" → `platform_list_services` (search=...)
-- "Show my API keys" → `platform_list_credentials`
-- "Which models are available?" → `platform_list_models`
+- "List / find a service" → `acedatacloud_list_services` (search=...)
+- "Show my API keys" → `acedatacloud_list_credentials`
+- "Which models are available?" → `acedatacloud_list_models`
 
 ## Making changes (write — ALWAYS confirm with the user first)
 Write tools do nothing unless called with confirm=true; without it they return a
 preview. Always show the user the preview and get explicit approval before
 re-calling with confirm=true.
-- Create an API key → `platform_create_credential` (needs an application_id)
-- Revoke a key → `platform_delete_credential`
-- Top up: `platform_create_order` then `platform_pay_order` → give the user pay_url
-- Manage platform tokens → `platform_create_platform_token` / `platform_delete_platform_token`
+- Create an API key → `acedatacloud_create_credential` (needs an application_id)
+- Revoke a key → `acedatacloud_delete_credential`
+- Top up: `acedatacloud_create_order` then `acedatacloud_pay_order` → give the user pay_url
+- Manage platform tokens → `acedatacloud_create_platform_token` / `acedatacloud_delete_platform_token`
 
 ## Admin (superuser token only)
-- Publish an announcement → `platform_create_announcement` (confirm=true)
+- Publish an announcement → `acedatacloud_create_announcement` (confirm=true)
 
 ## Rules
 - Never print a full token value back to the user in a shared context.

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -6,9 +6,9 @@ import httpx
 import pytest
 import respx
 
-from tools.admin_tools import platform_create_announcement
-from tools.read_tools import platform_get_balance, platform_list_services
-from tools.write_tools import platform_create_credential, platform_delete_credential
+from tools.admin_tools import acedatacloud_create_announcement
+from tools.read_tools import acedatacloud_get_balance, acedatacloud_list_services
+from tools.write_tools import acedatacloud_create_credential, acedatacloud_delete_credential
 
 API = "https://platform.acedata.cloud/api/v1"
 
@@ -17,7 +17,7 @@ API = "https://platform.acedata.cloud/api/v1"
 @pytest.mark.asyncio
 async def test_list_services_filters_by_search(mock_services_page):
     respx.get(f"{API}/services/").mock(return_value=httpx.Response(200, json=mock_services_page))
-    out = json.loads(await platform_list_services(search="suno"))
+    out = json.loads(await acedatacloud_list_services(search="suno"))
     assert out["count"] == 1
     assert out["items"][0]["alias"] == "suno"
 
@@ -28,7 +28,7 @@ async def test_get_balance_summarizes(mock_applications_page):
     respx.get(f"{API}/applications/").mock(
         return_value=httpx.Response(200, json=mock_applications_page)
     )
-    out = json.loads(await platform_get_balance())
+    out = json.loads(await acedatacloud_get_balance())
     assert out["total_remaining"] == 100.5
     assert out["unit"] == "Credit"
     assert out["applications"][0]["service_id"] == "svc-1"
@@ -42,7 +42,7 @@ async def test_create_credential_confirm_gate_no_http():
     route = respx.post(f"{API}/credentials/").mock(
         return_value=httpx.Response(201, json={"id": "x"})
     )
-    out = json.loads(await platform_create_credential(application_id="app-1", name="ci"))
+    out = json.loads(await acedatacloud_create_credential(application_id="app-1", name="ci"))
     assert out["status"] == "confirmation_required"
     assert out["action"] == "POST /credentials/"
     assert out["target"]["application_id"] == "app-1"
@@ -54,20 +54,20 @@ async def test_create_credential_confirm_gate_no_http():
 @pytest.mark.asyncio
 async def test_create_credential_confirmed_reveals_token(mock_credential):
     respx.post(f"{API}/credentials/").mock(return_value=httpx.Response(201, json=mock_credential))
-    out = json.loads(await platform_create_credential(application_id="app-1", confirm=True))
+    out = json.loads(await acedatacloud_create_credential(application_id="app-1", confirm=True))
     # Freshly minted token must be returned in full so the caller can store it.
     assert out["token"] == mock_credential["token"]
 
 
 @pytest.mark.asyncio
 async def test_delete_credential_confirm_gate():
-    out = json.loads(await platform_delete_credential(credential_id="cred-1"))
+    out = json.loads(await acedatacloud_delete_credential(credential_id="cred-1"))
     assert out["status"] == "confirmation_required"
     assert out["target"]["id"] == "cred-1"
 
 
 @pytest.mark.asyncio
 async def test_create_announcement_confirm_gate():
-    out = json.loads(await platform_create_announcement(title="T", content="C"))
+    out = json.loads(await acedatacloud_create_announcement(title="T", content="C"))
     assert out["status"] == "confirmation_required"
     assert "superuser" in out["action"]

--- a/acedatacloud/tools/admin_tools.py
+++ b/acedatacloud/tools/admin_tools.py
@@ -15,7 +15,7 @@ from core.utils import confirmation_required, dumps, error_json
 
 
 @mcp.tool()
-async def platform_create_announcement(
+async def acedatacloud_create_announcement(
     title: Annotated[str, Field(description="Announcement title. Required.")],
     content: Annotated[str, Field(description="Announcement body in Markdown. Required.")],
     rank: Annotated[

--- a/acedatacloud/tools/info_tools.py
+++ b/acedatacloud/tools/info_tools.py
@@ -4,7 +4,7 @@ from core.server import mcp
 
 
 @mcp.tool()
-async def platform_get_usage_guide() -> str:
+async def acedatacloud_get_usage_guide() -> str:
     """Get a guide for using the AceDataCloud platform management tools.
 
     Explains the available tools, the write-confirmation model, and the
@@ -19,25 +19,25 @@ ACEDATACLOUD_PLATFORM_TOKEN — NOT the api.acedata.cloud service token.
 Create one at https://platform.acedata.cloud/console/platform-tokens
 
 ## Read tools (safe)
-- platform_get_balance — remaining credits per subscription (+ total)
-- platform_list_applications — your subscriptions and balances
-- platform_list_services — list/search available services
-- platform_list_usage — recent API call records
-- platform_usage_summary — spend aggregated by API over N days
-- platform_list_credentials — your API keys (tokens masked)
-- platform_list_orders — recharge orders
-- platform_list_platform_tokens — platform tokens (masked)
-- platform_list_models — available chat models
-- platform_list_announcements — published announcements
+- acedatacloud_get_balance — remaining credits per subscription (+ total)
+- acedatacloud_list_applications — your subscriptions and balances
+- acedatacloud_list_services — list/search available services
+- acedatacloud_list_usage — recent API call records
+- acedatacloud_usage_summary — spend aggregated by API over N days
+- acedatacloud_list_credentials — your API keys (tokens masked)
+- acedatacloud_list_orders — recharge orders
+- acedatacloud_list_platform_tokens — platform tokens (masked)
+- acedatacloud_list_models — available chat models
+- acedatacloud_list_announcements — published announcements
 
 ## Write tools — require confirm=true
 Calling them without confirm returns a dry-run preview and does nothing.
-- platform_create_credential / platform_delete_credential
-- platform_create_order then platform_pay_order (returns pay_url)
-- platform_create_platform_token / platform_delete_platform_token
+- acedatacloud_create_credential / acedatacloud_delete_credential
+- acedatacloud_create_order then acedatacloud_pay_order (returns pay_url)
+- acedatacloud_create_platform_token / acedatacloud_delete_platform_token
 
 ## Admin tools — superuser token + confirm=true
-- platform_create_announcement
+- acedatacloud_create_announcement
 
 ## Notes
 - Amounts (remaining_amount, used_amount, total) are in Credits, not USD.

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -26,7 +26,7 @@ def _wrap(result: object, reveal: bool = False) -> str:
 
 
 @mcp.tool()
-async def platform_list_services(
+async def acedatacloud_list_services(
     search: Annotated[
         str | None,
         Field(
@@ -62,7 +62,7 @@ async def platform_list_services(
 
 
 @mcp.tool()
-async def platform_list_applications(
+async def acedatacloud_list_applications(
     service_id: Annotated[str | None, Field(description="Filter by service UUID.")] = None,
     scope: Annotated[
         str | None, Field(description="Filter by scope: 'Individual' or 'Global'.")
@@ -84,7 +84,7 @@ async def platform_list_applications(
 
 
 @mcp.tool()
-async def platform_get_balance(
+async def acedatacloud_get_balance(
     service_id: Annotated[
         str | None, Field(description="Optional service UUID to filter by.")
     ] = None,
@@ -116,7 +116,7 @@ async def platform_get_balance(
 
 
 @mcp.tool()
-async def platform_list_usage(
+async def acedatacloud_list_usage(
     api_id: Annotated[str | None, Field(description="Filter by API UUID.")] = None,
     status_code: Annotated[
         int | None, Field(description="Filter by HTTP status code, e.g. 200.")
@@ -145,7 +145,7 @@ async def platform_list_usage(
 
 
 @mcp.tool()
-async def platform_usage_summary(
+async def acedatacloud_usage_summary(
     days: Annotated[
         int, Field(description="Aggregate spend over the last N days.", ge=1, le=365)
     ] = 30,
@@ -177,7 +177,7 @@ async def platform_usage_summary(
 
 
 @mcp.tool()
-async def platform_list_credentials(
+async def acedatacloud_list_credentials(
     application_id: Annotated[str | None, Field(description="Filter by application UUID.")] = None,
     limit: Annotated[int, Field(description="Max credentials to return.", ge=1, le=100)] = 50,
 ) -> str:
@@ -194,7 +194,7 @@ async def platform_list_credentials(
 
 
 @mcp.tool()
-async def platform_list_orders(
+async def acedatacloud_list_orders(
     state: Annotated[
         str | None,
         Field(description="Filter by state: Pending/Paid/Finished/Expired/Failed/Refunded."),
@@ -216,7 +216,7 @@ async def platform_list_orders(
 
 
 @mcp.tool()
-async def platform_list_platform_tokens(
+async def acedatacloud_list_platform_tokens(
     limit: Annotated[int, Field(description="Max tokens to return.", ge=1, le=100)] = 50,
 ) -> str:
     """List your platform tokens (the credentials used to call this management API). Masked."""
@@ -230,7 +230,7 @@ async def platform_list_platform_tokens(
 
 
 @mcp.tool()
-async def platform_list_models() -> str:
+async def acedatacloud_list_models() -> str:
     """List the chat-completion models available on the platform (OpenAI-style)."""
     try:
         result = await client.get("/models/")
@@ -242,7 +242,7 @@ async def platform_list_models() -> str:
 
 
 @mcp.tool()
-async def platform_list_announcements(
+async def acedatacloud_list_announcements(
     limit: Annotated[int, Field(description="Max announcements to return.", ge=1, le=100)] = 20,
 ) -> str:
     """List published platform announcements (newest first)."""

--- a/acedatacloud/tools/write_tools.py
+++ b/acedatacloud/tools/write_tools.py
@@ -15,7 +15,7 @@ from core.utils import confirmation_required, dumps, error_json
 
 
 @mcp.tool()
-async def platform_create_credential(
+async def acedatacloud_create_credential(
     application_id: Annotated[
         str,
         Field(description="UUID of the application (subscription) to attach the key to. Required."),
@@ -56,7 +56,7 @@ async def platform_create_credential(
 
 
 @mcp.tool()
-async def platform_delete_credential(
+async def acedatacloud_delete_credential(
     credential_id: Annotated[str, Field(description="UUID of the credential to delete. Required.")],
     confirm: Annotated[bool, Field(description="Must be true to actually delete the key.")] = False,
 ) -> str:
@@ -76,7 +76,7 @@ async def platform_delete_credential(
 
 
 @mcp.tool()
-async def platform_create_order(
+async def acedatacloud_create_order(
     application_id: Annotated[
         str, Field(description="UUID of the application to recharge. Required.")
     ],
@@ -89,7 +89,7 @@ async def platform_create_order(
 ) -> str:
     """Create a recharge order for an application. Requires ``confirm=true``.
 
-    Returns the order (with its ``id``); call ``platform_pay_order`` next to get a
+    Returns the order (with its ``id``); call ``acedatacloud_pay_order`` next to get a
     payment link.
     """
     body = {"application_id": application_id, "package_id": package_id}
@@ -105,7 +105,7 @@ async def platform_create_order(
 
 
 @mcp.tool()
-async def platform_pay_order(
+async def acedatacloud_pay_order(
     order_id: Annotated[str, Field(description="UUID of the order to pay. Required.")],
     pay_way: Annotated[
         str, Field(description="Payment method: WechatPay/AliPay/Stripe/X402/PayPal/Reward.")
@@ -133,7 +133,7 @@ async def platform_pay_order(
 
 
 @mcp.tool()
-async def platform_create_platform_token(
+async def acedatacloud_create_platform_token(
     confirm: Annotated[
         bool, Field(description="Must be true to actually create the token.")
     ] = False,
@@ -154,7 +154,7 @@ async def platform_create_platform_token(
 
 
 @mcp.tool()
-async def platform_delete_platform_token(
+async def acedatacloud_delete_platform_token(
     token_id: Annotated[str, Field(description="UUID of the platform token to delete. Required.")],
     confirm: Annotated[
         bool, Field(description="Must be true to actually delete the token.")


### PR DESCRIPTION
## What

Rename every client-exposed identifier in the `acedatacloud` MCP from the `platform_` prefix to **`acedatacloud_`**, matching the server/package name. No behavior change — pure rename.

## Renamed

**Tools (18):**

| Before | After |
|---|---|
| `platform_list_services` | `acedatacloud_list_services` |
| `platform_list_applications` | `acedatacloud_list_applications` |
| `platform_get_balance` | `acedatacloud_get_balance` |
| `platform_list_usage` | `acedatacloud_list_usage` |
| `platform_usage_summary` | `acedatacloud_usage_summary` |
| `platform_list_credentials` | `acedatacloud_list_credentials` |
| `platform_list_orders` | `acedatacloud_list_orders` |
| `platform_list_platform_tokens` | `acedatacloud_list_platform_tokens` |
| `platform_list_models` | `acedatacloud_list_models` |
| `platform_list_announcements` | `acedatacloud_list_announcements` |
| `platform_create_credential` | `acedatacloud_create_credential` |
| `platform_delete_credential` | `acedatacloud_delete_credential` |
| `platform_create_order` | `acedatacloud_create_order` |
| `platform_pay_order` | `acedatacloud_pay_order` |
| `platform_create_platform_token` | `acedatacloud_create_platform_token` |
| `platform_delete_platform_token` | `acedatacloud_delete_platform_token` |
| `platform_create_announcement` | `acedatacloud_create_announcement` |
| `platform_get_usage_guide` | `acedatacloud_get_usage_guide` |

**Prompt:** `platform_guide` → `acedatacloud_guide`

## Notes

- Only the **prefix** changed. The `platform_token` *entity* inside `acedatacloud_list_platform_tokens` / `acedatacloud_create_platform_token` / `acedatacloud_delete_platform_token` is preserved.
- Config/entity strings are untouched: `ACEDATACLOUD_PLATFORM_TOKEN`, `PLATFORM_API_BASE_URL`, the `/platform-tokens/` route, `PlatformAPIError`, `PlatformAuthError`.
- Docs, prompt guidance, usage-guide text, README tables, CHANGELOG, and tests updated to match.

## Verification

- `ruff check .` → clean
- `mypy tools core main.py` → no issues (12 files)
- `pytest` → 24 passed
- `git diff --stat` → 83 insertions / 83 deletions (symmetric, rename-only)

## 🤖 对抗评审

VERDICT: CLEAN — mechanical identifier rename verified by lint + types + full test suite; entity/config strings explicitly preserved (no `platform_token` over-replacement).
