### PR TITLE
feat(acedatacloud): add catalog/docs/model tools + distributions (complete the MCP)

### DIFF
--- a/acedatacloud/CHANGELOG.md
+++ b/acedatacloud/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-06-28
+
+### Added
+
+- Public **catalog** tools (no token needed): `acedatacloud_get_service`,
+  `acedatacloud_get_pricing`, `acedatacloud_list_apis`, `acedatacloud_get_api_spec`,
+  `acedatacloud_list_datasets`, `acedatacloud_list_integrations`.
+- Public **docs** tools: `acedatacloud_search_docs`, `acedatacloud_list_docs`,
+  `acedatacloud_get_doc`.
+- Public **model catalog** tools: `acedatacloud_list_model_catalog`, `acedatacloud_get_model`.
+- Account tool: `acedatacloud_list_distributions` (referral status + commission history).
+- Client now supports a public (no-token) request path via `get_public`; catalog/docs/model
+  tools work with or without a platform token.
+
+### Notes
+
+- Catalog/docs lookups use list+filter (`services/?id=`, `apis/?path=`, `documents/?id=`)
+  because the platform's detail routes are unreliable; `apis`/`services` collection filters
+  that are ignored server-side are applied client-side.
+
 ## [0.1.0] - 2026-06-28
 
 ### Added

--- a/acedatacloud/README.md
+++ b/acedatacloud/README.md
@@ -36,6 +36,23 @@ MCP-compatible client.
 | `acedatacloud_list_platform_tokens` | Platform tokens (masked). |
 | `acedatacloud_list_models` | Available chat models. |
 | `acedatacloud_list_announcements` | Published announcements. |
+| `acedatacloud_list_distributions` | Your referral/affiliate status + commission history. |
+
+### Catalog & Docs (public — no token needed)
+
+| Tool | Description |
+|------|-------------|
+| `acedatacloud_get_service` | One service's detail (type, unit, free_amount, cost), by alias or id. |
+| `acedatacloud_get_pricing` | A service's billing unit, free_amount and display pricing. |
+| `acedatacloud_list_apis` | API endpoints, optionally scoped to one service (path, method, cost). |
+| `acedatacloud_get_api_spec` | One API's OpenAPI `definition` + cost, by path. |
+| `acedatacloud_list_datasets` | Downloadable datasets (price, download/preview URLs). |
+| `acedatacloud_list_integrations` | Third-party integrations. |
+| `acedatacloud_search_docs` | Full-text search the documentation (alias/title/snippet/url). |
+| `acedatacloud_list_docs` | Browse documentation pages. |
+| `acedatacloud_get_doc` | Fetch one doc's full content by UUID. |
+| `acedatacloud_list_model_catalog` | Rich model catalog (provider, modality, credit pricing). |
+| `acedatacloud_get_model` | Look up a model's pricing & capabilities by id/name. |
 
 ### Write (require `confirm=true`)
 

--- a/acedatacloud/core/client.py
+++ b/acedatacloud/core/client.py
@@ -45,16 +45,18 @@ class PlatformClient:
         logger.info(f"PlatformClient initialized with base_url: {self.base_url}")
         logger.debug(f"Platform token configured: {'Yes' if self.api_token else 'No'}")
 
-    def _get_headers(self) -> dict[str, str]:
-        token = get_request_api_token() or self.api_token
-        if not token:
-            logger.error("Platform token not configured!")
-            raise PlatformAuthError("Platform token not configured")
-        return {
+    def _get_headers(self, auth_required: bool = True) -> dict[str, str]:
+        headers = {
             "accept": "application/json",
-            "authorization": f"Bearer {token}",
             "content-type": "application/json",
         }
+        token = get_request_api_token() or self.api_token
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        elif auth_required:
+            logger.error("Platform token not configured!")
+            raise PlatformAuthError("Platform token not configured")
+        return headers
 
     def _handle_error_response(self, response: httpx.Response) -> None:
         """Parse an API error response and raise the appropriate exception."""
@@ -89,6 +91,7 @@ class PlatformClient:
         params: dict[str, Any] | None = None,
         json_body: dict[str, Any] | None = None,
         timeout: float | None = None,
+        auth_required: bool = True,
     ) -> Any:
         """Make a request to ``/api/v1{endpoint}`` and return parsed JSON.
 
@@ -109,7 +112,7 @@ class PlatformClient:
                     url,
                     params=clean_params or None,
                     json=json_body,
-                    headers=self._get_headers(),
+                    headers=self._get_headers(auth_required),
                     timeout=request_timeout,
                 )
                 logger.info(f"Response status: {response.status_code}")
@@ -132,6 +135,11 @@ class PlatformClient:
 
     async def get(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
         return await self.request("GET", endpoint, params=params)
+
+    async def get_public(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
+        """GET a public endpoint (catalog/docs/models/search). Sends the token if
+        configured but does not require one."""
+        return await self.request("GET", endpoint, params=params, auth_required=False)
 
     async def post(self, endpoint: str, json_body: dict[str, Any] | None = None) -> Any:
         return await self.request("POST", endpoint, json_body=json_body or {})

--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -1,0 +1,237 @@
+"""Unit tests for the catalog, docs and model-catalog tools + public client path."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from core.client import PlatformClient
+from tools.catalog_tools import (
+    acedatacloud_get_api_spec,
+    acedatacloud_get_pricing,
+    acedatacloud_get_service,
+    acedatacloud_list_apis,
+)
+from tools.docs_tools import (
+    acedatacloud_get_doc,
+    acedatacloud_search_docs,
+)
+from tools.model_tools import acedatacloud_get_model, acedatacloud_list_model_catalog
+from tools.read_tools import acedatacloud_list_distributions
+
+API = "https://platform.acedata.cloud/api/v1"
+UUID = "f1c66741-a488-43ca-91fc-e53fbbda639a"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_service_by_id_uses_id_filter():
+    route = respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "items": [{"id": UUID, "alias": "suno", "cost": [], "unit": "Credit"}],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_service(service=UUID))
+    assert out["alias"] == "suno"
+    assert route.calls[0].request.url.params["id"] == UUID
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_service_by_alias_paginates():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={"count": 1, "items": [{"id": "svc-1", "alias": "midjourney", "unit": "Count"}]},
+        )
+    )
+    out = json.loads(await acedatacloud_get_service(service="midjourney"))
+    assert out["id"] == "svc-1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_pricing_returns_cost():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "items": [
+                    {
+                        "id": UUID,
+                        "alias": "suno",
+                        "unit": "Credit",
+                        "free_amount": 0,
+                        "cost": [{"x": 1}],
+                    }
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_pricing(service=UUID))
+    assert out["unit"] == "Credit"
+    assert out["cost"] == [{"x": 1}]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_apis_trims_definition():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200, json={"count": 1, "items": [{"id": UUID, "alias": "suno"}]}
+        )
+    )
+    respx.get(f"{API}/apis/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 2,
+                "items": [
+                    {
+                        "id": "api-1",
+                        "service_id": UUID,
+                        "path": "/suno/audios",
+                        "definition": {"big": "blob"},
+                        "cost": [],
+                    },
+                    {
+                        "id": "api-2",
+                        "service_id": "other",
+                        "path": "/flux/images",
+                        "definition": {},
+                        "cost": [],
+                    },
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_list_apis(service=UUID))
+    assert out["count"] == 1
+    assert out["items"][0]["path"] == "/suno/audios"
+    assert "definition" not in out["items"][0]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_api_spec_by_path():
+    respx.get(f"{API}/apis/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "items": [
+                    {
+                        "id": "api-1",
+                        "path": "/suno/audios",
+                        "method": "POST",
+                        "definition": {"openapi": "3.0"},
+                        "cost": [],
+                    }
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_api_spec(path="/suno/audios"))
+    assert out["definition"] == {"openapi": "3.0"}
+    assert out["method"] == "POST"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_search_docs_uses_query_param():
+    route = respx.get(f"{API}/search/").mock(
+        return_value=httpx.Response(
+            200, json={"query": "suno", "lang": "en", "results": [{"alias": "x"}]}
+        )
+    )
+    out = json.loads(await acedatacloud_search_docs(query="suno", lang="en"))
+    assert out["results"][0]["alias"] == "x"
+    assert route.calls[0].request.url.params["query"] == "suno"
+
+
+@pytest.mark.asyncio
+async def test_get_doc_rejects_non_uuid():
+    out = json.loads(await acedatacloud_get_doc(doc_id="../etc/passwd"))
+    assert out["error"] == "Invalid Input"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_doc_by_id():
+    respx.get(f"{API}/documents/").mock(
+        return_value=httpx.Response(
+            200, json={"count": 1, "items": [{"id": UUID, "content": "# Hello"}]}
+        )
+    )
+    out = json.loads(await acedatacloud_get_doc(doc_id=UUID))
+    assert out["content"] == "# Hello"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_model_catalog_filters_modality():
+    respx.get(f"{API}/models/catalog/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "modalities": {"chat": 1, "video": 1},
+                "items": [
+                    {"id": "gpt-4.1", "modality": "chat", "provider": "OpenAI"},
+                    {"id": "veo-3", "modality": "video", "provider": "Google"},
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_list_model_catalog(modality="chat"))
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == "gpt-4.1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_model_substring_match():
+    respx.get(f"{API}/models/catalog/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {"id": "claude-opus-4.8", "name": "Claude Opus 4.8"},
+                    {"id": "gpt-4.1", "name": "GPT-4.1"},
+                ]
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_model(model="claude"))
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == "claude-opus-4.8"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_distributions_merges_status_and_history():
+    respx.get(f"{API}/distribution-statuses/").mock(
+        return_value=httpx.Response(200, json={"count": 1, "items": [{"level": 2, "reward": 12.5}]})
+    )
+    respx.get(f"{API}/distribution-histories/").mock(
+        return_value=httpx.Response(200, json={"count": 3, "items": [{"reward": 1.0}]})
+    )
+    out = json.loads(await acedatacloud_list_distributions())
+    assert out["status"]["level"] == 2
+    assert out["history_count"] == 3
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_public_get_omits_auth_header_when_no_token():
+    route = respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(200, json={"count": 0, "items": []})
+    )
+    public_client = PlatformClient(api_token="")
+    await public_client.get_public("/services/")
+    assert "authorization" not in {k.lower() for k in route.calls[0].request.headers}

--- a/acedatacloud/tools/__init__.py
+++ b/acedatacloud/tools/__init__.py
@@ -1,11 +1,22 @@
 """Tools module for the Platform MCP server."""
 
 # Import all tool modules so their @mcp.tool() decorators register with the server.
-from tools import admin_tools, info_tools, read_tools, write_tools
+from tools import (
+    admin_tools,
+    catalog_tools,
+    docs_tools,
+    info_tools,
+    model_tools,
+    read_tools,
+    write_tools,
+)
 
 __all__ = [
     "read_tools",
     "write_tools",
     "admin_tools",
     "info_tools",
+    "catalog_tools",
+    "docs_tools",
+    "model_tools",
 ]

--- a/acedatacloud/tools/catalog_tools.py
+++ b/acedatacloud/tools/catalog_tools.py
@@ -1,0 +1,213 @@
+"""Public catalog tools: services, pricing, APIs, specs, datasets, integrations.
+
+These hit the public catalog endpoints (no token required). The platform's
+detail endpoints (``/services/{id}/``, ``/apis/{id}/``) are unreliable, so every
+lookup here uses the list endpoints with the filters that actually work:
+``services/?id=``, ``apis/?path=`` and ``apis/?service_id=``.
+"""
+
+import re
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from core.client import client
+from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.server import mcp
+from core.utils import dumps, error_json
+
+_UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+async def _resolve_service(ref: str) -> dict[str, Any] | None:
+    """Resolve a service by UUID (``services/?id=``) or by alias (paginated match)."""
+    ref = ref.strip()
+    if _UUID.match(ref):
+        result = await client.get_public("/services/", {"id": ref})
+        items: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
+        return items[0] if items else None
+    target = ref.lower()
+    offset = 0
+    while offset < 600:
+        result = await client.get_public("/services/", {"limit": 50, "offset": offset})
+        page: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
+        if not page:
+            break
+        for it in page:
+            if (it.get("alias") or "").lower() == target:
+                return it
+        count = result.get("count", 0) if isinstance(result, dict) else 0
+        offset += 50
+        if offset >= count:
+            break
+    return None
+
+
+@mcp.tool()
+async def acedatacloud_get_service(
+    service: Annotated[
+        str,
+        Field(description="Service UUID or alias (e.g. 'suno', 'midjourney')."),
+    ],
+) -> str:
+    """Get one service's full detail: title, description, type, unit, free_amount
+    and its display pricing (``cost``). No token required.
+    """
+    try:
+        svc = await _resolve_service(service)
+        if not svc:
+            return error_json("Not Found", f"No service matched '{service}'.")
+        return dumps(svc)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_get_pricing(
+    service: Annotated[
+        str,
+        Field(description="Service UUID or alias to price (e.g. 'suno')."),
+    ],
+) -> str:
+    """Get a service's pricing: the billing ``unit`` (Count/Token/MB/GB/Credit),
+    ``free_amount`` and the display ``cost`` rules. No token required.
+    """
+    try:
+        svc = await _resolve_service(service)
+        if not svc:
+            return error_json("Not Found", f"No service matched '{service}'.")
+        return dumps(
+            {
+                "service_id": svc.get("id"),
+                "alias": svc.get("alias"),
+                "title": svc.get("title"),
+                "type": svc.get("type"),
+                "unit": svc.get("unit"),
+                "free_amount": svc.get("free_amount"),
+                "cost": svc.get("cost"),
+            }
+        )
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_list_apis(
+    service: Annotated[
+        str | None,
+        Field(description="Optional service UUID or alias to filter the APIs by."),
+    ] = None,
+    limit: Annotated[int, Field(description="Max APIs to return.", ge=1, le=100)] = 50,
+) -> str:
+    """List API endpoints, optionally scoped to one service. Each item carries the
+    path, method, stage and billing ``cost``. No token required.
+    """
+    try:
+        if service:
+            svc = await _resolve_service(service)
+            if not svc:
+                return error_json("Not Found", f"No service matched '{service}'.")
+            sid = svc.get("id")
+            # The /apis/?service_id= filter is not honored server-side, so collect
+            # and filter client-side by paging through the catalog.
+            collected: list[dict[str, Any]] = []
+            offset = 0
+            while offset < 2000 and len(collected) < limit:
+                result = await client.get_public("/apis/", {"limit": 50, "offset": offset})
+                page: list[dict[str, Any]] = (
+                    result.get("items", []) if isinstance(result, dict) else []
+                )
+                if not page:
+                    break
+                for it in page:
+                    if it.get("service_id") == sid:
+                        collected.append({k: v for k, v in it.items() if k != "definition"})
+                        if len(collected) >= limit:
+                            break
+                count = result.get("count", 0) if isinstance(result, dict) else 0
+                offset += 50
+                if offset >= count:
+                    break
+            return dumps({"count": len(collected), "items": collected})
+        result = await client.get_public("/apis/", {"limit": limit})
+        if not isinstance(result, dict):
+            return error_json("No Response", "The API returned an empty response.")
+        # Trim the OpenAPI blob from list view to keep output compact.
+        items = [
+            {k: v for k, v in it.items() if k != "definition"} for it in result.get("items", [])
+        ]
+        return dumps({"count": result.get("count"), "items": items})
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_get_api_spec(
+    path: Annotated[
+        str,
+        Field(description="API path, e.g. '/suno/audios' or '/midjourney/imagine'."),
+    ],
+) -> str:
+    """Get one API endpoint's OpenAPI spec (``definition``) plus its method, stage
+    and billing ``cost``, looked up by path. No token required.
+    """
+    try:
+        result = await client.get_public("/apis/", {"path": path})
+        items = result.get("items", []) if isinstance(result, dict) else []
+        if not items:
+            return error_json("Not Found", f"No API matched path '{path}'.")
+        api = items[0]
+        return dumps(
+            {
+                "id": api.get("id"),
+                "service_id": api.get("service_id"),
+                "title": api.get("title"),
+                "path": api.get("path"),
+                "method": api.get("method"),
+                "stage": api.get("stage"),
+                "cost": api.get("cost"),
+                "definition": api.get("definition"),
+            }
+        )
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_list_datasets(
+    limit: Annotated[int, Field(description="Max datasets to return.", ge=1, le=100)] = 50,
+) -> str:
+    """List downloadable datasets (title, price, download/preview URLs). No token required."""
+    try:
+        result = await client.get_public("/datasets/", {"limit": limit})
+        if not isinstance(result, dict):
+            return error_json("No Response", "The API returned an empty response.")
+        return dumps(result)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_list_integrations(
+    limit: Annotated[int, Field(description="Max integrations to return.", ge=1, le=100)] = 50,
+) -> str:
+    """List third-party integrations (title, options, stage). No token required."""
+    try:
+        result = await client.get_public("/integrations/", {"limit": limit})
+        if not isinstance(result, dict):
+            return error_json("No Response", "The API returned an empty response.")
+        return dumps(result)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)

--- a/acedatacloud/tools/docs_tools.py
+++ b/acedatacloud/tools/docs_tools.py
@@ -1,0 +1,96 @@
+"""Public documentation tools: full-text search, browse, and fetch by id.
+
+Discovery is via ``/search/?query=`` (rich results with alias/title/snippet/url).
+A single document's content is fetched via ``documents/?id=`` because the
+``documents/{id}/`` detail route is not reliable.
+"""
+
+import re
+from typing import Annotated
+
+from pydantic import Field
+
+from core.client import client
+from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.server import mcp
+from core.utils import dumps, error_json
+
+_UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+@mcp.tool()
+async def acedatacloud_search_docs(
+    query: Annotated[
+        str,
+        Field(description="Search text, e.g. 'suno lyrics' or 'midjourney imagine'."),
+    ],
+    lang: Annotated[
+        str | None,
+        Field(description="Optional language code, e.g. 'en', 'zh-cn', 'ja'."),
+    ] = None,
+) -> str:
+    """Full-text search the AceDataCloud documentation. Returns matching docs with
+    alias, title, snippet and url. No token required.
+    """
+    try:
+        result = await client.get_public("/search/", {"query": query, "lang": lang})
+        if not isinstance(result, dict):
+            return error_json("No Response", "The API returned an empty response.")
+        return dumps(result)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_list_docs(
+    doc_type: Annotated[
+        str | None,
+        Field(description="Optional document type filter, e.g. 'Text'."),
+    ] = None,
+    limit: Annotated[int, Field(description="Max documents to return.", ge=1, le=100)] = 30,
+) -> str:
+    """Browse documentation pages (newest/ranked). For finding a specific topic,
+    prefer ``acedatacloud_search_docs``. No token required.
+    """
+    try:
+        result = await client.get_public("/documents/", {"limit": limit, "type": doc_type})
+        if not isinstance(result, dict):
+            return error_json("No Response", "The API returned an empty response.")
+        # Trim long content in the browse view; use get_doc for full content.
+        items = []
+        for it in result.get("items", []):
+            slim = {k: v for k, v in it.items() if k != "content"}
+            content = it.get("content")
+            if isinstance(content, str):
+                slim["content_preview"] = content[:200]
+            items.append(slim)
+        return dumps({"count": result.get("count"), "items": items})
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_get_doc(
+    doc_id: Annotated[
+        str,
+        Field(description="Document UUID (from search results or list)."),
+    ],
+) -> str:
+    """Fetch one documentation page's full content by its UUID. No token required."""
+    try:
+        ref = doc_id.strip()
+        if not _UUID.match(ref):
+            return error_json("Invalid Input", "doc_id must be a document UUID.")
+        result = await client.get_public("/documents/", {"id": ref})
+        items = result.get("items", []) if isinstance(result, dict) else []
+        if not items:
+            return error_json("Not Found", f"No document with id '{ref}'.")
+        return dumps(items[0])
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)

--- a/acedatacloud/tools/model_tools.py
+++ b/acedatacloud/tools/model_tools.py
@@ -1,0 +1,84 @@
+"""Public model-catalog tools: rich catalog listing + per-model lookup.
+
+``acedatacloud_list_models`` (in read_tools) returns the OpenAI-style flat list.
+These add the richer ``/models/catalog/`` view with provider, modality and
+per-model credit pricing.
+"""
+
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from core.client import client
+from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.server import mcp
+from core.utils import dumps, error_json
+
+
+async def _catalog() -> dict[str, Any]:
+    result = await client.get_public("/models/catalog/")
+    return result if isinstance(result, dict) else {}
+
+
+@mcp.tool()
+async def acedatacloud_list_model_catalog(
+    modality: Annotated[
+        str | None,
+        Field(description="Filter by modality: chat/video/image/music/search/embedding."),
+    ] = None,
+    provider: Annotated[
+        str | None,
+        Field(description="Filter by provider substring, e.g. 'OpenAI', 'Anthropic'."),
+    ] = None,
+) -> str:
+    """List the model catalog with provider, modality and per-model credit pricing.
+
+    Returns the modality counts plus matching models. No token required.
+    """
+    try:
+        cat = await _catalog()
+        items = cat.get("items", [])
+        if modality:
+            m = modality.lower()
+            items = [it for it in items if (it.get("modality") or "").lower() == m]
+        if provider:
+            p = provider.lower()
+            items = [it for it in items if p in (it.get("provider") or "").lower()]
+        return dumps(
+            {
+                "modalities": cat.get("modalities"),
+                "count": len(items),
+                "items": items,
+            }
+        )
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_get_model(
+    model: Annotated[
+        str,
+        Field(description="Model id or name, e.g. 'gpt-4.1', 'claude', 'veo'."),
+    ],
+) -> str:
+    """Look up models by id/name (case-insensitive substring) with their credit
+    pricing and capabilities. No token required.
+    """
+    try:
+        cat = await _catalog()
+        q = model.strip().lower()
+        matches = [
+            it
+            for it in cat.get("items", [])
+            if q in (it.get("id") or "").lower() or q in (it.get("name") or "").lower()
+        ]
+        if not matches:
+            return error_json("Not Found", f"No model matched '{model}'.")
+        return dumps({"count": len(matches), "items": matches})
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -253,3 +253,29 @@ async def acedatacloud_list_announcements(
         return error_json("Authentication Error", e.message)
     except PlatformAPIError as e:
         return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_list_distributions(
+    limit: Annotated[
+        int, Field(description="Max commission history records to return.", ge=1, le=100)
+    ] = 20,
+) -> str:
+    """Show your referral/affiliate earnings: current status (level, total price,
+    total reward) plus recent commission events. Amounts are in Credits.
+    """
+    try:
+        status = await client.get("/distribution-statuses/", {"limit": 1})
+        history = await client.get("/distribution-histories/", {"limit": limit})
+        status_items = status.get("items", []) if isinstance(status, dict) else []
+        return dumps(
+            {
+                "status": status_items[0] if status_items else None,
+                "history_count": history.get("count") if isinstance(history, dict) else None,
+                "history": history.get("items", []) if isinstance(history, dict) else [],
+            }
+        )
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)


### PR DESCRIPTION
## What

Make the `acedatacloud` MCP actually **complete** — it previously only had account/billing tools (balance, usage, credentials, orders, tokens, announcements). This adds the missing **catalog, docs and model** coverage you'd expect from a platform MCP, plus referral earnings.

12 new tools (server now exposes 30):

**Catalog (public — no token)**
- `acedatacloud_get_service` — service detail (type/unit/free_amount/cost), by alias or id
- `acedatacloud_get_pricing` — billing unit + free_amount + display pricing
- `acedatacloud_list_apis` — API endpoints, optionally scoped to one service
- `acedatacloud_get_api_spec` — one API's OpenAPI `definition` + cost, by path
- `acedatacloud_list_datasets`, `acedatacloud_list_integrations`

**Docs (public)**
- `acedatacloud_search_docs` — full-text doc search (alias/title/snippet/url)
- `acedatacloud_list_docs` — browse pages
- `acedatacloud_get_doc` — full content by UUID

**Models (public)**
- `acedatacloud_list_model_catalog` — provider/modality/credit pricing
- `acedatacloud_get_model` — lookup by id/name

**Account**
- `acedatacloud_list_distributions` — referral/affiliate status + commission history

Client gains a public (no-token) path (`get_public`) so catalog/docs/model tools work with or without a platform token.

## Why list+filter (not detail endpoints)

I probed the live API first. The platform's **detail routes are unreliable**: `services/{id}/` and `apis/{id}/` return **500**, `documents/{id}/` returns **404**. And several **collection filters are ignored server-side** (`services/?alias=`, `apis/?service_id=` return everything). What *does* work: `services/?id=`, `apis/?path=`, `documents/?id=`, `search/?query=`. So every lookup uses list+filter, and the `service_id`/alias filters that the server ignores are applied **client-side**.

## Verification (live, against production)

Every new tool was called against `platform.acedata.cloud`:

| Tool | Result |
|---|---|
| get_service(suno) / get_pricing(suno) | ✅ detail + cost |
| list_apis(suno) | ✅ **13** suno-only APIs (was returning all 165 before the client-side filter fix) |
| get_api_spec(/suno/audios) | ✅ OpenAPI `definition` |
| list_datasets / list_integrations | ✅ |
| search_docs("suno lyrics") | ✅ 4 results |
| list_docs / get_doc(uuid) | ✅ full content |
| list_model_catalog(chat) | ✅ 76 chat models |
| get_model(claude) | ✅ 17 matches |
| list_distributions | ✅ status + history |

- 36 unit tests pass (12 new), `ruff check` + `ruff format --check` clean, `mypy` clean.

## 🤖 对抗评审

Self-review (Codex unavailable here). Findings & resolutions:
- **RISK: `apis/?service_id=` not honored** → `list_apis(service)` returned all 165 APIs. **Fixed**: client-side filter by `service_id`; live-confirmed 13 suno-only.
- **RISK: SSRF/path-injection on `get_doc`** → restricted `doc_id` to a UUID regex (rejects `../`); query-param only.
- **RISK: secret leakage** → catalog/docs are public, no secrets; account tools reuse the existing `mask_secrets`.
- **RISK: alias resolution unbounded** → `_resolve_service` caps pagination (≤600 / until `count`).

VERDICT: CLEAN after fixes.
