### PR TITLE
fix(vscode): replace retired shields.io VS Code Marketplace badge

### DIFF
--- a/acedatacloud/vscode/README.md
+++ b/acedatacloud/vscode/README.md
@@ -2,7 +2,7 @@
 
 Manage your Ace Data Cloud account — balance, usage, API keys, orders, and tokens.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-acedatacloud?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-acedatacloud) [![PyPI](https://img.shields.io/pypi/v/mcp-acedatacloud.svg?label=PyPI)](https://pypi.org/project/mcp-acedatacloud/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-acedatacloud) [![PyPI](https://img.shields.io/pypi/v/mcp-acedatacloud.svg?label=PyPI)](https://pypi.org/project/mcp-acedatacloud/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://mcp.acedata.cloud/mcp)
 
 Connect VS Code's AI agents to the Ace Data Cloud platform console. Check your balance, look up usage and spend, manage API keys and platform tokens, list services and models, and create or pay recharge orders — all from chat.
 

--- a/aichat/vscode/README.md
+++ b/aichat/vscode/README.md
@@ -2,7 +2,7 @@
 
 Unified OpenAI-compatible LLM gateway — chat with GPT, Claude, Gemini, Grok, DeepSeek, Kimi and more via a single endpoint.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-aichat?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-aichat) [![PyPI](https://img.shields.io/pypi/v/mcp-aichat.svg?label=PyPI)](https://pypi.org/project/mcp-aichat/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://aichat.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-aichat) [![PyPI](https://img.shields.io/pypi/v/mcp-aichat.svg?label=PyPI)](https://pypi.org/project/mcp-aichat/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://aichat.mcp.acedata.cloud/mcp)
 
 Connect VS Code's AI agents to the **Unified LLM gateway via Ace Data Cloud** service. Once configured, AI Assistant can chat with 50+ LLM models — GPT, Claude, Gemini, Grok, DeepSeek and more — through a single endpoint.
 

--- a/face/vscode/README.md
+++ b/face/vscode/README.md
@@ -2,7 +2,7 @@
 
 Face analysis and transforms — keypoints, beautify, age/gender, swap, cartoon, liveness. (Alpha)
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-face-transform?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-face-transform) [![PyPI](https://img.shields.io/pypi/v/mcp-face-transform.svg?label=PyPI)](https://pypi.org/project/mcp-face-transform/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://face.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-face-transform) [![PyPI](https://img.shields.io/pypi/v/mcp-face-transform.svg?label=PyPI)](https://pypi.org/project/mcp-face-transform/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://face.mcp.acedata.cloud/mcp)
 
 Bring AceDataCloud's Face Transform APIs into Copilot Chat. Detect 90+ keypoints per face, beautify portraits, age or de-age, swap perceived gender, face-swap between photos, cartoonize, and detect liveness.
 

--- a/fish/vscode/README.md
+++ b/fish/vscode/README.md
@@ -2,7 +2,7 @@
 
 Fish Audio TTS — generate natural speech and browse the Fish voice library.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-fish?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-fish) [![PyPI](https://img.shields.io/pypi/v/mcp-fish.svg?label=PyPI)](https://pypi.org/project/mcp-fish/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://fish.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-fish) [![PyPI](https://img.shields.io/pypi/v/mcp-fish.svg?label=PyPI)](https://pypi.org/project/mcp-fish/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://fish.mcp.acedata.cloud/mcp)
 
 Generate natural-sounding speech from text using Fish Audio voices via Ace Data Cloud. Browse and search the voice library, fetch model metadata, submit asynchronous generation tasks, and poll single or batched results.
 

--- a/flux/vscode/README.md
+++ b/flux/vscode/README.md
@@ -2,7 +2,7 @@
 
 Flux image generation by Black Forest Labs — dev, pro, ultra, and kontext editing.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-flux?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-flux) [![PyPI](https://img.shields.io/pypi/v/mcp-flux-pro.svg?label=PyPI)](https://pypi.org/project/mcp-flux-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://flux.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-flux) [![PyPI](https://img.shields.io/pypi/v/mcp-flux-pro.svg?label=PyPI)](https://pypi.org/project/mcp-flux-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://flux.mcp.acedata.cloud/mcp)
 
 Generate high-fidelity images with Flux from VS Code chat, or edit existing images via natural-language instructions using Flux Kontext.
 

--- a/grok/vscode/README.md
+++ b/grok/vscode/README.md
@@ -2,7 +2,7 @@
 
 Google Grok video generation — Grok 2, Grok 3, Grok 3.1 (incl. fast variants and upscale).
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-grok?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-grok) [![PyPI](https://img.shields.io/pypi/v/mcp-grok.svg?label=PyPI)](https://pypi.org/project/mcp-grok/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://grok.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-grok) [![PyPI](https://img.shields.io/pypi/v/mcp-grok.svg?label=PyPI)](https://pypi.org/project/mcp-grok/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://grok.mcp.acedata.cloud/mcp)
 
 Generate AI video with Google Grok from text or images, including high-quality Grok 3.1 and the fast variants. Supports 1080p upscale.
 

--- a/hailuo/vscode/README.md
+++ b/hailuo/vscode/README.md
@@ -2,7 +2,7 @@
 
 Hailuo (MiniMax) AI video — text-to-video and image-to-video with director mode.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-hailuo?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-hailuo) [![PyPI](https://img.shields.io/pypi/v/mcp-hailuo.svg?label=PyPI)](https://pypi.org/project/mcp-hailuo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://hailuo.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-hailuo) [![PyPI](https://img.shields.io/pypi/v/mcp-hailuo.svg?label=PyPI)](https://pypi.org/project/mcp-hailuo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://hailuo.mcp.acedata.cloud/mcp)
 
 Generate AI video using MiniMax Hailuo. Includes director-mode camera control for precise framing.
 

--- a/kling/vscode/README.md
+++ b/kling/vscode/README.md
@@ -2,7 +2,7 @@
 
 Kuaishou Kling video generation — text-to-video, image-to-video, extend, motion.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-kling?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-kling) [![PyPI](https://img.shields.io/pypi/v/mcp-kling.svg?label=PyPI)](https://pypi.org/project/mcp-kling/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://kling.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-kling) [![PyPI](https://img.shields.io/pypi/v/mcp-kling.svg?label=PyPI)](https://pypi.org/project/mcp-kling/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://kling.mcp.acedata.cloud/mcp)
 
 Generate Kling AI video from prompts or stills, extend existing clips, or apply motion control. Multiple model versions and quality modes.
 

--- a/luma/vscode/README.md
+++ b/luma/vscode/README.md
@@ -2,7 +2,7 @@
 
 AI video generation with Luma Dream Machine — text-to-video, image-to-video, extend.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-luma?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-luma) [![PyPI](https://img.shields.io/pypi/v/mcp-luma.svg?label=PyPI)](https://pypi.org/project/mcp-luma/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://luma.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-luma) [![PyPI](https://img.shields.io/pypi/v/mcp-luma.svg?label=PyPI)](https://pypi.org/project/mcp-luma/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://luma.mcp.acedata.cloud/mcp)
 
 Generate short cinematic videos from text or stills with Luma Dream Machine, or extend an existing clip — directly from chat.
 

--- a/nanobanana/vscode/README.md
+++ b/nanobanana/vscode/README.md
@@ -2,7 +2,7 @@
 
 Gemini-powered NanoBanana — generate and edit images via natural language.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-nanobanana?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-nanobanana) [![PyPI](https://img.shields.io/pypi/v/mcp-nanobanana-pro.svg?label=PyPI)](https://pypi.org/project/mcp-nanobanana-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://nanobanana.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-nanobanana) [![PyPI](https://img.shields.io/pypi/v/mcp-nanobanana-pro.svg?label=PyPI)](https://pypi.org/project/mcp-nanobanana-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://nanobanana.mcp.acedata.cloud/mcp)
 
 Image generation and edit-by-instruction using NanoBanana, NanoBanana 2, and NanoBanana Pro (built on Gemini).
 

--- a/openai/vscode/README.md
+++ b/openai/vscode/README.md
@@ -2,7 +2,7 @@
 
 OpenAI models via Ace Data Cloud — chat completions, embeddings, image generation and editing, Responses API, async tasks.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-openai?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-openai) [![PyPI](https://img.shields.io/pypi/v/mcp-openai.svg?label=PyPI)](https://pypi.org/project/mcp-openai/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://openai.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-openai) [![PyPI](https://img.shields.io/pypi/v/mcp-openai.svg?label=PyPI)](https://pypi.org/project/mcp-openai/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://openai.mcp.acedata.cloud/mcp)
 
 Connect VS Code's AI agents to the **OpenAI models via Ace Data Cloud** service. Once configured, AI Assistant can run OpenAI chat completions, generate embeddings, create or edit images, and orchestrate the Responses API — all routed through Ace Data Cloud.
 

--- a/producer/vscode/README.md
+++ b/producer/vscode/README.md
@@ -2,7 +2,7 @@
 
 AI music with Producer (FUZZ) — songs, lyrics, covers, vocal/instrument swap, section replace.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-producer?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-producer) [![PyPI](https://img.shields.io/pypi/v/mcp-producer.svg?label=PyPI)](https://pypi.org/project/mcp-producer/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://producer.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-producer) [![PyPI](https://img.shields.io/pypi/v/mcp-producer.svg?label=PyPI)](https://pypi.org/project/mcp-producer/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://producer.mcp.acedata.cloud/mcp)
 
 Music generation, lyric writing, song extension, covers, vocal/instrumental swap, section replace, and reference audio upload — using the Producer (FUZZ) models.
 

--- a/seedance/vscode/README.md
+++ b/seedance/vscode/README.md
@@ -2,7 +2,7 @@
 
 ByteDance Seedance — dance and motion video generation from text or image.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedance?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedance) [![PyPI](https://img.shields.io/pypi/v/mcp-seedance.svg?label=PyPI)](https://pypi.org/project/mcp-seedance/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedance.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedance) [![PyPI](https://img.shields.io/pypi/v/mcp-seedance.svg?label=PyPI)](https://pypi.org/project/mcp-seedance/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedance.mcp.acedata.cloud/mcp)
 
 Generate Seedance AI dance/motion videos. Configurable resolution, aspect ratio, duration, and optional audio.
 

--- a/seedream/vscode/README.md
+++ b/seedream/vscode/README.md
@@ -2,7 +2,7 @@
 
 Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-seedream?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
 
 High-resolution image generation and edit-by-instruction with ByteDance Seedream (3.0 / 4.0 / 4.5 / 5.0) and SeedEdit 3.0.
 

--- a/serp/vscode/README.md
+++ b/serp/vscode/README.md
@@ -2,7 +2,7 @@
 
 Google Search via Ace Data Cloud — web, images, news, maps, local, video.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-serp?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-serp) [![PyPI](https://img.shields.io/pypi/v/mcp-serp.svg?label=PyPI)](https://pypi.org/project/mcp-serp/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://serp.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-serp) [![PyPI](https://img.shields.io/pypi/v/mcp-serp.svg?label=PyPI)](https://pypi.org/project/mcp-serp/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://serp.mcp.acedata.cloud/mcp)
 
 Give Copilot live Google search results — web pages, images, news, maps, local places, and videos — with localization and time filters.
 

--- a/shorturl/vscode/README.md
+++ b/shorturl/vscode/README.md
@@ -2,7 +2,7 @@
 
 Create short URLs (surl.id) — single or batch, with custom slugs and expiration.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-shorturl?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-shorturl) [![PyPI](https://img.shields.io/pypi/v/mcp-shorturl.svg?label=PyPI)](https://pypi.org/project/mcp-shorturl/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://shorturl.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-shorturl) [![PyPI](https://img.shields.io/pypi/v/mcp-shorturl.svg?label=PyPI)](https://pypi.org/project/mcp-shorturl/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://shorturl.mcp.acedata.cloud/mcp)
 
 Shorten long URLs into surl.id links, optionally with a custom slug or expiration. Supports batch creation.
 

--- a/sora/vscode/README.md
+++ b/sora/vscode/README.md
@@ -2,7 +2,7 @@
 
 OpenAI Sora video generation — text-to-video, image-to-video, character references.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-sora?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-sora) [![PyPI](https://img.shields.io/pypi/v/mcp-sora.svg?label=PyPI)](https://pypi.org/project/mcp-sora/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://sora.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-sora) [![PyPI](https://img.shields.io/pypi/v/mcp-sora.svg?label=PyPI)](https://pypi.org/project/mcp-sora/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://sora.mcp.acedata.cloud/mcp)
 
 Generate short Sora videos from text prompts, animate stills, or carry a character reference across clips. Sora 1 and Sora 2 models supported.
 

--- a/suno/vscode/README.md
+++ b/suno/vscode/README.md
@@ -2,7 +2,7 @@
 
 AI music generation with Suno — songs, lyrics, covers, stems, and more.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-suno?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-suno) [![PyPI](https://img.shields.io/pypi/v/mcp-suno.svg?label=PyPI)](https://pypi.org/project/mcp-suno/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://suno.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-suno) [![PyPI](https://img.shields.io/pypi/v/mcp-suno.svg?label=PyPI)](https://pypi.org/project/mcp-suno/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://suno.mcp.acedata.cloud/mcp)
 
 Connect VS Code's AI agents to Suno through Ace Data Cloud. Generate songs from text prompts, write custom lyrics with full musical control, extend tracks, remix or cover, separate stems, export MP4/WAV/MIDI — all from chat.
 

--- a/veo/vscode/README.md
+++ b/veo/vscode/README.md
@@ -2,7 +2,7 @@
 
 Google Veo video generation — Veo 2, Veo 3, Veo 3.1 (incl. fast variants and upscale).
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-veo?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-veo) [![PyPI](https://img.shields.io/pypi/v/mcp-veo.svg?label=PyPI)](https://pypi.org/project/mcp-veo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://veo.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-veo) [![PyPI](https://img.shields.io/pypi/v/mcp-veo.svg?label=PyPI)](https://pypi.org/project/mcp-veo/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://veo.mcp.acedata.cloud/mcp)
 
 Generate AI video with Google Veo from text or images, including high-quality Veo 3.1 and the fast variants. Supports 1080p upscale.
 

--- a/wan/vscode/README.md
+++ b/wan/vscode/README.md
@@ -2,7 +2,7 @@
 
 Alibaba Wan video generation — text-to-video, image-to-video, reference video transfer.
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-wan?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-wan) [![PyPI](https://img.shields.io/pypi/v/mcp-wan.svg?label=PyPI)](https://pypi.org/project/mcp-wan/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://wan.mcp.acedata.cloud/mcp)
+[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-wan) [![PyPI](https://img.shields.io/pypi/v/mcp-wan.svg?label=PyPI)](https://pypi.org/project/mcp-wan/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://wan.mcp.acedata.cloud/mcp)
 
 Generate AI video with Alibaba Wan in 480P/720P/1080P, with optional audio and reference-video transfer.
 


### PR DESCRIPTION
## Problem

shields.io retired the `visual-studio-marketplace/v/*` endpoint (and its `vscode-marketplace/v/*` alias). Requests now return an SVG that literally reads:

> `visual-studio-marketplace | retired badge`

which is displayed on every one of our extension detail pages in VS Code (visible in-editor when browsing our extensions).

## Fix

All 20 `<subdir>/vscode/README.md` files updated to use a static shields.io `/badge/` URL:

    -[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/acedatacloud.mcp-...)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-...)
    +[![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-...)

The version is already shown separately in the extension header — the badge only ever needed to be a clickable link.

## Why not vsmarketplacebadges.dev?

Also down: `GET https://vsmarketplacebadges.dev/version/acedatacloud.mcp-acedatacloud.svg` → **500 Internal Server Error**. No drop-in dynamic-version alternative is available today.

## Propagation

The fix takes effect the next time each downstream extension is republished to the Marketplace. The next commit to any given subdir triggers `publish.yml` → new VSIX built with the fixed README → uploaded via `vsce publish`. This PR itself contains 20 subdirs' worth of file changes → sync-to-repos.yml will push each of the 20 downstream repos with the updated README → each triggers their own publish → all 20 extension pages update.

## 🤖 对抗评审

Reviewer scope: pure string substitution across 20 README files, single regex.

- ✓ `git diff --stat` shows exactly 20 files, 1 line each, +20/-20.
- ✓ New URL fetched HTTP 200 with a valid SVG (1318 bytes).
- ✓ Deep-link target (`marketplace.visualstudio.com/items?itemName=...`) unchanged for every file — clicking the badge still opens the correct extension page.
- ✓ Regex only matches the visual-studio-marketplace URL substring; leaves the link target and other badges (PyPI, hosted MCP) untouched.
- ✓ No other README in the monorepo uses this retired endpoint (verified via grep on `MCPs/*/README.md` — only `vscode/README.md` files had it).

VERDICT: **CLEAN**.