### PR TITLE
deploy: add hosted aichat glm openai MCPs

### DIFF
--- a/aichat/.github/workflows/deploy.yaml
+++ b/aichat/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/ISSUE_TEMPLATE/**"
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Build Number
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.github_token }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+
+      - name: Get Build Number
+        run: |
+          echo $BUILD_NUMBER
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Build Docker images
+        run: docker-compose build
+
+      - name: Push Docker images
+        run: docker-compose push
+
+      - name: Deploy
+        run: sh ./deploy/run.sh

--- a/aichat/deploy/production/deployment.yaml
+++ b/aichat/deploy/production/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mcp-aichat
+  name: mcp-aichat
+  namespace: acedatacloud
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: mcp-aichat
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: mcp-aichat
+    spec:
+      containers:
+        - name: mcp-aichat
+          image: ghcr.io/acedatacloud/mcp-aichat:${TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MCP_SERVER_URL
+              value: "https://aichat.mcp.acedata.cloud"
+            - name: ACEDATACLOUD_OAUTH_CLIENT_ID
+              value: "9qTprfZDnC6_gKS6RC_gPXWIKcTx-5hHiqUJIaP8Z-4"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 30m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/aichat/deploy/production/ingress.yaml
+++ b/aichat/deploy/production/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-aichat
+  namespace: acedatacloud
+  labels:
+    app: mcp-aichat
+  annotations:
+    kubernetes.io/ingress.class: "nginx-router"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+spec:
+  ingressClassName: nginx-router
+  tls:
+    - hosts:
+        - aichat.mcp.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: aichat.mcp.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-aichat
+                port:
+                  number: 8000

--- a/aichat/deploy/production/service.yaml
+++ b/aichat/deploy/production/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mcp-aichat
+  name: mcp-aichat
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: mcp-aichat

--- a/aichat/deploy/run.sh
+++ b/aichat/deploy/run.sh
@@ -1,0 +1,3 @@
+cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/service.yaml || true
+kubectl apply -f deploy/production/ingress.yaml || true

--- a/glm/.github/workflows/deploy.yaml
+++ b/glm/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/ISSUE_TEMPLATE/**"
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Build Number
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.github_token }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+
+      - name: Get Build Number
+        run: |
+          echo $BUILD_NUMBER
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Build Docker images
+        run: docker-compose build
+
+      - name: Push Docker images
+        run: docker-compose push
+
+      - name: Deploy
+        run: sh ./deploy/run.sh

--- a/glm/deploy/production/deployment.yaml
+++ b/glm/deploy/production/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mcp-glm
+  name: mcp-glm
+  namespace: acedatacloud
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: mcp-glm
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: mcp-glm
+    spec:
+      containers:
+        - name: mcp-glm
+          image: ghcr.io/acedatacloud/mcp-glm:${TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MCP_SERVER_URL
+              value: "https://glm.mcp.acedata.cloud"
+            - name: ACEDATACLOUD_OAUTH_CLIENT_ID
+              value: "oSulSGrS9Ot4hMf61uwHoK8liLKHWFmtdbSygZxxgM0"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 30m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/glm/deploy/production/ingress.yaml
+++ b/glm/deploy/production/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-glm
+  namespace: acedatacloud
+  labels:
+    app: mcp-glm
+  annotations:
+    kubernetes.io/ingress.class: "nginx-router"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+spec:
+  ingressClassName: nginx-router
+  tls:
+    - hosts:
+        - glm.mcp.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: glm.mcp.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-glm
+                port:
+                  number: 8000

--- a/glm/deploy/production/service.yaml
+++ b/glm/deploy/production/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mcp-glm
+  name: mcp-glm
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: mcp-glm

--- a/glm/deploy/run.sh
+++ b/glm/deploy/run.sh
@@ -1,0 +1,3 @@
+cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/service.yaml || true
+kubectl apply -f deploy/production/ingress.yaml || true

--- a/openai/.github/workflows/deploy.yaml
+++ b/openai/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/ISSUE_TEMPLATE/**"
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Build Number
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.github_token }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+
+      - name: Get Build Number
+        run: |
+          echo $BUILD_NUMBER
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Build Docker images
+        run: docker-compose build
+
+      - name: Push Docker images
+        run: docker-compose push
+
+      - name: Deploy
+        run: sh ./deploy/run.sh

--- a/openai/deploy/production/deployment.yaml
+++ b/openai/deploy/production/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mcp-openai
+  name: mcp-openai
+  namespace: acedatacloud
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: mcp-openai
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: mcp-openai
+    spec:
+      containers:
+        - name: mcp-openai
+          image: ghcr.io/acedatacloud/mcp-openai:${TAG}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MCP_SERVER_URL
+              value: "https://openai.mcp.acedata.cloud"
+            - name: ACEDATACLOUD_OAUTH_CLIENT_ID
+              value: "3--DhBeAk_e7qYeNbVA7j4jNPmOPJF-NWPB3HDuVmrU"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 30m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: docker-registry
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/openai/deploy/production/ingress.yaml
+++ b/openai/deploy/production/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-openai
+  namespace: acedatacloud
+  labels:
+    app: mcp-openai
+  annotations:
+    kubernetes.io/ingress.class: "nginx-router"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+spec:
+  ingressClassName: nginx-router
+  tls:
+    - hosts:
+        - openai.mcp.acedata.cloud
+      secretName: tls-wildcard-acedata-cloud
+  rules:
+    - host: openai.mcp.acedata.cloud
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-openai
+                port:
+                  number: 8000

--- a/openai/deploy/production/service.yaml
+++ b/openai/deploy/production/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mcp-openai
+  name: mcp-openai
+  namespace: acedatacloud
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+  selector:
+    app: mcp-openai

--- a/openai/deploy/run.sh
+++ b/openai/deploy/run.sh
@@ -1,0 +1,3 @@
+cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/service.yaml || true
+kubectl apply -f deploy/production/ingress.yaml || true


### PR DESCRIPTION
## Goal
Bring the advertised hosted MCP endpoints for AiChat, GLM, and OpenAI online.

Smoke testing showed these three endpoints currently fail before MCP app code is reached:
- `https://aichat.mcp.acedata.cloud/mcp`
- `https://glm.mcp.acedata.cloud/mcp`
- `https://openai.mcp.acedata.cloud/mcp`

Observed failure: Kubernetes Ingress fake certificate + nginx 404, with no `mcp-aichat`, `mcp-glm`, or `mcp-openai` Deployment/Service/Ingress resources and no GHCR container packages.

## Change
- Add deploy workflow for `aichat`, `glm`, and `openai`.
- Add production Deployment, Service, Ingress, and `deploy/run.sh` for each server.
- Use the existing hosted MCP pattern: `nginx-router`, `tls-wildcard-acedata-cloud`, single replica, `/health` probes, GHCR image `mcp-<service>:${BUILD_NUMBER}`.
- Add production OAuth client IDs for hosted OAuth flows; direct Bearer-token clients remain supported.

## Validation
- `.vscode/mcp.json` workspace config was updated locally with all hosted MCP HTTP servers and secret prompt inputs.
- Hosted smoke test before this fix: 22 total, 19 `initialize/tools/list` OK, 3 failed (`aichat`, `glm`, `openai`).
- Tool-call smoke test before this fix: 17 no-arg safe tool calls OK, 2 skipped because no safe no-arg tool (`luma`, `nanobanana`), 3 failed (`aichat`, `glm`, `openai`).
- Verified failing hosts present Ingress fake cert and 404 even with TLS verification disabled.
- Verified no K8s resources exist for the three missing services.
- Verified no GHCR packages exist yet for `mcp-aichat`, `mcp-glm`, `mcp-openai`.
- Ran YAML parse validation for all new workflow/K8s manifests.
- Ran `git diff --check`.

## 🤖 对抗评审
Round 1: `VERDICT: RISK`
- Risk: missing `ACEDATACLOUD_OAUTH_CLIENT_ID` would break hosted OAuth/DCR login flows.
- Action: created production OAuth applications for `aichat`, `glm`, and `openai` with redirect URI `https://<service>.mcp.acedata.cloud/oauth/callback`, scopes `profile platform`, and added their public client IDs to the Deployment env.

Round 2: `VERDICT: RISK`
- Risk: `${TAG}` image placeholder may not be substituted.
  - Rebuttal: each added service includes `deploy/run.sh`, and the deploy workflow calls `sh ./deploy/run.sh`; the script substitutes `${TAG}` with `$BUILD_NUMBER` before `kubectl apply`, matching existing healthy MCP services.
- Risk: OAuth client IDs are in git.
  - Rebuttal: these are public OAuth client IDs, not secrets. The client secret generated during app creation was not printed or committed.
- Risk: DNS records unverified.
  - Rebuttal: the smoke test and TLS probe already resolved all three hostnames to the Ingress controller; the current failure is missing Ingress routing/resources, not DNS absence.
- Risk: hosted-mode docs incomplete.
  - Rebuttal: this PR restores production deployment plumbing only; READMEs and `.env.example` already document `ACEDATACLOUD_OAUTH_CLIENT_ID` in existing MCPs and can be polished separately.
- Risk: deploy manifests may not sync to standalone repos.
  - Rebuttal: `sync.yaml` excludes only `.gitbooks` for these services; `deploy/` and `.github/workflows/deploy.yaml` are included by the existing rsync path.
