### PR TITLE
feat(acedatacloud MCP): marketing-material tools (search / random / by-channel / get)

### DIFF
--- a/acedatacloud/tests/test_materials.py
+++ b/acedatacloud/tests/test_materials.py
@@ -1,0 +1,112 @@
+"""Unit tests for the marketing-material tools."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from tools.materials_tools import (
+    acedatacloud_get_material,
+    acedatacloud_list_publish_channels,
+    acedatacloud_pick_random_materials,
+    acedatacloud_search_materials,
+)
+
+API = "https://platform.acedata.cloud/api/v1"
+MID = "f1c66741-a488-43ca-91fc-e53fbbda639a"
+CHAN = "a2c66741-a488-43ca-91fc-e53fbbda6300"
+
+
+def _materials(*items):
+    return httpx.Response(200, json={"count": len(items), "items": list(items)})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_search_keyword_matches_title_or_content():
+    respx.get(f"{API}/publish-materials/").mock(
+        return_value=_materials(
+            {"id": "1", "title": "AAA", "content": "nothing", "metadata": {}},
+            {"id": "2", "title": "BBB", "content": "has the keyword inside", "metadata": {}},
+        )
+    )
+    out = json.loads(await acedatacloud_search_materials(keyword="keyword"))
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == "2"
+    # preview by default, not full content
+    assert "content_preview" in out["items"][0]
+    assert "content" not in out["items"][0]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_channel_name_resolves_to_id_filter():
+    respx.get(f"{API}/publish-channels/").mock(
+        return_value=httpx.Response(
+            200, json={"count": 1, "items": [{"id": CHAN, "name": "zhihu", "title": "知乎"}]}
+        )
+    )
+    mat_route = respx.get(f"{API}/publish-materials/").mock(
+        return_value=_materials({"id": "1", "title": "T", "content": "c", "metadata": {}})
+    )
+    out = json.loads(await acedatacloud_search_materials(channel="zhihu"))
+    assert out["returned"] == 1
+    assert mat_route.calls[0].request.url.params["channel_id"] == CHAN
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_channel_no_match_returns_empty_note():
+    respx.get(f"{API}/publish-channels/").mock(
+        return_value=httpx.Response(200, json={"count": 0, "items": []})
+    )
+    out = json.loads(await acedatacloud_search_materials(channel="nonexistent"))
+    assert out["count"] == 0
+    assert "note" in out
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_pick_random_returns_full_content():
+    respx.get(f"{API}/publish-materials/").mock(
+        return_value=_materials(
+            {"id": "1", "title": "A", "content": "full one", "metadata": {}},
+            {"id": "2", "title": "B", "content": "full two", "metadata": {}},
+            {"id": "3", "title": "C", "content": "full three", "metadata": {}},
+        )
+    )
+    out = json.loads(await acedatacloud_pick_random_materials(count=2))
+    assert out["returned"] == 2
+    assert all("content" in it for it in out["items"])
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_material_by_id():
+    respx.get(f"{API}/publish-materials/{MID}/").mock(
+        return_value=httpx.Response(200, json={"id": MID, "title": "X", "content": "body"})
+    )
+    out = json.loads(await acedatacloud_get_material(material_id=MID))
+    assert out["id"] == MID
+    assert out["content"] == "body"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_publish_channels_search_filters():
+    respx.get(f"{API}/publish-channels/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 2,
+                "items": [
+                    {"id": CHAN, "name": "zhihu", "title": "知乎", "domain": "zhihu.com"},
+                    {"id": "x", "name": "medium", "title": "Medium", "domain": "medium.com"},
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_list_publish_channels(search="zhihu"))
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == CHAN

--- a/acedatacloud/tools/__init__.py
+++ b/acedatacloud/tools/__init__.py
@@ -6,6 +6,7 @@ from tools import (
     catalog_tools,
     docs_tools,
     info_tools,
+    materials_tools,
     model_tools,
     read_tools,
     write_tools,
@@ -18,5 +19,6 @@ __all__ = [
     "info_tools",
     "catalog_tools",
     "docs_tools",
+    "materials_tools",
     "model_tools",
 ]

--- a/acedatacloud/tools/materials_tools.py
+++ b/acedatacloud/tools/materials_tools.py
@@ -1,0 +1,296 @@
+"""Marketing-material tools for the AceDataCloud platform management API.
+
+Read-only access to the ``PublishMaterial`` catalog (``/publish-materials/``):
+search by keyword / language / channel / category / tags, pick random items,
+and fetch a single material's full content. Handy for pulling ready-to-post
+marketing copy into an agent workflow.
+
+The backend only filters ``title`` / ``lang`` / ``channel_id`` server-side, so
+keyword (title+content), category, tags and random selection are applied
+client-side over a generous fetch window.
+"""
+
+import random as _random
+import uuid
+from typing import Annotated, Any
+
+from pydantic import Field
+
+from core.client import client
+from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.server import mcp
+from core.utils import dumps, error_json
+
+# Upper bound on how many rows we pull before client-side filtering. Materials
+# are ordered newest-first server-side; if the catalog ever grows beyond this,
+# client-side filters/random only see the newest MAX_FETCH rows (acceptable for
+# a marketing helper).
+MAX_FETCH = 300
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+async def _resolve_channel_ids(channel: str) -> list[str]:
+    """Map a channel UUID or a name/title/domain substring to channel id(s)."""
+    if _is_uuid(channel):
+        return [channel]
+    result = await client.get("/publish-channels/", {"limit": MAX_FETCH})
+    items = result.get("items", []) if isinstance(result, dict) else []
+    needle = channel.lower()
+    return [
+        c["id"]
+        for c in items
+        if c.get("id")
+        and (
+            needle in (c.get("name") or "").lower()
+            or needle in (c.get("title") or "").lower()
+            or needle in (c.get("domain") or "").lower()
+        )
+    ]
+
+
+def _trim(material: dict[str, Any], include_content: bool) -> dict[str, Any]:
+    md = material.get("metadata") or {}
+    channels = material.get("channels") or []
+    out: dict[str, Any] = {
+        "id": material.get("id"),
+        "title": material.get("title"),
+        "lang": material.get("lang"),
+        "category": material.get("category"),
+        "tags": material.get("tags"),
+        "quality_score": md.get("quality_score"),
+        "channel_style": md.get("channel_style"),
+        "channels": [c.get("name") or c.get("title") for c in channels if isinstance(c, dict)],
+        "created_at": material.get("created_at"),
+    }
+    content = material.get("content") or ""
+    if include_content:
+        out["content"] = content
+    else:
+        out["content_preview"] = content[:200] + ("…" if len(content) > 200 else "")
+    return out
+
+
+def _match(
+    material: dict[str, Any],
+    keyword: str | None,
+    category: str | None,
+    tags: list[str] | None,
+) -> bool:
+    if keyword:
+        kw = keyword.lower()
+        title = (material.get("title") or "").lower()
+        content = (material.get("content") or "").lower()
+        if kw not in title and kw not in content:
+            return False
+    if category and category.lower() not in (material.get("category") or "").lower():
+        return False
+    if tags:
+        want = {t.lower() for t in tags}
+        have = {str(t).lower() for t in (material.get("tags") or [])}
+        if not (want & have):
+            return False
+    return True
+
+
+async def _query_materials(
+    keyword: str | None,
+    langs: list[str] | None,
+    channel: str | None,
+    channel_id: str | None,
+    category: str | None,
+    tags: list[str] | None,
+    randomize: bool,
+    include_content: bool,
+    limit: int,
+) -> dict[str, Any]:
+    # Resolve channel filter (name/substring → ids). channel_id takes precedence.
+    resolved_ids: list[str] | None = None
+    if channel_id:
+        resolved_ids = [channel_id]
+    elif channel:
+        resolved_ids = await _resolve_channel_ids(channel)
+        if not resolved_ids:
+            return {
+                "count": 0,
+                "returned": 0,
+                "items": [],
+                "note": f"No channel matched '{channel}'.",
+            }
+
+    server_params: dict[str, Any] = {"limit": MAX_FETCH}
+    if langs:
+        server_params["lang"] = langs
+    if resolved_ids:
+        server_params["channel_id"] = resolved_ids
+
+    result = await client.get("/publish-materials/", server_params)
+    items = result.get("items", []) if isinstance(result, dict) else []
+
+    matched = [m for m in items if _match(m, keyword, category, tags)]
+    total = len(matched)
+
+    if randomize:
+        _random.shuffle(matched)
+    selected = matched[: max(1, limit)]
+
+    return {
+        "count": total,
+        "returned": len(selected),
+        "items": [_trim(m, include_content) for m in selected],
+    }
+
+
+@mcp.tool()
+async def acedatacloud_list_publish_channels(
+    search: Annotated[
+        str | None,
+        Field(
+            description="Optional case-insensitive substring to match channel name/title/domain."
+        ),
+    ] = None,
+    limit: Annotated[int, Field(description="Max channels to return.", ge=1, le=300)] = 100,
+) -> str:
+    """List publish channels (Zhihu, CSDN, Medium, X, ...).
+
+    Use this to discover channel names/ids before filtering materials by channel.
+    """
+    try:
+        result = await client.get("/publish-channels/", {"limit": limit})
+        items = result.get("items", []) if isinstance(result, dict) else []
+        if search:
+            s = search.lower()
+            items = [
+                c
+                for c in items
+                if s in (c.get("name") or "").lower()
+                or s in (c.get("title") or "").lower()
+                or s in (c.get("domain") or "").lower()
+            ]
+        trimmed = [
+            {
+                "id": c.get("id"),
+                "name": c.get("name"),
+                "title": c.get("title"),
+                "domain": c.get("domain"),
+            }
+            for c in items
+        ]
+        return dumps({"count": len(trimmed), "items": trimmed})
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_search_materials(
+    keyword: Annotated[
+        str | None,
+        Field(
+            description="Case-insensitive substring matched against the material title AND content."
+        ),
+    ] = None,
+    langs: Annotated[
+        list[str] | None,
+        Field(description="Filter by one or more language codes, e.g. ['zh-cn', 'en']."),
+    ] = None,
+    channel: Annotated[
+        str | None,
+        Field(description="Channel UUID, or a name/title/domain substring (e.g. 'zhihu', 'CSDN')."),
+    ] = None,
+    channel_id: Annotated[
+        str | None, Field(description="Explicit channel UUID (takes precedence over `channel`).")
+    ] = None,
+    category: Annotated[
+        str | None,
+        Field(description="Case-insensitive substring matched against the material category."),
+    ] = None,
+    tags: Annotated[
+        list[str] | None, Field(description="Keep materials whose tags overlap any of these.")
+    ] = None,
+    randomize: Annotated[
+        bool, Field(description="Shuffle matches before returning (for random picks).")
+    ] = False,
+    include_content: Annotated[
+        bool, Field(description="Return full content instead of a short preview.")
+    ] = False,
+    limit: Annotated[int, Field(description="Max materials to return.", ge=1, le=100)] = 20,
+) -> str:
+    """Search marketing materials (ready-to-post copy) in the PublishMaterial catalog.
+
+    Combines server-side filters (language, channel) with client-side keyword
+    (title+content), category and tag matching, plus optional random selection.
+    Returns ``{count, returned, items}``; each item carries its quality_score,
+    channel_style and either a content preview or full content.
+    """
+    try:
+        data = await _query_materials(
+            keyword, langs, channel, channel_id, category, tags, randomize, include_content, limit
+        )
+        return dumps(data)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_pick_random_materials(
+    count: Annotated[
+        int, Field(description="How many random materials to return.", ge=1, le=20)
+    ] = 1,
+    langs: Annotated[
+        list[str] | None, Field(description="Optional language filter, e.g. ['zh-cn'].")
+    ] = None,
+    channel: Annotated[
+        str | None, Field(description="Optional channel UUID or name/title/domain substring.")
+    ] = None,
+    category: Annotated[
+        str | None, Field(description="Optional category substring filter.")
+    ] = None,
+) -> str:
+    """Pick random ready-to-post materials (full content included).
+
+    Convenience wrapper over search with ``randomize=True`` and full content —
+    e.g. "grab a random Zhihu post to publish".
+    """
+    try:
+        data = await _query_materials(
+            keyword=None,
+            langs=langs,
+            channel=channel,
+            channel_id=None,
+            category=category,
+            tags=None,
+            randomize=True,
+            include_content=True,
+            limit=count,
+        )
+        return dumps(data)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
+
+
+@mcp.tool()
+async def acedatacloud_get_material(
+    material_id: Annotated[str, Field(description="The material UUID.")],
+) -> str:
+    """Fetch one material's full detail (title, content, lang, tags, channels)."""
+    try:
+        result = await client.get(f"/publish-materials/{material_id}/")
+        if result is None:
+            return error_json("Not Found", f"No material with id {material_id}.")
+        return dumps(result)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)


### PR DESCRIPTION
## What
Adds 4 read-only tools to the **acedatacloud** MCP server for working with the PublishMaterial marketing-copy catalog:
- `acedatacloud_search_materials` — keyword (title+content), langs, channel (UUID **or** name/title/domain substring), category, tags, `randomize`, `include_content`, limit
- `acedatacloud_pick_random_materials` — N random ready-to-post materials, full content
- `acedatacloud_list_publish_channels` — discover channel names/ids
- `acedatacloud_get_material` — one material's full detail

## Design
Backend `/publish-materials/` only filters `title`/`lang`/`channel_id` server-side, so **keyword(title+content), category, tags, and random are applied client-side** over a newest-first fetch window (`MAX_FETCH=300`). No backend change required. `include_content` defaults to a 200-char preview to keep list payloads small.

## Validation
- `ruff check` + `ruff format` clean; `mypy` (strict) clean.
- Full suite green: **49 passed** (6 new in `tests/test_materials.py` — keyword filter, channel-name→id resolution asserted on the wire, empty-channel note, random full-content, get-by-id, channel search).

## 🤖 对抗评审
Reviewer: general-purpose subagent (read-only), cross-checked against core/client.py + the backend filter contract.
- Endpoints/param names (`/publish-materials/`, `/publish-channels/`, `lang`, `channel_id`, `limit`) match; `langs`→`lang` mapping correct.
- `_match` / `_resolve_channel_ids` / `_is_uuid` / random / `_trim` all correct + null-safe; empty channel match returns a note (no bogus results).
- `client.get` None-drop + list-encoding matches intent; no payload-leak default; no secret under-masking (materials carry no secret keys).
- Tests validate real behavior (not tautological).
- **VERDICT: CLEAN** (1 round).