### PR TITLE
fix(mcp-registry): add mcp-name ownership comment to 6 MCP READMEs

### DIFF
--- a/aichat/README.md
+++ b/aichat/README.md
@@ -1,5 +1,7 @@
 # MCP AiChat Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-aichat -->
+
 A Model Context Protocol (MCP) server for AI dialogue via the AceDataCloud platform.
 Supports a wide range of models including GPT-4/5, o-series, DeepSeek, Grok, and GLM.
 

--- a/face/README.md
+++ b/face/README.md
@@ -1,5 +1,7 @@
 # MCP Face Transform Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-face-transform -->
+
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that
 exposes the AceDataCloud Face Transform API — face keypoint detection,
 beautification, age/gender transform, face swap, cartoonization, and liveness

--- a/fish/README.md
+++ b/fish/README.md
@@ -1,5 +1,7 @@
 # MCP Fish Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-fish -->
+
 A Model Context Protocol (MCP) server for Fish Audio TTS (Text-to-Speech) via the AceDataCloud platform.
 Generate natural-sounding speech and explore the Fish voice model library.
 

--- a/glm/README.md
+++ b/glm/README.md
@@ -1,5 +1,7 @@
 # MCP GLM Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-glm -->
+
 A Model Context Protocol (MCP) server for Zhipu GLM chat completions via the AceDataCloud platform.
 
 ## Features

--- a/grok/README.md
+++ b/grok/README.md
@@ -1,5 +1,7 @@
 # GrokMCP
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-grok -->
+
 [![PyPI version](https://img.shields.io/pypi/v/mcp-grok.svg)](https://pypi.org/project/mcp-grok/)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/webextrator/README.md
+++ b/webextrator/README.md
@@ -1,5 +1,7 @@
 # MCP WebExtrator Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-webextrator -->
+
 A Model Context Protocol (MCP) server for web rendering and structured content extraction
 via the AceDataCloud WebExtrator platform.
 


### PR DESCRIPTION
Adds the `mcp-name: io.github.AceDataCloud/<pypi-name>` HTML comment to the top of 6 MCP READMEs so `mcp-publisher publish` no longer rejects them at MCP Registry ownership validation.

## Background

The [MCP Registry](https://registry.modelcontextprotocol.io) requires each published server's PyPI package README to contain a line like:

    mcp-name: io.github.<owner>/<pypi-package-name>

as proof of ownership. Without it, `mcp-publisher publish` fails with:

    registry validation failed for package 0 (mcp-<name>):
    PyPI package '<name>' ownership validation failed.
    The server name 'io.github.AceDataCloud/<name>' must appear as
    'mcp-name: io.github.AceDataCloud/<name>' in the package README

This comment was already present in 15 of 22 MCP subdirs (`acedatacloud`, `wan`, `suno`, `luma`, `flux`, `serp`, `seedream`, `hailuo`, `kling`, `sora`, `veo`, `shorturl`, `nanobanana`, `seedance`, `producer`). This PR adds it to the remaining 6:

| Subdir | mcp-name value |
|---|---|
| `aichat` | `io.github.AceDataCloud/mcp-aichat` |
| `face` | `io.github.AceDataCloud/mcp-face-transform` |
| `fish` | `io.github.AceDataCloud/mcp-fish` |
| `glm` | `io.github.AceDataCloud/mcp-glm` |
| `grok` | `io.github.AceDataCloud/mcp-grok` |
| `webextrator` | `io.github.AceDataCloud/mcp-webextrator` |

Each `mcp-name` matches that subdir's `pyproject.toml` `name` field exactly.

## Out of scope

- **`openai`** is intentionally *not* included. `mcp-openai` on PyPI is owned by a different user (`S1M0N38`), so `twine upload` 403s before `Publish to MCP Registry` ever runs — adding an `mcp-name` line here would be dead code. That subdir needs a **PyPI package rename** first (separate PR / decision).
- **JetBrains publish failures** (`VeoMCP`, `FaceTransformMCP`, `FishMCP`) — `Failed to upload plugin: Unfortunately, you don't have sufficient permissions`. The plugin ID needs to be pre-registered on the JetBrains Marketplace vendor account. Separate action.
- **VS Code publish transient `ECONNRESET`** (`FluxMCP`, `LumaMCP`) — Visual Studio Marketplace query flake; simple re-run fixes it. Already retried.

## Verification

After merge → `sync-to-repos.yml` fires → each of the 6 downstream repos gets a push → each downstream's `publish.yml` fires → `Publish to MCP Registry` step passes for all 6.

## 🤖 对抗评审

Round 1 — Reviewer (Explore subagent, read-only): flagged 1 RISK.

- **RISK: `openai/README.md` also missing.** → **Rebutted.** The `openai` failure has a different root cause (PyPI 403, package name owned by another user). `Publish to MCP Registry` is gated on `needs: publish-pypi` and shows `skipped` — never reads the README. Adding a `mcp-name` line for `mcp-openai` before renaming the package is dead code, and the eventual line has to match the new (renamed) PyPI package. Deferred to the naming-decision PR.

Everything else: ✓ package names match `pyproject.toml`, ✓ format matches working convention (line 3, HTML comment), ✓ no README build exclusions, ✓ no line-ending anomalies.

Round 2 — no changes to re-review.

VERDICT: **CLEAN** (with the openai deferral rationale above).