### PR TITLE
fix(acedatacloud): shorten server.json description to <=100 chars

### DIFF
--- a/acedatacloud/server.json
+++ b/acedatacloud/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.AceDataCloud/mcp-acedatacloud",
-  "description": "MCP server for managing your AceData Cloud account — services, pricing, APIs, docs, models, balance, usage, API keys, orders & announcements",
+  "description": "Manage your AceData Cloud account: services, pricing, APIs, docs, balance, usage, keys & orders",
   "version": "2026.6.28.0",
   "repository": {
     "url": "https://github.com/AceDataCloud/AceDataCloudMCP",


### PR DESCRIPTION
## What

Shorten the `acedatacloud/server.json` `description` to **≤100 chars** so the MCP Registry publish step passes.

## Why

`mcp-acedatacloud` now publishes to PyPI ✅ and deploys to `mcp.acedata.cloud` ✅, but the **Publish to MCP Registry** job failed with:

```
422 Unprocessable Entity: validation failed
errors: [{ message: "expected length <= 100", location: "body.description", value: "MCP server for managing your AceData Cloud account — services, pricing, APIs, docs, models, balance, usage, API keys, orders & announcements" }]
```

The description was 140 chars. Shortened to 95:

> Manage your AceData Cloud account: services, pricing, APIs, docs, balance, usage, keys & orders

## Effect

On merge, the sub-repo sync re-runs `publish.yml`; the MCP Registry listing then succeeds (and PyPI bumps to the next date build). No code change.

## 🤖 对抗评审

VERDICT: CLEAN — one-line metadata change to satisfy a registry length constraint; no behavioral surface.
