### PR TITLE
feat(webextrator): MCP deploy manifests for hosting

### DIFF
--- a/webextrator/deploy/production/deployment.yaml
+++ b/webextrator/deploy/production/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mcp-webextrator
+  name: mcp-webextrator
+  namespace: acedatacloud
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: mcp-webextrator
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: mcp-webextrator
+    spec:
+      containers:
+        - name: mcp-webextrator
+          image: ghcr.io/acedatacloud/mcp-webextrator:${TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MCP_SERVER_URL
+              value: "https://webextrator.mcp.acedata.cloud"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 30m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/webextrator/deploy/production/ingress.yaml
+++ b/webextrator/deploy/production/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-webextrator
+  namespace: acedatacloud
+  labels:
+    app: mcp-webextrator
+  annotations:
+    kubernetes.io/ingress.class: "nginx-router"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+spec:
+  ingressClassName: nginx-router
+  tls:
+    - hosts:
+        - webextrator.mcp.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: webextrator.mcp.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-webextrator
+                port:
+                  number: 8000

--- a/webextrator/deploy/production/service.yaml
+++ b/webextrator/deploy/production/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mcp-webextrator
+  name: mcp-webextrator
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: mcp-webextrator


### PR DESCRIPTION
P0: webextrator MCP 此前无部署清单/无镜像(/health=000)。补 deployment/service/ingress(mirror shorturl, webextrator.mcp.acedata.cloud, nginx-router, tls-wildcard)。镜像 build+apply 为后续步骤。