### PR TITLE
feat(seedance): sync MCP to Seedance 2.0 (mini, 4k, reference audio/video, dur 2-15)

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -16,10 +16,10 @@ Generate AI videos directly from Claude, VS Code, or any MCP-compatible client.
 
 - **Text to Video** - Create AI-generated videos from text prompts
 - **Image to Video** - Animate images with first frame, last frame, and reference image control
-- **Multiple Models** - Support for Seedance 1.5 Pro, 1.0 Pro, 1.0 Pro Fast, 1.0 Lite T2V/I2V
-- **Multiple Resolutions** - 480p, 720p (default), and 1080p output
+- **Multiple Models** - Support for Seedance 2.0 (incl. Fast/Mini, multimodal reference), 1.5 Pro, 1.0 Pro, 1.0 Pro Fast, 1.0 Lite T2V/I2V
+- **Multiple Resolutions** - 480p, 720p (default), 1080p, and 4k output (4k: `doubao-seedance-2-0-260128` only)
 - **Flexible Aspect Ratios** - 16:9, 9:16, 1:1, 4:3, 3:4, 21:9, and adaptive
-- **Audio Generation** - Generate synchronized audio for videos (1.5 Pro)
+- **Audio Generation** - Generate synchronized audio for videos (1.5 Pro and 2.0 series)
 - **Service Tiers** - Default (priority) and Flex (cost-effective) processing
 - **Task Tracking** - Monitor generation progress and retrieve results
 
@@ -364,10 +364,11 @@ Claude: I'll generate a video with synchronized audio.
 
 | Model                                 | Description       | Features                   |
 | ------------------------------------- | ----------------- | -------------------------- |
-| `doubao-seedance-2-0-260128`          | 2.0               | Latest generation quality  |
+| `doubao-seedance-2-0-260128`          | 2.0 (default)     | Latest generation, 4k, multimodal reference |
 | `doubao-seedance-2-0-fast-260128`     | 2.0 Fast          | Latest generation fast     |
+| `doubao-seedance-2-0-mini-260615`     | 2.0 Mini          | Latest generation, lightweight, cheapest 2.0 |
 | `doubao-seedance-1-5-pro-251215`      | 1.5 Pro           | Audio generation, T2V, I2V |
-| `doubao-seedance-1-0-pro-250528`      | 1.0 Pro (default) | High quality T2V, I2V      |
+| `doubao-seedance-1-0-pro-250528`      | 1.0 Pro           | High quality T2V, I2V      |
 | `doubao-seedance-1-0-pro-fast-251015` | 1.0 Pro Fast      | Faster generation          |
 | `doubao-seedance-1-0-lite-t2v-250428` | 1.0 Lite T2V      | Lightweight text-to-video  |
 | `doubao-seedance-1-0-lite-i2v-250428` | 1.0 Lite I2V      | Lightweight image-to-video |
@@ -394,7 +395,7 @@ Claude: I'll generate a video with synchronized audio.
 | `ACEDATACLOUD_API_BASE_URL`   | API base URL                | `https://api.acedata.cloud`      |
 | `ACEDATACLOUD_OAUTH_CLIENT_ID`  | OAuth client ID (hosted mode) | —                           |
 | `ACEDATACLOUD_PLATFORM_BASE_URL` | Platform base URL            | `https://platform.acedata.cloud` |
-| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-1-0-pro-250528` |
+| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-2-0-260128` |
 | `SEEDANCE_DEFAULT_RESOLUTION` | Default resolution          | `720p`                           |
 | `SEEDANCE_DEFAULT_RATIO`      | Default aspect ratio        | `16:9`                           |
 | `SEEDANCE_DEFAULT_DURATION`   | Default duration (seconds)  | `5`                              |

--- a/seedance/core/config.py
+++ b/seedance/core/config.py
@@ -23,9 +23,7 @@ class Settings:
 
     # Default Settings
     default_model: str = field(
-        default_factory=lambda: os.getenv(
-            "SEEDANCE_DEFAULT_MODEL", "doubao-seedance-1-0-pro-250528"
-        )
+        default_factory=lambda: os.getenv("SEEDANCE_DEFAULT_MODEL", "doubao-seedance-2-0-260128")
     )
     default_resolution: str = field(
         default_factory=lambda: os.getenv("SEEDANCE_DEFAULT_RESOLUTION", "720p")

--- a/seedance/core/types.py
+++ b/seedance/core/types.py
@@ -4,13 +4,14 @@ from typing import Literal
 
 # Seedance video models
 SeedanceModel = Literal[
+    "doubao-seedance-2-0-260128",
+    "doubao-seedance-2-0-fast-260128",
+    "doubao-seedance-2-0-mini-260615",
     "doubao-seedance-1-5-pro-251215",
     "doubao-seedance-1-0-pro-250528",
     "doubao-seedance-1-0-pro-fast-251015",
     "doubao-seedance-1-0-lite-t2v-250428",
     "doubao-seedance-1-0-lite-i2v-250428",
-    "doubao-seedance-2-0-260128",
-    "doubao-seedance-2-0-fast-260128",
 ]
 
 # Video aspect ratios
@@ -29,6 +30,7 @@ Resolution = Literal[
     "480p",
     "720p",
     "1080p",
+    "4k",
 ]
 
 # Service tiers
@@ -41,6 +43,8 @@ ServiceTier = Literal[
 ContentType = Literal[
     "text",
     "image_url",
+    "audio_url",
+    "video_url",
 ]
 
 # Image roles for content items
@@ -51,7 +55,7 @@ ImageRole = Literal[
 ]
 
 # Default values
-DEFAULT_MODEL: SeedanceModel = "doubao-seedance-1-0-pro-250528"
+DEFAULT_MODEL: SeedanceModel = "doubao-seedance-2-0-260128"
 DEFAULT_RESOLUTION: Resolution = "720p"
 DEFAULT_RATIO: AspectRatio = "16:9"
 DEFAULT_DURATION: int = 5

--- a/seedance/main.py
+++ b/seedance/main.py
@@ -60,7 +60,7 @@ Examples:
 
 Environment Variables:
   ACEDATACLOUD_API_TOKEN        API token from AceDataCloud (required)
-  SEEDANCE_DEFAULT_MODEL        Default model (default: doubao-seedance-1-0-pro-250528)
+  SEEDANCE_DEFAULT_MODEL        Default model (default: doubao-seedance-2-0-260128)
   SEEDANCE_DEFAULT_RESOLUTION   Default resolution (default: 720p)
   SEEDANCE_DEFAULT_RATIO        Default aspect ratio (default: 16:9)
   SEEDANCE_DEFAULT_DURATION     Default duration in seconds (default: 5)

--- a/seedance/prompts/__init__.py
+++ b/seedance/prompts/__init__.py
@@ -38,9 +38,10 @@ When the user wants to generate video, choose the appropriate tool based on thei
 ## Choosing the Right Model
 - **Latest generation quality:** `doubao-seedance-2-0-260128`
 - **Latest generation fast:** `doubao-seedance-2-0-fast-260128`
-- **Best quality + audio:** `doubao-seedance-1-5-pro-251215`
-- **Balanced (default):** `doubao-seedance-1-0-pro-250528`
-- **Fastest/cheapest:** `doubao-seedance-1-0-pro-fast-251015`
+- **Latest generation lightweight / cheapest within 2.0:** `doubao-seedance-2-0-mini-260615`
+- **1.5 flagship + audio:** `doubao-seedance-1-5-pro-251215`
+- **1.0 standard:** `doubao-seedance-1-0-pro-250528`
+- **Fastest/cheapest 1.0:** `doubao-seedance-1-0-pro-fast-251015`
 - **Lightweight T2V:** `doubao-seedance-1-0-lite-t2v-250428`
 - **Lightweight I2V:** `doubao-seedance-1-0-lite-i2v-250428`
 
@@ -54,12 +55,13 @@ When the user wants to generate video, choose the appropriate tool based on thei
 1. Video generation is async in MCP and should return quickly with a task_id
 2. After submission, poll with `seedance_get_task` until the final video URLs are available
 2. Default resolution is 720p, default ratio is 16:9
-3. Duration range: 2-12 seconds
-4. Only 1.5 Pro model supports audio generation
+3. Duration range: 2-15 seconds (Seedance 2.0 supports 4-15)
+4. Audio generation is supported by the 1.5 Pro and 2.0 series models
 5. Use 'flex' service_tier for 50% cost savings
 6. Use seed parameter for reproducible results
 7. reference_image_urls CANNOT be combined with first_frame/last_frame
-8. Use callback_url for async processing in production
+8. Seedance 2.0 also accepts reference audio/video (reference_audio_urls / reference_video_urls)
+9. Use callback_url for async processing in production
 """
 
 

--- a/seedance/tests/test_config.py
+++ b/seedance/tests/test_config.py
@@ -13,7 +13,7 @@ def test_settings_default_values() -> None:
 
         settings = Settings()
         assert settings.api_base_url == "https://api.acedata.cloud"
-        assert settings.default_model == "doubao-seedance-1-0-pro-250528"
+        assert settings.default_model == "doubao-seedance-2-0-260128"
         assert settings.default_resolution == "720p"
         assert settings.default_ratio == "16:9"
         assert settings.default_duration == 5

--- a/seedance/tools/info_tools.py
+++ b/seedance/tools/info_tools.py
@@ -18,27 +18,30 @@ async def seedance_list_models() -> str:
 
 | Model | Type | Strengths | Audio | Cost (720p/sec) |
 |-------|------|-----------|-------|-----------------|
-| doubao-seedance-2-0-260128 | 2.0 | Latest generation quality model | No | N/A |
-| doubao-seedance-2-0-fast-260128 | 2.0 Fast | Latest generation fast/cost-optimized model | No | N/A |
-| doubao-seedance-1-5-pro-251215 | Flagship | Newest, highest quality, audio support | Yes | ~$0.025 |
-| doubao-seedance-1-0-pro-250528 | Standard | Balanced quality and speed (default) | No | ~$0.049 |
+| doubao-seedance-2-0-260128 | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (default) | Yes | ~$0.146 |
+| doubao-seedance-2-0-fast-260128 | 2.0 Fast | Latest generation, faster, up to 720p | Yes | ~$0.117 |
+| doubao-seedance-2-0-mini-260615 | 2.0 Mini | Latest generation, lightweight, cheapest within 2.0, up to 720p | Yes | ~$0.073 |
+| doubao-seedance-1-5-pro-251215 | Flagship | 1.5, high quality, audio support | Yes | ~$0.025 |
+| doubao-seedance-1-0-pro-250528 | Standard | Balanced quality and speed | No | ~$0.049 |
 | doubao-seedance-1-0-pro-fast-251015 | Fast | Cost-optimized, faster generation | No | ~$0.014 |
 | doubao-seedance-1-0-lite-t2v-250428 | Lite T2V | Lightweight text-to-video | No | ~$0.033 |
 | doubao-seedance-1-0-lite-i2v-250428 | Lite I2V | Lightweight image-to-video | No | ~$0.033 |
 
 Model Selection Guide:
-- Latest quality: doubao-seedance-2-0-260128
+- Latest quality / default: doubao-seedance-2-0-260128 (up to 4k, multimodal reference)
 - Latest fast: doubao-seedance-2-0-fast-260128
-- Best quality: doubao-seedance-1-5-pro-251215 (newest flagship)
-- Best value: doubao-seedance-1-0-pro-250528 (standard, default)
-- Fastest/cheapest: doubao-seedance-1-0-pro-fast-251015
+- Latest lightweight / cheapest within 2.0: doubao-seedance-2-0-mini-260615
+- 1.5 flagship (audio): doubao-seedance-1-5-pro-251215
+- 1.0 standard: doubao-seedance-1-0-pro-250528
+- Fastest/cheapest 1.0: doubao-seedance-1-0-pro-fast-251015
 - Text-only lightweight: doubao-seedance-1-0-lite-t2v-250428
 - Image-to-video lightweight: doubao-seedance-1-0-lite-i2v-250428
 
 Notes:
-- Audio generation is only supported by the 1.5 Pro model
+- Audio generation (generate_audio) is supported by the 1.5 Pro and 2.0 series models
+- Seedance 2.0 adds multimodal reference inputs: real-person/character image, reference audio, reference video
 - 'flex' service tier offers 50% discount on all models
-- Resolution affects cost: 480p < 720p < 1080p
+- Resolution affects cost: 480p < 720p < 1080p < 4k ('4k' is doubao-seedance-2-0-260128 only; 2-0-fast / 2-0-mini max at 720p)
 """
 
 
@@ -59,6 +62,7 @@ async def seedance_list_resolutions() -> str:
 | 480p | Low resolution | Previews, drafts, cost savings |
 | 720p | HD (default) | General use, social media |
 | 1080p | Full HD | High-quality production |
+| 4k | Ultra HD | Highest detail (doubao-seedance-2-0-260128 only) |
 
 Available Aspect Ratios:
 

--- a/seedance/tools/video_tools.py
+++ b/seedance/tools/video_tools.py
@@ -39,11 +39,14 @@ async def seedance_generate_video(
         Field(
             description=(
                 "Model version to use. Options: "
-                "'doubao-seedance-2-0-260128' (latest generation quality model), "
-                "'doubao-seedance-2-0-fast-260128' (latest generation fast model), "
-                "'doubao-seedance-1-5-pro-251215' (newest flagship, supports audio), "
-                "'doubao-seedance-1-0-pro-250528' (standard, default), "
-                "'doubao-seedance-1-0-pro-fast-251015' (fast, cost-optimized), "
+                "'doubao-seedance-2-0-260128' (latest generation, highest quality, "
+                "supports 4k and multimodal reference, default), "
+                "'doubao-seedance-2-0-fast-260128' (latest generation, faster, up to 720p), "
+                "'doubao-seedance-2-0-mini-260615' (latest generation, lightweight, "
+                "cheapest within the 2.0 series, up to 720p), "
+                "'doubao-seedance-1-5-pro-251215' (1.5 flagship, supports audio), "
+                "'doubao-seedance-1-0-pro-250528' (1.0 standard), "
+                "'doubao-seedance-1-0-pro-fast-251015' (1.0 fast, cost-optimized), "
                 "'doubao-seedance-1-0-lite-t2v-250428' (lightweight text-to-video), "
                 "'doubao-seedance-1-0-lite-i2v-250428' (lightweight image-to-video)."
             )
@@ -51,7 +54,13 @@ async def seedance_generate_video(
     ] = DEFAULT_MODEL,
     resolution: Annotated[
         Resolution,
-        Field(description=("Video resolution. Options: '480p', '720p' (default), '1080p'.")),
+        Field(
+            description=(
+                "Video resolution. Options: '480p', '720p' (default), '1080p', '4k'. "
+                "'4k' is supported only by 'doubao-seedance-2-0-260128'; "
+                "'2-0-fast' and '2-0-mini' max out at '720p'."
+            )
+        ),
     ] = DEFAULT_RESOLUTION,
     ratio: Annotated[
         AspectRatio,
@@ -67,11 +76,11 @@ async def seedance_generate_video(
         int | None,
         Field(
             description=(
-                "Video duration in seconds. Range: 2-12. Default is 5. "
-                "Mutually exclusive with 'frames'."
+                "Video duration in seconds. Range: 2-15 (Seedance 2.0 supports 4-15). "
+                "Default is 5. Mutually exclusive with 'frames'."
             ),
             ge=2,
-            le=12,
+            le=15,
         ),
     ] = None,
     frames: Annotated[
@@ -79,7 +88,7 @@ async def seedance_generate_video(
         Field(
             description=(
                 "Frame count for the generated video. "
-                "Must satisfy 25+4n (e.g. 29, 33, 37, ..., 289). "
+                "Must satisfy 25+4n (e.g. 29, 33, 37, ..., 361). "
                 "Mutually exclusive with 'duration'."
             ),
         ),
@@ -89,7 +98,8 @@ async def seedance_generate_video(
         Field(
             description=(
                 "If true, generate audio along with the video. "
-                "Only supported by 'doubao-seedance-1-5-pro-251215' model. "
+                "Supported by 'doubao-seedance-1-5-pro-251215' and the "
+                "'doubao-seedance-2-0' series; other models ignore it. "
                 "Approximately doubles the cost. Default is false."
             )
         ),
@@ -235,8 +245,28 @@ async def seedance_generate_video_from_image(
         Field(
             description=(
                 "List of reference image URLs for style/content guidance. "
+                "For the Seedance 2.0 series these can be real-person / character "
+                "references that keep the subject consistent (up to 9). "
                 "These images influence the look but are not used as frames. "
                 "Cannot be combined with first_frame_url or last_frame_url."
+            )
+        ),
+    ] = [],  # noqa: B006
+    reference_audio_urls: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Seedance 2.0 only. Reference audio URLs (up to 3) for voice timbre / "
+                "background music. Ignored by 1.x models."
+            )
+        ),
+    ] = [],  # noqa: B006
+    reference_video_urls: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Seedance 2.0 only. Reference video URLs (up to 3) for subject, camera "
+                "movement, motion or overall style. Ignored by 1.x models."
             )
         ),
     ] = [],  # noqa: B006
@@ -245,16 +275,22 @@ async def seedance_generate_video_from_image(
         Field(
             description=(
                 "Model version to use. "
-                "Use 'doubao-seedance-2-0-260128' for latest generation quality, "
-                "'doubao-seedance-2-0-fast-260128' for latest generation speed, "
-                "For image-to-video, consider 'doubao-seedance-1-0-lite-i2v-250428' "
-                "for lightweight I2V, or any Pro model for higher quality."
+                "Use 'doubao-seedance-2-0-260128' (default) for latest-generation quality "
+                "and multimodal reference, 'doubao-seedance-2-0-fast-260128' or "
+                "'doubao-seedance-2-0-mini-260615' for faster/cheaper 2.0, or a 1.x model "
+                "such as 'doubao-seedance-1-0-lite-i2v-250428' for lightweight I2V."
             )
         ),
     ] = DEFAULT_MODEL,
     resolution: Annotated[
         Resolution,
-        Field(description="Video resolution. Options: '480p', '720p', '1080p'."),
+        Field(
+            description=(
+                "Video resolution. Options: '480p', '720p', '1080p', '4k'. "
+                "'4k' is supported only by 'doubao-seedance-2-0-260128'; "
+                "'2-0-fast' and '2-0-mini' max out at '720p'."
+            )
+        ),
     ] = DEFAULT_RESOLUTION,
     ratio: Annotated[
         AspectRatio,
@@ -264,11 +300,11 @@ async def seedance_generate_video_from_image(
         int | None,
         Field(
             description=(
-                "Video duration in seconds. Range: 2-12. Default is 5. "
-                "Mutually exclusive with 'frames'."
+                "Video duration in seconds. Range: 2-15 (Seedance 2.0 supports 4-15). "
+                "Default is 5. Mutually exclusive with 'frames'."
             ),
             ge=2,
-            le=12,
+            le=15,
         ),
     ] = None,
     frames: Annotated[
@@ -276,7 +312,7 @@ async def seedance_generate_video_from_image(
         Field(
             description=(
                 "Frame count for the generated video. "
-                "Must satisfy 25+4n (e.g. 29, 33, 37, ..., 289). "
+                "Must satisfy 25+4n (e.g. 29, 33, 37, ..., 361). "
                 "Mutually exclusive with 'duration'."
             ),
         ),
@@ -285,7 +321,8 @@ async def seedance_generate_video_from_image(
         bool,
         Field(
             description=(
-                "If true, generate audio. Only supported by 1.5 Pro model. Default is false."
+                "If true, generate audio. Supported by 'doubao-seedance-1-5-pro-251215' "
+                "and the 'doubao-seedance-2-0' series. Default is false."
             )
         ),
     ] = False,
@@ -337,10 +374,17 @@ async def seedance_generate_video_from_image(
     Returns:
         Task ID and generated video information including URLs and metadata.
     """
-    if not first_frame_url and not last_frame_url and not reference_image_urls:
+    if (
+        not first_frame_url
+        and not last_frame_url
+        and not reference_image_urls
+        and not reference_audio_urls
+        and not reference_video_urls
+    ):
         return (
             "Error: At least one of first_frame_url, last_frame_url, "
-            "or reference_image_urls must be provided."
+            "reference_image_urls, reference_audio_urls, or reference_video_urls "
+            "must be provided."
         )
 
     if reference_image_urls and (first_frame_url or last_frame_url):
@@ -380,6 +424,12 @@ async def seedance_generate_video_from_image(
                 "role": "reference_image",
             }
         )
+
+    for audio_url in reference_audio_urls:
+        content.append({"type": "audio_url", "audio_url": {"url": audio_url}})
+
+    for video_url in reference_video_urls:
+        content.append({"type": "video_url", "video_url": {"url": video_url}})
 
     payload: dict[str, Any] = {
         "model": model,


### PR DESCRIPTION
Sync the **seedance** MCP server to the live Seedance 2.0 capability. The MCP had only a partial 2.0 update (it listed `2-0-260128`/`2-0-fast` but was missing the mini model, `4k`, reference audio/video, the 15s duration ceiling, and still defaulted to the now-rejected `doubao-seedance-1-0-pro-250528`).

## What changed
- **Types** (`core/types.py`): add `doubao-seedance-2-0-mini-260615`; add `4k` resolution; add `audio_url` + `video_url` content types; default model → `doubao-seedance-2-0-260128`.
- **Config** (`core/config.py`) + `main.py` help: `SEEDANCE_DEFAULT_MODEL` default → `doubao-seedance-2-0-260128` (the old default is rejected by the worker).
- **Tools** (`tools/video_tools.py`): both tools get the mini model, `4k` (with the `2-0-260128`-only / fast+mini-cap-720p caveat), `duration` `le=12 → le=15`, and the `generate_audio` note updated to the 1.5-Pro + 2.0 series. The image tool gains `reference_audio_urls` / `reference_video_urls` params that emit `audio_url` / `video_url` content items.
- **Info/prompts/README**: model table adds mini with real 720p pricing (2-0 ~$0.146, fast ~$0.117, mini ~$0.073 per the cost rules), 4k, audio-for-2.0, duration 2-15.
- **Test**: `tests/test_config.py` default-model assertion updated.

Local: `ruff check` clean, `pytest` 36 passed / 2 skipped.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). One round.

- RISK: "Seedance 2.0 duration 4–15" vs schema `ge=2 le=15`. → **Rebut**: accurate — the schema accepts 2–15; the worker comment states "Seedance 2.0 supports 4–15s; we accept 2–15 and let upstream reject sub-4s". Text reads "2-15 (Seedance 2.0 supports 4-15)".
- RISK: README still says audio is 1.5-Pro-only. → **Fixed**: updated the README "Audio Generation" feature line (and "Multiple Resolutions" to include 4k).
- RISK: `generate_audio` "other models ignore it" asserts ignore-vs-reject. → **Rebut**: matches the PlatformBackend OpenAPI source wording ("其他模型将忽略该参数").
- RISK: `2-0-mini` called "cheapest" unqualified — 1.5-Pro/1.0-Pro are cheaper at 720p. → **Fixed**: qualified to "cheapest within the 2.0 series" everywhere.
- RISK: reference limits (≤9 image, ≤3 a/v) documented but not enforced client-side. → **Rebut**: the OpenAPI schema is itself permissive (no `maxItems`); the worker enforces at the boundary and returns a clear 400. The MCP intentionally mirrors the API contract rather than duplicating boundary validation.

VERDICT after fixes: CLEAN.
