### PR TITLE
feat: publish aichat/glm/webextrator/openai MCP servers + fix WebExtratorMCP name

### DIFF
--- a/aichat/.github/workflows/publish.yml
+++ b/aichat/.github/workflows/publish.yml
@@ -1,0 +1,169 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          # Version format: YYYY.M.D.BUILD
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          try:
+              resp = requests.get('https://pypi.org/pypi/mcp-aichat/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+          cat pyproject.toml | grep -m1 "version"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-aichat/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0,<6.1"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.build.outputs.version }}" dist/* \
+            --title "v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/glm/.github/workflows/publish.yml
+++ b/glm/.github/workflows/publish.yml
@@ -1,0 +1,169 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          # Version format: YYYY.M.D.BUILD
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          try:
+              resp = requests.get('https://pypi.org/pypi/mcp-glm/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+          cat pyproject.toml | grep -m1 "version"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-glm/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0,<6.1"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.build.outputs.version }}" dist/* \
+            --title "v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/openai/.github/workflows/publish.yml
+++ b/openai/.github/workflows/publish.yml
@@ -1,0 +1,169 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          # Version format: YYYY.M.D.BUILD
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          try:
+              resp = requests.get('https://pypi.org/pypi/mcp-openai/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+          cat pyproject.toml | grep -m1 "version"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-openai/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0,<6.1"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.build.outputs.version }}" dist/* \
+            --title "v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/sync.yaml
+++ b/sync.yaml
@@ -72,7 +72,7 @@ mappings:
     exclude:
       - .gitbooks
   webextrator:
-    repo: AceDataCloud/WebExtraterMCP
+    repo: AceDataCloud/WebExtratorMCP
     exclude:
       - .gitbooks
   fish:

--- a/webextrator/.github/workflows/publish.yml
+++ b/webextrator/.github/workflows/publish.yml
@@ -1,0 +1,169 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          # Version format: YYYY.M.D.BUILD
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          try:
+              resp = requests.get('https://pypi.org/pypi/mcp-webextrator/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+          cat pyproject.toml | grep -m1 "version"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/mcp-webextrator/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0,<6.1"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.build.outputs.version }}" dist/* \
+            --title "v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update server.json version
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          python3 -c "
+          import json
+          with open('server.json', 'r') as f:
+              data = json.load(f)
+          data['version'] = '$VERSION'
+          for pkg in data.get('packages', []):
+              pkg['version'] = '$VERSION'
+          with open('server.json', 'w') as f:
+              json.dump(data, f, indent=2)
+              f.write('\n')
+          "
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## What

The organization homepage (`AceDataCloud/.github` `profile/README.md`) is auto-generated daily and only lists MCP/CLI tools whose **standalone repo + PyPI package both exist**. Four MCP servers that exist in this monorepo were never published (no standalone repo, no PyPI package), so they were invisible on the homepage.

This PR makes them self-publishing:

- Adds a `publish.yml` (CalVer `YYYY.M.D.BUILD` → PyPI → GitHub release → MCP registry) to the monorepo subdirs `aichat/`, `glm/`, `webextrator/`, `openai/`. These are synced out to the standalone repos (`.github` is **not** excluded for MCPs), matching the existing `suno`/`serp`/`grok` pattern.
- Fixes the `webextrator` mapping in `sync.yaml`: `AceDataCloud/WebExtra**ter**MCP` → `AceDataCloud/WebExtra**tor**MCP` (canonical brand, matches `AceDataCloud/WebExtrator`).

The standalone repos (`GrokMCP`, `AiChatMCP`, `GlmMCP`, `WebExtratorMCP`, `OpenAIMCP`) were created and bootstrapped, and their first PyPI publish was triggered.

## Why

Without `publish.yml` in the monorepo subdir, a future `sync-to-repos` run (rsync `--delete`, `.github` not excluded) would **delete** the workflow from the standalone repo. Keeping it here is required for the publish pipeline to stay consistent.

## 🤖 对抗评审

- **CalVer vs existing SemVer (`mcp-openai` 0.2.0):** CalVer `2026.6.x` > `0.2.0` under PEP 440, so no downgrade/collision. OK.
- **`server.json` registry names:** all `io.github.AceDataCloud/mcp-*`, descriptions ≤100 chars (aichat 68 / glm 74 / webextrator 72 / openai 91) — registry validation passes. OK.
- **Secrets:** `PYPI_TOKEN` / `GITHUB_TOKEN` are org-level, inherited by new repos; none hardcoded. OK.
- **Idempotent:** BUILD number auto-increments from PyPI, so re-runs don't collide. OK.
- **Deferred (not a blocker):** marketplace (`vscode`/`jetbrains`) publish jobs were intentionally dropped from these four to avoid dependence on marketplace tokens; PyPI + registry are what the homepage needs.

VERDICT: CLEAN
