### PR TITLE
ci: weekly cron to refresh all MCP package CalVer

### DIFF
--- a/.github/workflows/sync-to-repos.yml
+++ b/.github/workflows/sync-to-repos.yml
@@ -3,6 +3,9 @@ name: Sync to Sub-Repos
 on:
   push:
     branches: [main]
+  schedule:
+    # Weekly full re-sync (Monday 03:00 UTC) → refresh every package's CalVer
+    - cron: '0 3 * * 1'
   workflow_dispatch:
     inputs:
       sync_all:
@@ -26,6 +29,11 @@ jobs:
         id: changes
         run: |
           SYNC_ALL="${{ github.event.inputs.sync_all }}"
+
+          # Scheduled runs always do a full re-sync (no code change to detect).
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            SYNC_ALL="true"
+          fi
 
           # Read sync.yaml to get mapping keys
           DIRS=$(grep -E '^\s+\w+:$' sync.yaml | sed 's/://;s/^\s*//' | grep -v '^repo$\|^exclude$\|^mappings$')


### PR DESCRIPTION
## Goal
CalVer publish only fires when a server subdir changes, so untouched packages stall. Add a weekly cron that forces a full re-sync of every server to its subrepo (each subrepo's publish.yml then mints a fresh CalVer) — no code change needed.

## Change (only sync-to-repos.yml)
- Add `schedule` trigger: cron `0 3 * * 1` (Mon 03:00 UTC).
- Detect-changes step: if `github.event_name == schedule` → force `SYNC_ALL=true`, taking the existing all-dirs matrix branch.
- push / manual workflow_dispatch behavior unchanged.

## 🤖 对抗评审
VERDICT: CLEAN — trivial CI trigger. Schedule cron runs only on default branch; forces full sync without touching push/manual paths; valid YAML.