### PR TITLE
fix(face,fish): add missing Gradle build scripts for JetBrains plugin

### DIFF
--- a/face/jetbrains/build.gradle.kts
+++ b/face/jetbrains/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "2.1.20"
+    id("org.jetbrains.intellij.platform") version "2.6.0"
+}
+
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
+
+kotlin {
+    jvmToolchain(21)
+}
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+    }
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+        }
+    }
+
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        channels = providers.gradleProperty("pluginVersion")
+            .map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
+}
+
+tasks {
+    wrapper {
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
+    }
+}

--- a/face/jetbrains/settings.gradle.kts
+++ b/face/jetbrains/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "mcp-plugin"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}

--- a/fish/jetbrains/build.gradle.kts
+++ b/fish/jetbrains/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "2.1.20"
+    id("org.jetbrains.intellij.platform") version "2.6.0"
+}
+
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
+
+kotlin {
+    jvmToolchain(21)
+}
+
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
+}
+
+dependencies {
+    intellijPlatform {
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+    }
+}
+
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+        }
+    }
+
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
+        channels = providers.gradleProperty("pluginVersion")
+            .map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
+}
+
+tasks {
+    wrapper {
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
+    }
+}

--- a/fish/jetbrains/settings.gradle.kts
+++ b/fish/jetbrains/settings.gradle.kts
@@ -1,0 +1,5 @@
+rootProject.name = "mcp-plugin"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}


### PR DESCRIPTION
## Fix

`face/jetbrains/` and `fish/jetbrains/` were missing `build.gradle.kts` and `settings.gradle.kts`. Without them, Gradle assumes an uninitialised directory and runs the `init` task, which exits 1 immediately:

    FAILURE: Build failed with an exception.
    For more information about the 'init' task, please refer to
    https://docs.gradle.org/8.12/userguide/build_init_plugin.html
    BUILD FAILED in 6s

Both files are copied **verbatim** from `luma/jetbrains/` (which builds cleanly). They only reference generic properties from `gradle.properties` (`pluginGroup`, `pluginName`, `pluginVersion`, `platformType`, `platformVersion`, etc.), so no per-repo substitution is needed — each repo's own `gradle.properties` already has the correct plugin ID (`com.acedatacloud.mcp.face` / `com.acedatacloud.mcp.fish`) and name.

## Impact

After merge → sync-to-repos fires → `FaceTransformMCP` and `FishMCP` Gradle builds will succeed.

Note: `publishPlugin` will then still fail with `Unfortunately, you don't have sufficient permissions` because the plugin IDs have never been uploaded to JetBrains Marketplace under our vendor account. That first-time seeding will be handled separately (via manual upload).

## 🤖 对抗评审

Reviewer scope: copying two existing generic Gradle files from a working sibling.

- ✓ Both files diffed byte-for-byte against `luma/jetbrains/*` — identical.
- ✓ Target `gradle.properties` files already contain the correct `pluginGroup`, `pluginName`, and `pluginVersion` for each repo.
- ✓ No hardcoded `luma` reference anywhere in the copied files.
- ✓ Sync-to-repos rsync will pick up the two new files into the downstream repos without touching anything else.

VERDICT: **CLEAN**.