### PR TITLE
chore(seedance): drop dead 1.x models (2.0-only)

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -357,7 +357,6 @@ Claude: I'll create a video from your image.
 User: Create a video of rain falling with sound
 
 Claude: I'll generate a video with synchronized audio.
-[Calls seedance_generate_video with prompt="Rain falling on a quiet street" and generate_audio=True, model="doubao-seedance-1-5-pro-251215"]
 ```
 
 ## Available Models
@@ -367,11 +366,6 @@ Claude: I'll generate a video with synchronized audio.
 | `doubao-seedance-2-0-260128`          | 2.0 (default)     | Latest generation, 4k, multimodal reference |
 | `doubao-seedance-2-0-fast-260128`     | 2.0 Fast          | Latest generation fast     |
 | `doubao-seedance-2-0-mini-260615`     | 2.0 Mini          | Latest generation, lightweight, cheapest 2.0 |
-| `doubao-seedance-1-5-pro-251215`      | 1.5 Pro           | Audio generation, T2V, I2V |
-| `doubao-seedance-1-0-pro-250528`      | 1.0 Pro           | High quality T2V, I2V      |
-| `doubao-seedance-1-0-pro-fast-251015` | 1.0 Pro Fast      | Faster generation          |
-| `doubao-seedance-1-0-lite-t2v-250428` | 1.0 Lite T2V      | Lightweight text-to-video  |
-| `doubao-seedance-1-0-lite-i2v-250428` | 1.0 Lite I2V      | Lightweight image-to-video |
 
 ## Available Aspect Ratios
 

--- a/seedance/core/types.py
+++ b/seedance/core/types.py
@@ -7,11 +7,6 @@ SeedanceModel = Literal[
     "doubao-seedance-2-0-260128",
     "doubao-seedance-2-0-fast-260128",
     "doubao-seedance-2-0-mini-260615",
-    "doubao-seedance-1-5-pro-251215",
-    "doubao-seedance-1-0-pro-250528",
-    "doubao-seedance-1-0-pro-fast-251015",
-    "doubao-seedance-1-0-lite-t2v-250428",
-    "doubao-seedance-1-0-lite-i2v-250428",
 ]
 
 # Video aspect ratios

--- a/seedance/prompts/__init__.py
+++ b/seedance/prompts/__init__.py
@@ -39,11 +39,6 @@ When the user wants to generate video, choose the appropriate tool based on thei
 - **Latest generation quality:** `doubao-seedance-2-0-260128`
 - **Latest generation fast:** `doubao-seedance-2-0-fast-260128`
 - **Latest generation lightweight / cheapest within 2.0:** `doubao-seedance-2-0-mini-260615`
-- **1.5 flagship + audio:** `doubao-seedance-1-5-pro-251215`
-- **1.0 standard:** `doubao-seedance-1-0-pro-250528`
-- **Fastest/cheapest 1.0:** `doubao-seedance-1-0-pro-fast-251015`
-- **Lightweight T2V:** `doubao-seedance-1-0-lite-t2v-250428`
-- **Lightweight I2V:** `doubao-seedance-1-0-lite-i2v-250428`
 
 ## Checking Status
 **Tool:** `seedance_get_task`
@@ -93,12 +88,10 @@ def seedance_workflow_examples() -> str:
 
 ## Workflow 5: High Quality with Audio
 1. User wants premium video with sound
-2. Call `seedance_generate_video(prompt="...", model="doubao-seedance-1-5-pro-251215", generate_audio=true, resolution="1080p")`
 3. Return task_id and video URL
 
 ## Workflow 6: Budget-Friendly Generation
 1. User wants cheap/fast results
-2. Call `seedance_generate_video(prompt="...", model="doubao-seedance-1-0-pro-fast-251015", service_tier="flex", resolution="480p")`
 3. Return task_id and video URL
 
 ## Workflow 7: Mobile-First Content

--- a/seedance/tests/test_integration.py
+++ b/seedance/tests/test_integration.py
@@ -42,7 +42,7 @@ class TestVideoTools:
 
         result = await seedance_generate_video(
             prompt="A simple test video, blue sky with clouds",
-            model="doubao-seedance-1-0-pro-fast-251015",
+            model="doubao-seedance-2-0-fast-260128",
             resolution="480p",
             duration=2,
         )
@@ -67,9 +67,9 @@ class TestInfoTools:
         print("\n=== List Models Result ===")
         print(result)
 
-        assert "doubao-seedance-1-5-pro-251215" in result
-        assert "doubao-seedance-1-0-pro-250528" in result
-        assert "doubao-seedance-1-0-pro-fast-251015" in result
+        assert "doubao-seedance-2-0-260128" in result
+        assert "doubao-seedance-2-0-fast-260128" in result
+        assert "doubao-seedance-2-0-mini-260615" in result
 
     @pytest.mark.asyncio
     async def test_list_resolutions(self) -> None:
@@ -115,7 +115,7 @@ class TestTaskTools:
         # Generate a video first
         gen_result = await seedance_generate_video(
             prompt="A simple test video",
-            model="doubao-seedance-1-0-pro-fast-251015",
+            model="doubao-seedance-2-0-fast-260128",
             resolution="480p",
             duration=2,
         )

--- a/seedance/tools/info_tools.py
+++ b/seedance/tools/info_tools.py
@@ -21,21 +21,11 @@ async def seedance_list_models() -> str:
 | doubao-seedance-2-0-260128 | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (default) | Yes | ~$0.146 |
 | doubao-seedance-2-0-fast-260128 | 2.0 Fast | Latest generation, faster, up to 720p | Yes | ~$0.117 |
 | doubao-seedance-2-0-mini-260615 | 2.0 Mini | Latest generation, lightweight, cheapest within 2.0, up to 720p | Yes | ~$0.073 |
-| doubao-seedance-1-5-pro-251215 | Flagship | 1.5, high quality, audio support | Yes | ~$0.025 |
-| doubao-seedance-1-0-pro-250528 | Standard | Balanced quality and speed | No | ~$0.049 |
-| doubao-seedance-1-0-pro-fast-251015 | Fast | Cost-optimized, faster generation | No | ~$0.014 |
-| doubao-seedance-1-0-lite-t2v-250428 | Lite T2V | Lightweight text-to-video | No | ~$0.033 |
-| doubao-seedance-1-0-lite-i2v-250428 | Lite I2V | Lightweight image-to-video | No | ~$0.033 |
 
 Model Selection Guide:
 - Latest quality / default: doubao-seedance-2-0-260128 (up to 4k, multimodal reference)
 - Latest fast: doubao-seedance-2-0-fast-260128
 - Latest lightweight / cheapest within 2.0: doubao-seedance-2-0-mini-260615
-- 1.5 flagship (audio): doubao-seedance-1-5-pro-251215
-- 1.0 standard: doubao-seedance-1-0-pro-250528
-- Fastest/cheapest 1.0: doubao-seedance-1-0-pro-fast-251015
-- Text-only lightweight: doubao-seedance-1-0-lite-t2v-250428
-- Image-to-video lightweight: doubao-seedance-1-0-lite-i2v-250428
 
 Notes:
 - Audio generation (generate_audio) is supported by the 1.5 Pro and 2.0 series models

--- a/seedance/tools/video_tools.py
+++ b/seedance/tools/video_tools.py
@@ -39,16 +39,11 @@ async def seedance_generate_video(
         Field(
             description=(
                 "Model version to use. Options: "
-                "'doubao-seedance-2-0-260128' (latest generation, highest quality, "
-                "supports 4k and multimodal reference, default), "
-                "'doubao-seedance-2-0-fast-260128' (latest generation, faster, up to 720p), "
-                "'doubao-seedance-2-0-mini-260615' (latest generation, lightweight, "
-                "cheapest within the 2.0 series, up to 720p), "
-                "'doubao-seedance-1-5-pro-251215' (1.5 flagship, supports audio), "
-                "'doubao-seedance-1-0-pro-250528' (1.0 standard), "
-                "'doubao-seedance-1-0-pro-fast-251015' (1.0 fast, cost-optimized), "
-                "'doubao-seedance-1-0-lite-t2v-250428' (lightweight text-to-video), "
-                "'doubao-seedance-1-0-lite-i2v-250428' (lightweight image-to-video)."
+                "'doubao-seedance-2-0-260128' (highest quality, supports 4k and "
+                "multimodal reference, default), "
+                "'doubao-seedance-2-0-fast-260128' (faster, up to 720p), "
+                "'doubao-seedance-2-0-mini-260615' (lightweight, cheapest within 2.0, "
+                "up to 720p)."
             )
         ),
     ] = DEFAULT_MODEL,
@@ -98,8 +93,7 @@ async def seedance_generate_video(
         Field(
             description=(
                 "If true, generate audio along with the video. "
-                "Supported by 'doubao-seedance-1-5-pro-251215' and the "
-                "'doubao-seedance-2-0' series; other models ignore it. "
+                "Supported by the 'doubao-seedance-2-0' series; other models ignore it. "
                 "Approximately doubles the cost. Default is false."
             )
         ),
@@ -277,8 +271,7 @@ async def seedance_generate_video_from_image(
                 "Model version to use. "
                 "Use 'doubao-seedance-2-0-260128' (default) for latest-generation quality "
                 "and multimodal reference, 'doubao-seedance-2-0-fast-260128' or "
-                "'doubao-seedance-2-0-mini-260615' for faster/cheaper 2.0, or a 1.x model "
-                "such as 'doubao-seedance-1-0-lite-i2v-250428' for lightweight I2V."
+                "'doubao-seedance-2-0-mini-260615' for faster/cheaper 2.0."
             )
         ),
     ] = DEFAULT_MODEL,
@@ -321,8 +314,7 @@ async def seedance_generate_video_from_image(
         bool,
         Field(
             description=(
-                "If true, generate audio. Supported by 'doubao-seedance-1-5-pro-251215' "
-                "and the 'doubao-seedance-2-0' series. Default is false."
+                "If true, generate audio. Supported by the 'doubao-seedance-2-0' series. Default is false."
             )
         ),
     ] = False,


### PR DESCRIPTION
Follow-up: live worker rejects Seedance 1.x; remove them from the advertised model lists/docs to match the OpenAPI which is now 2.0-only. Bot + 2.0 tests pass.