### PR TITLE
feat(acedatacloud): fan-out keyword search for services

### DIFF
--- a/acedatacloud/CHANGELOG.md
+++ b/acedatacloud/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Keyword **fan-out search** for services (mirrors the docs search): the query is
+  split on whitespace and each keyword is matched and ranked across service
+  `alias`, `title`, `description` and `tags`, best-first — so `music generation`
+  now finds "Suno Music Generation" instead of returning nothing.
+  - `acedatacloud_list_services`: `search` upgraded from a single alias/title
+    substring match to the ranked fan-out.
+  - `acedatacloud_get_service` / `acedatacloud_get_pricing`: when a reference
+    isn't a UUID or exact alias, fall back to a ranked alias/title match so a
+    fuzzy phrase (e.g. `midjourney imagine`) still resolves to the best service.
 - Expose backend-supported filters that the tools previously dropped, closing
   the gap between the MCP surface and the platform API:
   - `acedatacloud_search_docs`: new `limit` (server caps at 30).

--- a/acedatacloud/core/search.py
+++ b/acedatacloud/core/search.py
@@ -1,0 +1,98 @@
+"""Client-side fan-out keyword search shared by catalog/read tools.
+
+Mirrors the platform's documentation search (``/api/v1/search/``): split a query
+on whitespace into keywords, then score each item by an exact-phrase hit plus
+per-keyword hits across weighted fields, and rank best-first. Kept pure so it is
+unit-testable without network access.
+"""
+
+from __future__ import annotations
+
+import string
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+MIN_TERM_LEN = 2
+MAX_TERMS = 10
+_STRIP = string.punctuation
+
+# Score weights: an exact phrase is worth far more than a single keyword, so an
+# item matching the whole query outranks one matching just one word.
+PHRASE_SCORE = 100
+TERM_SCORE = 10
+
+
+def tokenize_query(query: str | None) -> list[str]:
+    """Split a query on whitespace into distinct lowercase keywords.
+
+    Trims surrounding punctuation per token (keeps internal punctuation such as
+    ``nano-banana``), drops tokens shorter than :data:`MIN_TERM_LEN`, de-dupes
+    (order-preserving) and caps the count at :data:`MAX_TERMS`. CJK queries have
+    no spaces, so they collapse to a single keyword (the phrase).
+    """
+    if not query:
+        return []
+    terms: list[str] = []
+    seen: set[str] = set()
+    for raw in query.split():
+        tok = raw.strip(_STRIP).lower()
+        if len(tok) < MIN_TERM_LEN or tok in seen:
+            continue
+        seen.add(tok)
+        terms.append(tok)
+        if len(terms) >= MAX_TERMS:
+            break
+    return terms
+
+
+def _field_text(value: Any) -> str | None:
+    """Flatten a field value to searchable text (joins list/tuple items)."""
+    if value is None:
+        return None
+    if isinstance(value, list | tuple):
+        return " ".join(str(v) for v in value)
+    return value if isinstance(value, str) else str(value)
+
+
+def _text_score(text: str | None, phrase: str, terms: Iterable[str]) -> int:
+    if not text:
+        return 0
+    low = text.lower()
+    score = 0
+    if phrase and phrase.lower() in low:
+        score += PHRASE_SCORE
+    for term in terms:
+        if term in low:
+            score += TERM_SCORE
+    return score
+
+
+def score_item(
+    item: Mapping[str, Any], phrase: str, terms: list[str], fields: Mapping[str, float]
+) -> float:
+    """Sum weighted field scores for one item. ``fields`` maps name → weight."""
+    total = 0.0
+    for field, weight in fields.items():
+        total += weight * _text_score(_field_text(item.get(field)), phrase, terms)
+    return total
+
+
+def rank_items(
+    items: Iterable[Mapping[str, Any]],
+    query: str | None,
+    fields: Mapping[str, float],
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fan a query out across ``fields`` and return items ranked best-first.
+
+    Items scoring 0 (no keyword matched) are dropped. With an empty query the
+    input order is preserved. ``limit`` truncates the ranked list when set.
+    """
+    materialized = [dict(it) for it in items]
+    phrase = (query or "").strip()
+    terms = tokenize_query(query)
+    if not phrase and not terms:
+        return materialized[:limit] if limit is not None else materialized
+    scored = [(score_item(it, phrase, terms, fields), it) for it in materialized]
+    ranked = [it for score, it in sorted(scored, key=lambda p: p[0], reverse=True) if score > 0]
+    return ranked[:limit] if limit is not None else ranked

--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -57,6 +57,27 @@ async def test_get_service_by_alias_paginates():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_get_service_fuzzy_fallback_when_no_exact_alias():
+    # No alias equals the phrase, so resolution falls back to a keyword fan-out
+    # over the scanned services and returns the best match.
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 2,
+                "items": [
+                    {"id": "svc-1", "alias": "midjourney", "title": "Midjourney Imagine"},
+                    {"id": "svc-2", "alias": "flux", "title": "Flux Image"},
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_service(service="midjourney imagine"))
+    assert out["id"] == "svc-1"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_get_pricing_returns_cost():
     respx.get(f"{API}/services/").mock(
         return_value=httpx.Response(

--- a/acedatacloud/tests/test_search.py
+++ b/acedatacloud/tests/test_search.py
@@ -1,0 +1,70 @@
+"""Unit tests for the client-side fan-out search helper (pure, no network)."""
+
+from core.search import MAX_TERMS, rank_items, score_item, tokenize_query
+
+
+class TestTokenizeQuery:
+    def test_splits_on_whitespace_and_lowercases(self):
+        assert tokenize_query("Music Video Generation") == ["music", "video", "generation"]
+
+    def test_trims_surrounding_punctuation_keeps_internal(self):
+        assert tokenize_query("suno, nano-banana!") == ["suno", "nano-banana"]
+
+    def test_drops_short_tokens_and_dedupes(self):
+        assert tokenize_query("a suno suno x") == ["suno"]
+
+    def test_caps_number_of_terms(self):
+        many = " ".join(f"term{i}" for i in range(MAX_TERMS + 5))
+        assert len(tokenize_query(many)) == MAX_TERMS
+
+    def test_empty_or_none(self):
+        assert tokenize_query("") == []
+        assert tokenize_query(None) == []
+
+    def test_cjk_stays_single_term(self):
+        assert tokenize_query("音乐生成") == ["音乐生成"]
+
+
+class TestScoreItem:
+    FIELDS = {"alias": 3, "title": 3, "tags": 2, "description": 1}
+
+    def test_phrase_beats_single_term(self):
+        item = {"title": "Suno Music Generation"}
+        phrase_hit = score_item(item, "music generation", ["music", "generation"], self.FIELDS)
+        one_term = score_item(
+            {"title": "only music here"}, "music generation", ["music", "generation"], self.FIELDS
+        )
+        assert phrase_hit > one_term
+
+    def test_weighted_fields(self):
+        alias_hit = score_item({"alias": "suno"}, "suno", ["suno"], self.FIELDS)
+        desc_hit = score_item({"description": "suno"}, "suno", ["suno"], self.FIELDS)
+        assert alias_hit > desc_hit
+
+    def test_tags_list_is_searched(self):
+        item = {"tags": ["music", "audio"]}
+        assert score_item(item, "audio", ["audio"], self.FIELDS) > 0
+
+    def test_no_match_is_zero(self):
+        assert score_item({"title": "nothing"}, "zzz", ["zzz"], self.FIELDS) == 0
+
+
+class TestRankItems:
+    FIELDS = {"alias": 3, "title": 3, "tags": 2, "description": 1}
+
+    def test_multi_word_query_ranks_and_filters(self):
+        items = [
+            {"alias": "flux", "title": "Flux Image Generation"},
+            {"alias": "suno", "title": "Suno Music Generation", "tags": ["music"]},
+            {"alias": "serp", "title": "Google Search"},
+        ]
+        ranked = rank_items(items, "music generation", self.FIELDS)
+        assert [it["alias"] for it in ranked] == ["suno", "flux"]  # serp dropped (no hit)
+
+    def test_limit_truncates(self):
+        items = [{"title": f"generation {i}"} for i in range(5)]
+        assert len(rank_items(items, "generation", self.FIELDS, limit=2)) == 2
+
+    def test_empty_query_preserves_order(self):
+        items = [{"alias": "a"}, {"alias": "b"}]
+        assert rank_items(items, "", self.FIELDS) == items

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -24,6 +24,18 @@ async def test_list_services_filters_by_search(mock_services_page):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_services_multiword_search_ranks(mock_services_page):
+    # "音乐生成" is split as "音乐 生成"; the old substring match ("音乐 生成" in
+    # title) would find nothing, but the fan-out matches both keywords and ranks
+    # Suno (both hit) above Flux (only "生成" hits).
+    respx.get(f"{API}/services/").mock(return_value=httpx.Response(200, json=mock_services_page))
+    out = json.loads(await acedatacloud_list_services(search="音乐 生成"))
+    assert out["items"][0]["alias"] == "suno"
+    assert {it["alias"] for it in out["items"]} == {"suno", "flux"}
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_get_balance_summarizes(mock_applications_page):
     respx.get(f"{API}/applications/").mock(
         return_value=httpx.Response(200, json=mock_applications_page)

--- a/acedatacloud/tools/catalog_tools.py
+++ b/acedatacloud/tools/catalog_tools.py
@@ -13,6 +13,7 @@ from pydantic import Field
 
 from core.client import client
 from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.search import rank_items
 from core.server import mcp
 from core.utils import dumps, error_json
 
@@ -20,13 +21,16 @@ _UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4
 
 
 async def _resolve_service(ref: str) -> dict[str, Any] | None:
-    """Resolve a service by UUID (``services/?id=``) or by alias (paginated match)."""
+    """Resolve a service by UUID (``services/?id=``), then exact alias, then a
+    keyword fan-out fallback (alias/title/description/tags) so a fuzzy phrase like
+    ``midjourney imagine`` still resolves to the best-matching service."""
     ref = ref.strip()
     if _UUID.match(ref):
         result = await client.get_public("/services/", {"id": ref})
         items: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
         return items[0] if items else None
     target = ref.lower()
+    seen: list[dict[str, Any]] = []
     offset = 0
     while offset < 600:
         result = await client.get_public("/services/", {"limit": 50, "offset": offset})
@@ -36,11 +40,16 @@ async def _resolve_service(ref: str) -> dict[str, Any] | None:
         for it in page:
             if (it.get("alias") or "").lower() == target:
                 return it
+        seen.extend(page)
         count = result.get("count", 0) if isinstance(result, dict) else 0
         offset += 50
         if offset >= count:
             break
-    return None
+    # No exact alias — fall back to a ranked keyword match. Restrict scoring to
+    # the identity fields (alias/title) so a stray word in a long description
+    # can't resolve a precise lookup to an unrelated service.
+    ranked = rank_items(seen, ref, {"alias": 3, "title": 3}, limit=1)
+    return ranked[0] if ranked else None
 
 
 @mcp.tool()

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 from core.client import client, get_request_user_id
 from core.exceptions import PlatformAPIError, PlatformAuthError
+from core.search import rank_items
 from core.server import mcp
 from core.utils import dumps, error_json
 
@@ -30,7 +31,8 @@ async def acedatacloud_list_services(
     search: Annotated[
         str | None,
         Field(
-            description="Optional case-insensitive substring to match against service alias or title."
+            description="Optional keyword search (fan-out): split on spaces and ranked "
+            "across service alias, title, description and tags."
         ),
     ] = None,
     service_type: Annotated[
@@ -51,8 +53,9 @@ async def acedatacloud_list_services(
     """List the services available on the AceDataCloud platform.
 
     A *service* is a product (e.g. ``suno``, ``midjourney``) you can subscribe to.
-    ``search`` finds one by alias/title (client-side); ``service_type``, ``tag`` and
-    ``private`` are applied server-side. Returns count + items.
+    ``search`` finds one by keyword (fan-out across alias/title/description/tags,
+    ranked best-first); ``service_type``, ``tag`` and ``private`` are applied
+    server-side. Returns count + items.
     """
     try:
         server_filters = {
@@ -63,13 +66,10 @@ async def acedatacloud_list_services(
         if search:
             result = await client.get("/services/", {"limit": 300, **server_filters})
             items = result.get("items", []) if isinstance(result, dict) else []
-            s = search.lower()
-            items = [
-                it
-                for it in items
-                if s in (it.get("alias") or "").lower() or s in (it.get("title") or "").lower()
-            ]
-            return dumps({"count": len(items), "items": items})
+            ranked = rank_items(
+                items, search, {"alias": 3, "title": 3, "tags": 2, "description": 1}
+            )
+            return dumps({"count": len(ranked), "items": ranked})
         result = await client.get("/services/", {"limit": limit, **server_filters})
         return _wrap(result)
     except PlatformAuthError as e:


### PR DESCRIPTION
## Problem

Service search in the AceDataCloud MCP matched a **single case-insensitive substring** on `alias` OR `title` only:

- `acedatacloud_list_services(search="music generation")` → found nothing (no service `alias`/`title` contains that exact contiguous phrase), and `description` was never searched.
- `acedatacloud_get_service` / `acedatacloud_get_pricing` resolved a service by **exact alias** only — a fuzzy phrase returned `Not Found`.

This is the same weakness just fixed for the docs search (`acedatacloud_search_docs`), now applied to services.

## Fix — reusable fan-out search

New `core/search.py` (pure, unit-tested): split the query on **whitespace** into keywords (trims surrounding punctuation, keeps internal like `nano-banana`; de-duped, bounded), score each item by **exact-phrase + per-keyword hits across weighted fields**, and rank best-first.

- **`acedatacloud_list_services(search=)`** — ranked fan-out over `alias` (×3), `title` (×3), `tags` (×2), `description` (×1). `music generation` now returns "Suno Music Generation", ranked.
- **`_resolve_service()`** (used by `get_service` / `get_pricing`) — resolution order is UUID → exact alias → **fuzzy alias/title fan-out fallback**, so `midjourney imagine` resolves to the Midjourney service. Exact UUID/alias always win; the fuzzy fallback is scoped to identity fields (alias/title) so a stray word in a long description can't mis-resolve a precise lookup.

Materials/`list_apis` intentionally left unchanged (materials weren't in scope; `list_apis` filters `service` server-side).

## Tests

- New `tests/test_search.py` for `tokenize_query` / `score_item` / `rank_items` (pure, no network).
- New multi-word service-search + fuzzy-resolve tests.
- Full suite: **64 passed**. ruff + mypy strict clean.
