### PR TITLE
feat(acedatacloud): expose backend-supported filters in MCP tools

### DIFF
--- a/acedatacloud/CHANGELOG.md
+++ b/acedatacloud/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Expose backend-supported filters that the tools previously dropped, closing
+  the gap between the MCP surface and the platform API:
+  - `acedatacloud_search_docs`: new `limit` (server caps at 30).
+  - `acedatacloud_list_docs`: new `tag`, `private` and `offset` filters.
+  - `acedatacloud_list_apis`: now uses the server-side `service` (alias or UUID)
+    filter plus a new `stage` filter, instead of paging the whole API catalog
+    client-side.
+  - `acedatacloud_list_services`: new `service_type`, `tag` and `private`
+    filters, applied server-side.
+
 ## [0.3.0] - 2026-06-29
 
 ### Added

--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -15,6 +15,7 @@ from tools.catalog_tools import (
 )
 from tools.docs_tools import (
     acedatacloud_get_doc,
+    acedatacloud_list_docs,
     acedatacloud_search_docs,
 )
 from tools.model_tools import acedatacloud_get_model, acedatacloud_list_model_catalog
@@ -81,17 +82,12 @@ async def test_get_pricing_returns_cost():
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_list_apis_trims_definition():
-    respx.get(f"{API}/services/").mock(
-        return_value=httpx.Response(
-            200, json={"count": 1, "items": [{"id": UUID, "alias": "suno"}]}
-        )
-    )
-    respx.get(f"{API}/apis/").mock(
+async def test_list_apis_uses_server_side_service_filter():
+    route = respx.get(f"{API}/apis/").mock(
         return_value=httpx.Response(
             200,
             json={
-                "count": 2,
+                "count": 1,
                 "items": [
                     {
                         "id": "api-1",
@@ -100,21 +96,18 @@ async def test_list_apis_trims_definition():
                         "definition": {"big": "blob"},
                         "cost": [],
                     },
-                    {
-                        "id": "api-2",
-                        "service_id": "other",
-                        "path": "/flux/images",
-                        "definition": {},
-                        "cost": [],
-                    },
                 ],
             },
         )
     )
-    out = json.loads(await acedatacloud_list_apis(service=UUID))
+    out = json.loads(await acedatacloud_list_apis(service=UUID, stage="Production"))
     assert out["count"] == 1
     assert out["items"][0]["path"] == "/suno/audios"
     assert "definition" not in out["items"][0]
+    # The service+stage filters are pushed to the server, not paged client-side.
+    params = route.calls[0].request.url.params
+    assert params["service"] == UUID
+    assert params["stage"] == "Production"
 
 
 @respx.mock
@@ -150,9 +143,31 @@ async def test_search_docs_uses_query_param():
             200, json={"query": "suno", "lang": "en", "results": [{"alias": "x"}]}
         )
     )
-    out = json.loads(await acedatacloud_search_docs(query="suno", lang="en"))
+    out = json.loads(await acedatacloud_search_docs(query="suno", lang="en", limit=5))
     assert out["results"][0]["alias"] == "x"
-    assert route.calls[0].request.url.params["query"] == "suno"
+    params = route.calls[0].request.url.params
+    assert params["query"] == "suno"
+    assert params["limit"] == "5"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_docs_passes_tag_and_private_filters():
+    route = respx.get(f"{API}/documents/").mock(
+        return_value=httpx.Response(
+            200,
+            json={"count": 1, "items": [{"id": UUID, "alias": "app-doc", "content": "x" * 500}]},
+        )
+    )
+    out = json.loads(await acedatacloud_list_docs(tag="application", private=False, offset=10))
+    assert out["count"] == 1
+    # Long content is trimmed to a preview in the browse view.
+    assert "content" not in out["items"][0]
+    assert len(out["items"][0]["content_preview"]) == 200
+    params = route.calls[0].request.url.params
+    assert params["tag"] == "application"
+    assert params["private"] == "false"
+    assert params["offset"] == "10"
 
 
 @pytest.mark.asyncio

--- a/acedatacloud/tools/catalog_tools.py
+++ b/acedatacloud/tools/catalog_tools.py
@@ -101,39 +101,21 @@ async def acedatacloud_list_apis(
         str | None,
         Field(description="Optional service UUID or alias to filter the APIs by."),
     ] = None,
+    stage: Annotated[
+        str | None,
+        Field(description="Optional publication stage filter: Alpha/Beta/Production."),
+    ] = None,
     limit: Annotated[int, Field(description="Max APIs to return.", ge=1, le=100)] = 50,
 ) -> str:
-    """List API endpoints, optionally scoped to one service. Each item carries the
-    path, method, stage and billing ``cost``. No token required.
+    """List API endpoints, optionally scoped to one ``service`` and/or ``stage``.
+    Each item carries the path, method, stage and billing ``cost``. No token required.
     """
     try:
-        if service:
-            svc = await _resolve_service(service)
-            if not svc:
-                return error_json("Not Found", f"No service matched '{service}'.")
-            sid = svc.get("id")
-            # The /apis/?service_id= filter is not honored server-side, so collect
-            # and filter client-side by paging through the catalog.
-            collected: list[dict[str, Any]] = []
-            offset = 0
-            while offset < 2000 and len(collected) < limit:
-                result = await client.get_public("/apis/", {"limit": 50, "offset": offset})
-                page: list[dict[str, Any]] = (
-                    result.get("items", []) if isinstance(result, dict) else []
-                )
-                if not page:
-                    break
-                for it in page:
-                    if it.get("service_id") == sid:
-                        collected.append({k: v for k, v in it.items() if k != "definition"})
-                        if len(collected) >= limit:
-                            break
-                count = result.get("count", 0) if isinstance(result, dict) else 0
-                offset += 50
-                if offset >= count:
-                    break
-            return dumps({"count": len(collected), "items": collected})
-        result = await client.get_public("/apis/", {"limit": limit})
+        # The backend `/apis/` list honors `service` (alias or UUID) and `stage`
+        # server-side, so filter there instead of paging the whole catalog.
+        result = await client.get_public(
+            "/apis/", {"limit": limit, "service": service, "stage": stage}
+        )
         if not isinstance(result, dict):
             return error_json("No Response", "The API returned an empty response.")
         # Trim the OpenAPI blob from list view to keep output compact.

--- a/acedatacloud/tools/docs_tools.py
+++ b/acedatacloud/tools/docs_tools.py
@@ -40,9 +40,7 @@ async def acedatacloud_search_docs(
     ``acedatacloud_list_docs`` (e.g. ``tag='application'``, ``private=False``).
     """
     try:
-        result = await client.get_public(
-            "/search/", {"query": query, "lang": lang, "limit": limit}
-        )
+        result = await client.get_public("/search/", {"query": query, "lang": lang, "limit": limit})
         if not isinstance(result, dict):
             return error_json("No Response", "The API returned an empty response.")
         return dumps(result)
@@ -60,11 +58,15 @@ async def acedatacloud_list_docs(
     ] = None,
     tag: Annotated[
         str | None,
-        Field(description="Optional tag filter, e.g. 'application'. Matches docs carrying this tag."),
+        Field(
+            description="Optional tag filter, e.g. 'application'. Matches docs carrying this tag."
+        ),
     ] = None,
     private: Annotated[
         bool | None,
-        Field(description="Filter by privacy: False = public only, True = private only, unset = all."),
+        Field(
+            description="Filter by privacy: False = public only, True = private only, unset = all."
+        ),
     ] = None,
     offset: Annotated[int, Field(description="Pagination offset.", ge=0)] = 0,
     limit: Annotated[int, Field(description="Max documents to return.", ge=1, le=100)] = 30,

--- a/acedatacloud/tools/docs_tools.py
+++ b/acedatacloud/tools/docs_tools.py
@@ -28,12 +28,21 @@ async def acedatacloud_search_docs(
         str | None,
         Field(description="Optional language code, e.g. 'en', 'zh-cn', 'ja'."),
     ] = None,
+    limit: Annotated[
+        int, Field(description="Max results to return (server caps at 30).", ge=1, le=30)
+    ] = 10,
 ) -> str:
     """Full-text search the AceDataCloud documentation. Returns matching docs with
     alias, title, snippet and url. No token required.
+
+    This is content-relevance search over *public* docs only; it does not accept
+    structural filters. To filter by tag / type / privacy, use
+    ``acedatacloud_list_docs`` (e.g. ``tag='application'``, ``private=False``).
     """
     try:
-        result = await client.get_public("/search/", {"query": query, "lang": lang})
+        result = await client.get_public(
+            "/search/", {"query": query, "lang": lang, "limit": limit}
+        )
         if not isinstance(result, dict):
             return error_json("No Response", "The API returned an empty response.")
         return dumps(result)
@@ -49,13 +58,32 @@ async def acedatacloud_list_docs(
         str | None,
         Field(description="Optional document type filter, e.g. 'Text'."),
     ] = None,
+    tag: Annotated[
+        str | None,
+        Field(description="Optional tag filter, e.g. 'application'. Matches docs carrying this tag."),
+    ] = None,
+    private: Annotated[
+        bool | None,
+        Field(description="Filter by privacy: False = public only, True = private only, unset = all."),
+    ] = None,
+    offset: Annotated[int, Field(description="Pagination offset.", ge=0)] = 0,
     limit: Annotated[int, Field(description="Max documents to return.", ge=1, le=100)] = 30,
 ) -> str:
-    """Browse documentation pages (newest/ranked). For finding a specific topic,
-    prefer ``acedatacloud_search_docs``. No token required.
+    """Browse documentation pages (newest/ranked), optionally filtered by ``doc_type``,
+    ``tag`` and ``private``. For content-relevance search prefer
+    ``acedatacloud_search_docs``. No token required.
     """
     try:
-        result = await client.get_public("/documents/", {"limit": limit, "type": doc_type})
+        result = await client.get_public(
+            "/documents/",
+            {
+                "limit": limit,
+                "offset": offset,
+                "type": doc_type,
+                "tag": tag,
+                "private": None if private is None else str(private).lower(),
+            },
+        )
         if not isinstance(result, dict):
             return error_json("No Response", "The API returned an empty response.")
         # Trim long content in the browse view; use get_doc for full content.

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -33,6 +33,15 @@ async def acedatacloud_list_services(
             description="Optional case-insensitive substring to match against service alias or title."
         ),
     ] = None,
+    service_type: Annotated[
+        str | None,
+        Field(description="Filter by type: Api/Proxy/Integration/Dataset/Introduction/Agent."),
+    ] = None,
+    tag: Annotated[str | None, Field(description="Filter by tag, e.g. 'application'.")] = None,
+    private: Annotated[
+        bool | None,
+        Field(description="Filter by privacy: False = public only, True = private only, unset = all."),
+    ] = None,
     limit: Annotated[
         int, Field(description="Max services to return when not searching.", ge=1, le=300)
     ] = 100,
@@ -40,11 +49,17 @@ async def acedatacloud_list_services(
     """List the services available on the AceDataCloud platform.
 
     A *service* is a product (e.g. ``suno``, ``midjourney``) you can subscribe to.
-    Use ``search`` to find one by alias/title. Returns count + items.
+    ``search`` finds one by alias/title (client-side); ``service_type``, ``tag`` and
+    ``private`` are applied server-side. Returns count + items.
     """
     try:
+        server_filters = {
+            "type": service_type,
+            "tag": tag,
+            "private": None if private is None else str(private).lower(),
+        }
         if search:
-            result = await client.get("/services/", {"limit": 300})
+            result = await client.get("/services/", {"limit": 300, **server_filters})
             items = result.get("items", []) if isinstance(result, dict) else []
             s = search.lower()
             items = [
@@ -53,7 +68,7 @@ async def acedatacloud_list_services(
                 if s in (it.get("alias") or "").lower() or s in (it.get("title") or "").lower()
             ]
             return dumps({"count": len(items), "items": items})
-        result = await client.get("/services/", {"limit": limit})
+        result = await client.get("/services/", {"limit": limit, **server_filters})
         return _wrap(result)
     except PlatformAuthError as e:
         return error_json("Authentication Error", e.message)

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -40,7 +40,9 @@ async def acedatacloud_list_services(
     tag: Annotated[str | None, Field(description="Filter by tag, e.g. 'application'.")] = None,
     private: Annotated[
         bool | None,
-        Field(description="Filter by privacy: False = public only, True = private only, unset = all."),
+        Field(
+            description="Filter by privacy: False = public only, True = private only, unset = all."
+        ),
     ] = None,
     limit: Annotated[
         int, Field(description="Max services to return when not searching.", ge=1, le=300)


### PR DESCRIPTION
## What

The AceDataCloud MCP tools were dropping several query filters that the platform
backend actually supports, so callers couldn't reproduce common console queries
(e.g. "docs tagged `application`, non-private"). Benchmarked every changed tool
against its backend list view and wired the missing params through.

| Tool | Added | Backend source |
|---|---|---|
| `acedatacloud_search_docs` | `limit` (caps at 30) | `app/views/search.py` (`clamp_limit`) |
| `acedatacloud_list_docs` | `tag`, `private`, `offset` | `app/views/document.py` `get_queryset` (id/private/type/tag) |
| `acedatacloud_list_apis` | server-side `service` (alias/uuid) + `stage` | `app/views/api.py` `get_queryset` (path/service/stage) |
| `acedatacloud_list_services` | `service_type`, `tag`, `private` | `app/views/service.py` `get_queryset` (id/type/private/tag) |

### Notable fix

`list_apis` previously believed `?service_id=` wasn't honored server-side and
paged the **entire** `/apis/` catalog (up to 2000 rows) to filter client-side.
The backend does honor `?service=<alias-or-uuid>`, so this now pushes the filter
(plus `stage`) to the server in a single request.

## Notes

- Booleans are serialized as `"true"/"false"` to match the backend's
  `private.lower() == "true"` parsing; the HTTP client drops `None` params.
- `search_docs` stays content-relevance only (public, non-private by design);
  its docstring now points at `list_docs` for structural tag/private filtering.

## Verification

- `pytest tests/` → **43 passed** (added coverage for the new params + rewrote
  the `list_apis` test to assert server-side `service`/`stage` params).
- `ruff check` clean, `mypy` clean.

## 🤖 对抗评审

codex `exec --sandbox read-only` reviewed the staged diff (param-name parity vs
backend, boolean serialization, the client-side→server-side `list_apis` switch,
injection, test integrity). **VERDICT: CLEAN** (1 round).
