### PR TITLE
fix(acedatacloud): durable platform token as MCP access token, drop refresh/offline_access

### DIFF
--- a/acedatacloud/core/config.py
+++ b/acedatacloud/core/config.py
@@ -35,8 +35,9 @@ class Settings:
 
     # OAuth / remote-auth configuration. When MCP_SERVER_URL is set, the HTTP
     # transport enables OAuth 2.1 (DCR) and delegates user login to
-    # auth.acedata.cloud, issuing the resulting 15-day JWT as the access token
-    # (the management API at platform.acedata.cloud accepts that JWT directly).
+    # auth.acedata.cloud, then mints a durable, non-expiring platform-* token
+    # (via platform.acedata.cloud) and issues it as the access token — so
+    # redeploys/restarts never force re-authorization.
     server_url: str = field(default_factory=lambda: os.getenv("MCP_SERVER_URL", ""))
     auth_base_url: str = field(
         default_factory=lambda: os.getenv(

--- a/acedatacloud/core/oauth.py
+++ b/acedatacloud/core/oauth.py
@@ -8,10 +8,11 @@ Flow:
 2. MCP server redirects to auth.acedata.cloud/oauth2/authorize (consent page)
 3. User logs in (if needed), sees consent page, approves
 4. auth.acedata.cloud issues an authorization code, redirects to /oauth/callback
-5. MCP server exchanges code for JWT + refresh_token via POST /oauth2/token (with PKCE)
-6. MCP server uses JWT as the access_token (platform.acedata.cloud accepts it directly)
-7. Issues the JWT as OAuth access_token, auth refresh_token mapped to MCP refresh_token
-8. On refresh: calls auth.acedata.cloud with stored refresh_token → new JWT
+5. MCP server exchanges code for a JWT via POST /oauth2/token (with PKCE)
+6. MCP server uses that JWT to mint a durable, non-expiring platform-* token
+   (POST platform.acedata.cloud/api/v1/platform-tokens/, reused via a tag)
+7. Issues the platform token as the OAuth access_token — no refresh flow, so
+   redeploys/pod restarts never force re-authorization
 """
 
 import base64
@@ -39,6 +40,8 @@ from core.client import set_request_api_token
 from core.config import settings
 
 MCP_ACCESS_SCOPE = "mcp:access"
+# Stamped on platform tokens this MCP mints, so re-auth reuses one instead of piling up.
+PLATFORM_TOKEN_TAG = "mcp:acedatacloud"
 
 
 def _normalize_scopes(scopes: list[str] | None) -> list[str]:
@@ -48,19 +51,17 @@ def _normalize_scopes(scopes: list[str] | None) -> list[str]:
 class AceDataCloudOAuthProvider:
     """OAuth provider that delegates authentication to AceDataCloud platform.
 
-    Refresh tokens are backed by auth.acedata.cloud — pod restarts don't break
-    refresh because the real refresh_token lives at the authorization server.
+    The access token is a durable, non-expiring platform-* token minted from the
+    user's JWT. There is no refresh flow — the token never expires, so pod
+    restarts/redeploys never force re-authorization.
     """
 
     def __init__(self) -> None:
         self._clients: dict[str, OAuthClientInformationFull] = {}
         self._auth_codes: dict[
-            str, tuple[AuthorizationCode, str, str | None]
-        ] = {}  # code → (AuthCode, api_token, auth_refresh_token)
+            str, tuple[AuthorizationCode, str]
+        ] = {}  # code → (AuthCode, platform_token)
         self._access_tokens: dict[str, AccessToken] = {}
-        self._refresh_tokens: dict[str, RefreshToken] = {}
-        # Maps MCP refresh_token → auth.acedata.cloud refresh_token (the real one)
-        self._auth_refresh_tokens: dict[str, str] = {}
         self._pending_auth: dict[str, dict] = {}  # mcp_state → {client_id, params}
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
@@ -68,13 +69,13 @@ class AceDataCloudOAuthProvider:
         if client:
             return client
         # After pod restart, registered clients are forgotten. Synthesize so
-        # token/refresh calls don't get a hard 401 — real auth is via
-        # auth.acedata.cloud refresh_token validation.
+        # token calls don't get a hard 401 — the access token is a durable
+        # platform-* token validated by platform.acedata.cloud.
         synthetic = OAuthClientInformationFull(
             client_id=client_id,
             redirect_uris=[AnyUrl("https://auth.acedata.cloud/user/connections")],
             token_endpoint_auth_method="none",
-            grant_types=["authorization_code", "refresh_token"],
+            grant_types=["authorization_code"],
             response_types=["code"],
         )
         self._clients[client_id] = synthetic
@@ -111,12 +112,12 @@ class AceDataCloudOAuthProvider:
 
         callback_url = f"{settings.server_url}/oauth/callback"
 
-        # Request offline_access so auth.acedata.cloud returns a refresh_token
+        # Only need profile + platform to mint a durable platform token.
         auth_params = {
             "client_id": settings.oauth_client_id,
             "redirect_uri": callback_url,
             "response_type": "code",
-            "scope": "profile platform offline_access",
+            "scope": "profile platform",
             "state": mcp_state,
             "code_challenge": auth_code_challenge,
             "code_challenge_method": "S256",
@@ -140,7 +141,7 @@ class AceDataCloudOAuthProvider:
             return JSONResponse({"error": "Invalid or expired state"}, status_code=400)
 
         try:
-            # Exchange code for JWT + refresh_token from auth.acedata.cloud
+            # Exchange code for a JWT from auth.acedata.cloud
             code_verifier = pending.get("auth_code_verifier", "")
             token_data = await self._exchange_code_for_tokens(adc_code, code_verifier)
             if not token_data:
@@ -149,18 +150,14 @@ class AceDataCloudOAuthProvider:
                 )
 
             jwt_token = token_data["access_token"]
-            auth_refresh = token_data.get("refresh_token")  # from auth.acedata.cloud
 
-            # For management MCP, the JWT itself IS the access_token
-            api_token = jwt_token
-            claims = self._decode_jwt_payload(jwt_token)
-            if claims:
-                logger.info(
-                    f"OAuth: issuing JWT as access token "
-                    f"(user_id={claims.get('user_id')}, exp={claims.get('exp')})"
-                )
+            # Mint a durable, non-expiring platform-* token as the access token.
+            api_token = await self._get_platform_token(jwt_token)
+            if not api_token:
+                logger.error("handle_callback: platform-token mint failed, returning 502")
+                return JSONResponse({"error": "Failed to issue platform token"}, status_code=502)
 
-            # Create MCP authorization code (carries both api_token and auth_refresh)
+            # Create MCP authorization code (carries the durable platform token)
             auth_code_str = secrets.token_urlsafe(48)
             auth_code = AuthorizationCode(
                 code=auth_code_str,
@@ -172,7 +169,7 @@ class AceDataCloudOAuthProvider:
                 redirect_uri_provided_explicitly=pending["redirect_uri_provided_explicitly"],
                 resource=pending.get("resource"),
             )
-            self._auth_codes[auth_code_str] = (auth_code, api_token, auth_refresh)
+            self._auth_codes[auth_code_str] = (auth_code, api_token)
 
             # Redirect back to Claude with the MCP auth code
             redirect_uri = pending["redirect_uri"]
@@ -209,11 +206,11 @@ class AceDataCloudOAuthProvider:
         data = self._auth_codes.pop(authorization_code.code, None)
         if not data:
             raise ValueError("Authorization code not found or already used")
-        _, api_token, auth_refresh = data
+        _, api_token = data
 
         client_id = client.client_id or ""
 
-        # Store access token
+        # The access token is a durable, non-expiring platform-* token.
         self._access_tokens[api_token] = AccessToken(
             token=api_token,
             client_id=client_id,
@@ -221,130 +218,34 @@ class AceDataCloudOAuthProvider:
             expires_at=None,
         )
 
-        # Issue MCP refresh_token backed by auth.acedata.cloud's refresh_token
-        mcp_refresh_str = secrets.token_urlsafe(48)
-        self._refresh_tokens[mcp_refresh_str] = RefreshToken(
-            token=mcp_refresh_str,
-            client_id=client_id,
-            scopes=_normalize_scopes(authorization_code.scopes),
-        )
-        if auth_refresh:
-            self._auth_refresh_tokens[mcp_refresh_str] = auth_refresh
-
-        logger.info(
-            f"OAuth token exchange: issued access token for client {client_id} "
-            f"(auth_refresh={'yes' if auth_refresh else 'no'})"
-        )
+        logger.info(f"OAuth token exchange: issued durable platform token for client {client_id}")
         return OAuthToken(
             access_token=api_token,
             token_type="Bearer",
             scope=" ".join(_normalize_scopes(authorization_code.scopes)),
-            refresh_token=mcp_refresh_str if auth_refresh else None,
         )
 
     async def load_refresh_token(
         self,
-        client: OAuthClientInformationFull,
-        refresh_token: str,
+        client: OAuthClientInformationFull,  # noqa: ARG002
+        refresh_token: str,  # noqa: ARG002
     ) -> RefreshToken | None:
-        stored = self._refresh_tokens.get(refresh_token)
-        if stored:
-            return stored
-        # After pod restart, in-memory refresh tokens are lost. But the client
-        # sends us its MCP refresh_token which we can't validate locally.
-        # Synthesize so exchange_refresh_token can attempt auth.acedata.cloud.
-        return RefreshToken(
-            token=refresh_token,
-            client_id=client.client_id or "",
-            scopes=[MCP_ACCESS_SCOPE],
-        )
+        # No refresh flow — the access token is a durable, non-expiring platform token.
+        return None
 
     async def exchange_refresh_token(
         self,
-        client: OAuthClientInformationFull,
-        refresh_token: RefreshToken,
-        scopes: list[str],
+        client: OAuthClientInformationFull,  # noqa: ARG002
+        refresh_token: RefreshToken,  # noqa: ARG002
+        scopes: list[str],  # noqa: ARG002
     ) -> OAuthToken:
-        """Refresh by calling auth.acedata.cloud with the stored auth refresh_token."""
-        client_id = client.client_id or ""
-        old_mcp_refresh = refresh_token.token
+        from mcp.server.auth.provider import TokenError
 
-        # Get the auth.acedata.cloud refresh_token mapped to this MCP refresh
-        auth_refresh = self._auth_refresh_tokens.pop(old_mcp_refresh, None)
-        self._refresh_tokens.pop(old_mcp_refresh, None)
-
-        if not auth_refresh:
-            # Post-restart without stored mapping — try using the MCP refresh
-            # token directly as an auth refresh_token (in case the client stored
-            # the original auth refresh_token as-is from a previous version)
-            logger.warning(
-                f"No auth_refresh_token for MCP refresh {old_mcp_refresh[:12]}..., "
-                "falling back to in-memory lookup"
-            )
-            # Fall back to returning existing access_token if still in memory
-            for token, at in self._access_tokens.items():
-                if at.client_id == client_id:
-                    new_mcp_refresh = secrets.token_urlsafe(48)
-                    self._refresh_tokens[new_mcp_refresh] = RefreshToken(
-                        token=new_mcp_refresh,
-                        client_id=client_id,
-                        scopes=_normalize_scopes(scopes or refresh_token.scopes),
-                    )
-                    return OAuthToken(
-                        access_token=token,
-                        token_type="Bearer",
-                        scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
-                        refresh_token=new_mcp_refresh,
-                    )
-            from mcp.server.auth.provider import TokenError
-
-            raise TokenError(
-                error="invalid_grant",
-                error_description="Refresh token expired, please re-authorize",
-            )
-
-        # Call auth.acedata.cloud to refresh the JWT
-        token_data = await self._refresh_auth_token(auth_refresh)
-        if not token_data:
-            from mcp.server.auth.provider import TokenError
-
-            raise TokenError(
-                error="invalid_grant",
-                error_description="auth.acedata.cloud refresh failed, please re-authorize",
-            )
-
-        new_jwt = token_data["access_token"]
-        new_auth_refresh = token_data.get("refresh_token", auth_refresh)
-
-        # For management MCP, JWT IS the access_token
-        new_api_token = new_jwt
-
-        # Remove old access_token for this client, store new one
-        for token, at in list(self._access_tokens.items()):
-            if at.client_id == client_id:
-                del self._access_tokens[token]
-        self._access_tokens[new_api_token] = AccessToken(
-            token=new_api_token,
-            client_id=client_id,
-            scopes=_normalize_scopes(scopes or refresh_token.scopes),
-            expires_at=None,
-        )
-
-        # Issue new MCP refresh_token mapped to the new auth refresh_token
-        new_mcp_refresh = secrets.token_urlsafe(48)
-        self._refresh_tokens[new_mcp_refresh] = RefreshToken(
-            token=new_mcp_refresh,
-            client_id=client_id,
-            scopes=_normalize_scopes(scopes or refresh_token.scopes),
-        )
-        self._auth_refresh_tokens[new_mcp_refresh] = new_auth_refresh
-
-        logger.info(f"OAuth refresh: issued new JWT access token for client {client_id}")
-        return OAuthToken(
-            access_token=new_api_token,
-            token_type="Bearer",
-            scope=" ".join(_normalize_scopes(scopes or refresh_token.scopes)),
-            refresh_token=new_mcp_refresh,
+        # Tokens never expire, so there is nothing to refresh. An old client that
+        # still holds a pre-migration refresh_token gets a clean re-auth prompt.
+        raise TokenError(
+            error="invalid_grant",
+            error_description="This server issues non-expiring tokens; refresh is not supported.",
         )
 
     async def load_access_token(self, token: str) -> AccessToken | None:
@@ -368,9 +269,6 @@ class AceDataCloudOAuthProvider:
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         if isinstance(token, AccessToken):
             self._access_tokens.pop(token.token, None)
-        elif isinstance(token, RefreshToken):
-            self._auth_refresh_tokens.pop(token.token, None)
-            self._refresh_tokens.pop(token.token, None)
         logger.info(f"Revoked token: {token.token[:8]}...")
 
     # --- Internal helpers ---
@@ -433,30 +331,58 @@ class AceDataCloudOAuthProvider:
             logger.exception("OAuth token exchange error")
         return None
 
-    async def _refresh_auth_token(self, auth_refresh_token: str) -> dict[str, str] | None:
-        """Call auth.acedata.cloud to refresh the JWT using the auth refresh_token."""
-        token_url = f"{settings.auth_base_url}/oauth2/token"
+    async def _get_platform_token(self, jwt_token: str) -> str | None:
+        """Mint (or reuse) a durable, non-expiring platform-* token for the user.
+
+        platform.acedata.cloud accepts the JWT (JWTAuthentication) to create a
+        PlatformToken, which never expires. Reuse is keyed on a tag so repeated
+        authorizations don't pile up orphan tokens.
+        """
+        headers = {"Authorization": f"Bearer {jwt_token}"}
+        endpoint = f"{settings.api_base_url.rstrip('/')}/api/v1/platform-tokens/"
+        user_id = (self._decode_jwt_payload(jwt_token) or {}).get("user_id")
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                response = await client.post(
-                    token_url,
-                    data={
-                        "grant_type": "refresh_token",
-                        "refresh_token": auth_refresh_token,
-                        "client_id": settings.oauth_client_id,
+                # Reuse an existing tagged token if the user already has one.
+                # user_id is required: the list endpoint 403s a non-superuser
+                # whose page contains another user's token.
+                if user_id:
+                    resp = await client.get(
+                        endpoint,
+                        headers=headers,
+                        params={"user_id": user_id, "tag": PLATFORM_TOKEN_TAG},
+                    )
+                    if resp.status_code == 200:
+                        existing = self._extract_token(resp.json())
+                        if existing:
+                            logger.info("OAuth: reusing existing platform token")
+                            return existing
+
+                # Otherwise mint a new durable, tagged token.
+                resp = await client.post(
+                    endpoint,
+                    headers=headers,
+                    json={
+                        "tags": [PLATFORM_TOKEN_TAG],
+                        "metadata": {"source": "mcp-acedatacloud"},
                     },
                 )
-                if response.status_code == 200:
-                    data: dict[str, str] = response.json()
-                    if data.get("access_token"):
-                        logger.info("auth.acedata.cloud refresh OK, new JWT issued")
-                        return data
-                    logger.error(f"Auth refresh 200 but no access_token: {list(data.keys())}")
-                else:
-                    logger.warning(
-                        f"auth.acedata.cloud refresh failed: {response.status_code} "
-                        f"{response.text[:200]}"
-                    )
+            if resp.status_code in (200, 201):
+                token = resp.json().get("token")
+                if token:
+                    logger.info("OAuth: issued durable platform token as access token")
+                    return str(token)
+            logger.error(f"platform-token mint failed: {resp.status_code} {resp.text[:200]}")
         except Exception:
-            logger.exception("auth.acedata.cloud refresh error")
+            logger.exception("platform-token mint error")
+        return None
+
+    @staticmethod
+    def _extract_token(payload: object) -> str | None:
+        """Pull the first token from a list or paginated platform-tokens response."""
+        results = payload.get("results", payload) if isinstance(payload, dict) else payload
+        if isinstance(results, list):
+            for item in results:
+                if isinstance(item, dict) and item.get("token"):
+                    return str(item["token"])
         return None

--- a/acedatacloud/tests/test_oauth_platform_token.py
+++ b/acedatacloud/tests/test_oauth_platform_token.py
@@ -1,0 +1,95 @@
+"""Tests for the durable platform-token OAuth flow (mint / reuse / no-refresh)."""
+
+import base64
+import json
+
+import httpx
+import pytest
+import respx
+from mcp.server.auth.provider import RefreshToken, TokenError
+
+from core.oauth import PLATFORM_TOKEN_TAG, AceDataCloudOAuthProvider
+
+API = "https://platform.acedata.cloud/api/v1"
+
+
+def _make_jwt(claims: dict) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    return f"aaa.{payload}.bbb"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_platform_token_reuses_existing_tagged_token():
+    provider = AceDataCloudOAuthProvider()
+    jwt = _make_jwt({"user_id": "u1"})
+    list_route = respx.get(f"{API}/platform-tokens/").mock(
+        return_value=httpx.Response(
+            200, json={"results": [{"token": "platform-existing", "tags": [PLATFORM_TOKEN_TAG]}]}
+        )
+    )
+    create_route = respx.post(f"{API}/platform-tokens/").mock(
+        return_value=httpx.Response(201, json={"token": "platform-new"})
+    )
+
+    token = await provider._get_platform_token(jwt)
+
+    assert token == "platform-existing"
+    assert list_route.called
+    assert create_route.call_count == 0  # reuse must not mint a new token
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_platform_token_creates_when_none_exist():
+    provider = AceDataCloudOAuthProvider()
+    jwt = _make_jwt({"user_id": "u1"})
+    respx.get(f"{API}/platform-tokens/").mock(
+        return_value=httpx.Response(200, json={"results": []})
+    )
+    create_route = respx.post(f"{API}/platform-tokens/").mock(
+        return_value=httpx.Response(201, json={"token": "platform-new"})
+    )
+
+    token = await provider._get_platform_token(jwt)
+
+    assert token == "platform-new"
+    # The created token must be tagged so future authorizations reuse it.
+    body = json.loads(create_route.calls.last.request.content)
+    assert PLATFORM_TOKEN_TAG in body["tags"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_platform_token_returns_none_on_create_failure():
+    provider = AceDataCloudOAuthProvider()
+    jwt = _make_jwt({"user_id": "u1"})
+    respx.get(f"{API}/platform-tokens/").mock(
+        return_value=httpx.Response(200, json={"results": []})
+    )
+    respx.post(f"{API}/platform-tokens/").mock(return_value=httpx.Response(403, text="forbidden"))
+
+    assert await provider._get_platform_token(jwt) is None
+
+
+def test_extract_token_handles_paginated_and_plain_list():
+    provider = AceDataCloudOAuthProvider()
+    assert provider._extract_token({"results": [{"token": "platform-a"}]}) == "platform-a"
+    assert provider._extract_token([{"token": "platform-b"}]) == "platform-b"
+    assert provider._extract_token({"results": []}) is None
+    assert provider._extract_token([{"no_token": 1}]) is None
+
+
+@pytest.mark.asyncio
+async def test_exchange_refresh_token_is_unsupported():
+    provider = AceDataCloudOAuthProvider()
+    rt = RefreshToken(token="whatever", client_id="c1", scopes=["mcp:access"])
+    with pytest.raises(TokenError) as exc:
+        await provider.exchange_refresh_token(client=None, refresh_token=rt, scopes=[])
+    assert exc.value.error == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_returns_none():
+    provider = AceDataCloudOAuthProvider()
+    assert await provider.load_refresh_token(client=None, refresh_token="x") is None


### PR DESCRIPTION
## Problem

Users had to **re-authorize the AceDataCloud connector after every deploy** of the `mcp-acedatacloud` server (studio.acedata.cloud / Claude connectors).

Root cause (two compounding bugs):
1. The server kept all OAuth refresh state in **in-memory dicts** (`_auth_refresh_tokens`, `_refresh_tokens`). The pod runs `replicas: 1`, so every redeploy/restart wiped them.
2. Even the #420 "refresh-backed-by-auth" design was dead on arrival: `auth.acedata.cloud` **never returned a `refresh_token`** because the MCP's `OAuthApplication` isn't granted the `offline_access` scope — so `AuthBackend` filters it out (`OAuthAuthorizeView`) and `OAuthTokenView` only returns a refresh_token when `offline_access` is in the granted scopes. Live logs showed `Token exchange OK (refresh_token=no)` / `auth_refresh=no`.

## Fix

Stop relying on a refresh flow. After the OAuth code→JWT exchange, mint (or **reuse**) a **durable, non-expiring `platform-*` token** from `platform.acedata.cloud/api/v1/platform-tokens/` and issue **that** as the MCP access token:

- `platform.acedata.cloud`'s `TokenAuthentication` accepts `platform-*` tokens and **does not enforce expiry** → the access token never expires.
- `load_access_token` already accepts any token via a stateless direct fallback → survives pod restarts with no in-memory dependency.
- Reuse is keyed on a `mcp:acedatacloud` **tag** (companion PlatformBackend PR adds `tags` + `?tag=` filter) so repeated authorizations don't pile up orphan tokens. Reuse GET is scoped by `user_id` (decoded from the JWT); if the claim is missing it safely skips reuse and mints.

Removed the now-dead refresh/offline_access code:
- `authorize` scope: `profile platform offline_access` → `profile platform`
- `load_refresh_token` → returns `None`; `exchange_refresh_token` → raises `TokenError(invalid_grant)` (an old client holding a pre-migration refresh_token gets one clean re-auth prompt, then a durable token)
- dropped `_auth_refresh_tokens` / `_refresh_tokens` maps and `_refresh_auth_token`

## Depends on

`AceDataCloud/PlatformBackend#847` (platform-token `tags`/`metadata` + `?tag=` filter) — **deploy that first**. Without it the `?tag=` filter is ignored and reuse degrades to "always mint" (still correct, just no dedupe).

## Test

- Added `tests/test_oauth_platform_token.py`: reuse-existing, create-when-none (asserts tag stamped), create-failure→None, `_extract_token` (paginated + plain list), `exchange_refresh_token` raises, `load_refresh_token` returns None.
- Full suite: **55 passed**. `ruff` + `mypy --strict` clean.

## 🤖 对抗评审

Independent reviewer (read-only) reviewed this PR + the PlatformBackend companion.

- **(a) cross-user token leak via reuse?** No — reuse GET only runs with `user_id` present; backend list is `user_id`-scoped + per-row `IsSuperUserOrCreator` 403s foreign rows; `_extract_token` only consumes 200 bodies.
- **(b) `?tag` filter safety?** Parameterized `tags__contains`, composed with user scoping — no injection, not over-broad.
- **(c) broken handshake / None path?** `load_access_token` always returns a token (restart-safe); mint failure → clean 502; `get_client` synthesizes post-restart; the only in-memory bit left (`_auth_codes`, seconds-long, single replica) is unchanged from before.
- **(d) migration?** (PlatformBackend) additive nullable columns, correct deps, no backfill.
- Non-material note: unverified JWT `user_id` diverging from backend `request.user.id` would silently mint fresh instead of reusing — degrades, never leaks.

**VERDICT: CLEAN**
