### PR TITLE
fix(mcps): sync tool surfaces with current API docs (8 providers)

### DIFF
--- a/flux/tools/image_tools.py
+++ b/flux/tools/image_tools.py
@@ -27,8 +27,9 @@ async def flux_generate_image(
             description="Flux model to use for generation. Options:\n"
             "- flux-dev: Fast development model, good balance of speed and quality (default)\n"
             "- flux-pro: Higher quality production model\n"
-            "- flux-pro-1.1: Improved production model with better prompt following\n"
-            "- flux-pro-1.1-ultra: Highest quality, supports aspect ratios instead of pixel sizes\n"
+            "- flux-2-flex: Flux 2 flexible model, pixel sizes (x >= 64, multiple of 32)\n"
+            "- flux-2-pro: Flux 2 professional model, high quality\n"
+            "- flux-2-max: Flux 2 maximum-quality model\n"
             "- flux-kontext-pro: Context-aware model for editing and style transfer\n"
             "- flux-kontext-max: Maximum context model for complex editing tasks"
         ),
@@ -36,10 +37,10 @@ async def flux_generate_image(
     size: Annotated[
         str | None,
         Field(
-            description="Image size. For flux-dev/pro/pro-1.1: pixel dimensions like '1024x1024' "
-            "(256-1440px, multiples of 32). For flux-pro-1.1-ultra and kontext models: aspect "
-            "ratios like '1:1', '16:9', '9:16', '4:3', '3:2', '2:3', '4:5', '5:4', '3:4', "
-            "'21:9', '9:21'. Default varies by model."
+            description="Image size. For flux-dev: pixel dimensions like '1024x1024' "
+            "(256-1440px, multiples of 32). For flux-2-flex/pro/max: pixel dimensions "
+            "(x >= 64, multiples of 32). For kontext models: image ratios like '1:1', '16:9', "
+            "'9:16', '4:3', '3:2', '2:3', '4:5', '5:4', '3:4', '21:9', '9:21'. Default varies by model."
         ),
     ] = None,
     count: Annotated[

--- a/flux/tools/info_tools.py
+++ b/flux/tools/info_tools.py
@@ -26,14 +26,17 @@ Image Generation Models:
   Speed: Medium  |  Quality: High  |  Size: 256-1440px (multiples of 32)
   Best for: Production use, higher quality requirements
 
-- flux-pro-1.1
-  Speed: Medium  |  Quality: High  |  Size: 256-1440px (multiples of 32)
-  Best for: Improved prompt following, better detail rendering
+- flux-2-flex
+  Speed: Medium  |  Quality: High  |  Size: pixel dims (x >= 64, multiples of 32)
+  Best for: Flexible Flux 2 generation with fine size control
 
-- flux-pro-1.1-ultra
-  Speed: Slower  |  Quality: Highest  |  Size: Aspect ratios only
-  Best for: Maximum quality, marketing materials, final outputs
-  Supports: 1:1, 16:9, 9:16, 4:3, 3:2, 2:3, 4:5, 5:4, 3:4, 21:9, 9:21
+- flux-2-pro
+  Speed: Medium  |  Quality: Higher  |  Size: pixel dims (x >= 64, multiples of 32)
+  Best for: Professional Flux 2 production output
+
+- flux-2-max
+  Speed: Slower  |  Quality: Highest  |  Size: pixel dims (x >= 64, multiples of 32)
+  Best for: Maximum-quality Flux 2 output, final renders
 
 Context-Aware Models (Best for Editing):
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -49,12 +52,12 @@ Context-Aware Models (Best for Editing):
 
 Size Guide:
 ━━━━━━━━━━━
-Pixel dimensions (flux-dev/pro/pro-1.1):
+Pixel dimensions (flux-dev, flux-2-flex/pro/max):
   Square: 1024x1024
   Landscape: 1344x768, 1280x720
   Portrait: 768x1344, 720x1280
 
-Aspect ratios (ultra/kontext models):
+Image ratios (kontext models):
   Square: 1:1
   Landscape: 16:9, 21:9, 4:3, 3:2, 5:4
   Portrait: 9:16, 9:21, 3:4, 2:3, 4:5
@@ -62,7 +65,7 @@ Aspect ratios (ultra/kontext models):
 Recommendations:
 ━━━━━━━━━━━━━━━
 - Quick generation → flux-dev
-- High quality → flux-pro-1.1-ultra
+- High quality → flux-2-max
 - Image editing → flux-kontext-pro
 - Complex editing → flux-kontext-max
 """
@@ -102,7 +105,7 @@ Workflows:
    flux_generate_image(prompt="...") → get image_url
 
 2. High Quality Generation:
-   flux_generate_image(prompt="...", model="flux-pro-1.1-ultra", size="16:9")
+   flux_generate_image(prompt="...", model="flux-2-max", size="1024x1024")
 
 3. Image Editing:
    flux_edit_image(prompt="Change the sky to sunset", image_url="https://...")

--- a/flux/vscode/README.md
+++ b/flux/vscode/README.md
@@ -55,7 +55,7 @@ For screenshots, token setup, project-level and user-level `mcp.json`, and Copil
 
 ## Supported Models
 
-`flux-dev`, `flux-pro`, `flux-pro-1.1`, `flux-pro-1.1-ultra`, `flux-kontext-pro`, `flux-kontext-max`
+`flux-dev`, `flux-pro`, `flux-2-flex`, `flux-2-pro`, `flux-2-max`, `flux-kontext-pro`, `flux-kontext-max`
 
 ## Pricing
 

--- a/kling/tools/video_tools.py
+++ b/kling/tools/video_tools.py
@@ -296,6 +296,10 @@ async def kling_extend_video(
             description="Generation mode. 'std' (standard, default), 'pro' (higher quality), or '4k' (native 4K, only for kling-v3 and kling-v3-omni)."
         ),
     ] = DEFAULT_MODE,
+    duration: Annotated[
+        Duration,
+        Field(description="Duration of the extended segment in seconds. Supports 5 or 10."),
+    ] = DEFAULT_DURATION,
     negative_prompt: Annotated[
         str | None,
         Field(description="Things to avoid in the extended video."),
@@ -324,6 +328,7 @@ async def kling_extend_video(
         "prompt": prompt,
         "model": model,
         "mode": mode,
+        "duration": duration,
     }
 
     if negative_prompt:

--- a/nanobanana/tools/image_tools.py
+++ b/nanobanana/tools/image_tools.py
@@ -91,6 +91,18 @@ async def nanobanana_edit_image(
             description="Model to use for editing. 'nano-banana' (default, alias of gemini-2.5-flash-image) is faster. 'nano-banana-2' (alias of gemini-3.1-flash-image) offers pro-level quality at flash speed. 'nano-banana-pro' (alias of gemini-3-pro-image) offers highest quality."
         ),
     ] = "nano-banana",
+    aspect_ratio: Annotated[
+        AspectRatio | None,
+        Field(
+            description="Aspect ratio of the edited image. Options: '1:1', '3:2', '2:3', '16:9', '9:16', '4:3', '3:4'. If omitted, the model infers it from the input images."
+        ),
+    ] = None,
+    resolution: Annotated[
+        Resolution | None,
+        Field(
+            description="Resolution of the edited image. Options: '1K', '2K', '4K'. Only works with 'nano-banana-pro' model."
+        ),
+    ] = None,
 ) -> str:
     """Edit or combine images using AI based on a text prompt.
 
@@ -121,6 +133,11 @@ async def nanobanana_edit_image(
         "image_urls": image_urls,
         "model": model,
     }
+
+    if aspect_ratio:
+        payload["aspect_ratio"] = aspect_ratio
+    if resolution:
+        payload["resolution"] = resolution
 
     result = await client.edit_image_async(**payload)
     return format_image_result(result)

--- a/producer/tools/audio_tools.py
+++ b/producer/tools/audio_tools.py
@@ -30,6 +30,36 @@ async def producer_generate_music(
             description="If true, generate instrumental music without vocals. Default is false (with vocals)."
         ),
     ] = False,
+    lyrics_strength: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how strongly the lyrics drive the generation. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    sound_strength: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how strongly the sound/style drives the generation. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    weirdness: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how experimental/unusual the generation is. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    seed: Annotated[
+        int | None,
+        Field(
+            description="Seed for reproducible generation. Reuse the same seed to reproduce a result."
+        ),
+    ] = None,
     callback_url: Annotated[
         str | None,
         Field(
@@ -53,13 +83,23 @@ async def producer_generate_music(
     Returns:
         Task ID and generated audio information including URLs, title, lyrics, and duration.
     """
-    result = await client.generate_audio(
-        action="generate",
-        prompt=prompt,
-        model=model,
-        instrumental=instrumental,
-        callback_url=callback_url,
-    )
+    payload: dict = {
+        "action": "generate",
+        "prompt": prompt,
+        "model": model,
+        "instrumental": instrumental,
+        "callback_url": callback_url,
+    }
+    if lyrics_strength is not None:
+        payload["lyrics_strength"] = lyrics_strength
+    if sound_strength is not None:
+        payload["sound_strength"] = sound_strength
+    if weirdness is not None:
+        payload["weirdness"] = weirdness
+    if seed is not None:
+        payload["seed"] = seed
+
+    result = await client.generate_audio(**payload)
     return format_audio_result(result)
 
 
@@ -93,6 +133,36 @@ async def producer_generate_custom_music(
             description="If true, generate instrumental version (lyrics will be ignored). Default is false."
         ),
     ] = False,
+    lyrics_strength: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how strongly the lyrics drive the generation. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    sound_strength: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how strongly the sound/style drives the generation. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    weirdness: Annotated[
+        float | None,
+        Field(
+            description="Creative control for how experimental/unusual the generation is. Range 0-1.",
+            ge=0.0,
+            le=1.0,
+        ),
+    ] = None,
+    seed: Annotated[
+        int | None,
+        Field(
+            description="Seed for reproducible generation. Reuse the same seed to reproduce a result."
+        ),
+    ] = None,
     callback_url: Annotated[
         str | None,
         Field(description="Webhook callback URL for asynchronous notifications."),
@@ -125,6 +195,14 @@ async def producer_generate_custom_music(
 
     if style:
         payload["style"] = style
+    if lyrics_strength is not None:
+        payload["lyrics_strength"] = lyrics_strength
+    if sound_strength is not None:
+        payload["sound_strength"] = sound_strength
+    if weirdness is not None:
+        payload["weirdness"] = weirdness
+    if seed is not None:
+        payload["seed"] = seed
 
     result = await client.generate_audio(**payload)
     return format_audio_result(result)

--- a/seedream/core/types.py
+++ b/seedream/core/types.py
@@ -5,6 +5,7 @@ from typing import Literal
 # Seedream model types
 SeedreamModel = Literal[
     "doubao-seedream-5-0-260128",
+    "doubao-seedream-5.0-lite",
     "doubao-seedream-4-5-251128",
     "doubao-seedream-4-0-250828",
     "doubao-seedream-3-0-t2i-250415",

--- a/seedream/tools/image_tools.py
+++ b/seedream/tools/image_tools.py
@@ -33,6 +33,7 @@ async def seedream_generate_image(
         Field(
             description="Model to use for generation. "
             "'doubao-seedream-5-0-260128' (v5.0, latest flagship, highest quality). "
+            "'doubao-seedream-5.0-lite' (v5.0 economy variant, faster and lower cost). "
             "'doubao-seedream-4-5-251128' (v4.5, previous flagship, great quality). "
             "'doubao-seedream-4-0-250828' (v4.0, stable, best value). "
             "'doubao-seedream-3-0-t2i-250415' (v3 text-to-image, supports seed and guidance_scale). "

--- a/seedream/tools/info_tools.py
+++ b/seedream/tools/info_tools.py
@@ -21,6 +21,7 @@ async def seedream_list_models() -> str:
 | Model | Version | Type | Features | Price |
 |-------|---------|------|----------|-------|
 | `doubao-seedream-5-0-260128` | v5.0 | Text-to-Image | Latest flagship, highest quality, sequential generation, streaming, web search | ~$0.040/image |
+| `doubao-seedream-5.0-lite` | v5.0 | Text-to-Image | Economy v5.0 variant, faster and lower cost | lower cost |
 | `doubao-seedream-4-5-251128` | v4.5 | Text-to-Image | Previous flagship, great quality, sequential generation, streaming | ~$0.037/image |
 | `doubao-seedream-4-0-250828` | v4.0 | Text-to-Image | Stable, cost-effective, sequential generation, streaming | ~$0.030/image |
 | `doubao-seedream-3-0-t2i-250415` | v3.0 | Text-to-Image | Seed control, guidance scale, reproducible results | ~$0.038/image |

--- a/veo/core/client.py
+++ b/veo/core/client.py
@@ -167,11 +167,12 @@ class VeoClient:
         logger.info(f"🎬 Generating video with action: {kwargs.get('action', 'text2video')}")
         return await self.request("/veo/videos", self._with_async_callback(kwargs))
 
-    async def get_1080p(self, video_id: str) -> dict[str, Any]:
+    async def get_1080p(self, video_id: str, model: str) -> dict[str, Any]:
         """Get 1080p version of a video."""
         logger.info(f"📺 Getting 1080p video for: {video_id}")
         return await self.request(
-            "/veo/videos", self._with_async_callback({"action": "get1080p", "video_id": video_id})
+            "/veo/videos",
+            self._with_async_callback({"action": "get1080p", "video_id": video_id, "model": model}),
         )
 
     async def upsample_video(self, **kwargs: Any) -> dict[str, Any]:

--- a/veo/tools/video_tools.py
+++ b/veo/tools/video_tools.py
@@ -183,6 +183,12 @@ async def veo_get_1080p(
             description="The video ID from a previous generation result. This is the 'id' field from the video data, not the task_id."
         ),
     ],
+    model: Annotated[
+        VeoModel,
+        Field(
+            description="The model used to generate the source video. Required by the API; pass the same model you used for the original generation."
+        ),
+    ] = DEFAULT_MODEL,
 ) -> str:
     """Get the 1080p high-resolution version of a generated video.
 
@@ -199,7 +205,7 @@ async def veo_get_1080p(
     Returns:
         Task ID and the 1080p video information including the new video URL.
     """
-    result = await client.get_1080p(video_id)
+    result = await client.get_1080p(video_id, model)
     return format_video_result(result)
 
 

--- a/wan/tools/video_tools.py
+++ b/wan/tools/video_tools.py
@@ -34,8 +34,8 @@ async def wan_generate_video(
     ] = DEFAULT_RESOLUTION,
     audio: Annotated[
         bool,
-        Field(description="Whether the generated video should include audio. Default is false."),
-    ] = False,
+        Field(description="Whether the generated video should include audio. Default is true."),
+    ] = True,
     audio_url: Annotated[
         str | None,
         Field(
@@ -44,10 +44,8 @@ async def wan_generate_video(
     ] = None,
     prompt_extend: Annotated[
         bool,
-        Field(
-            description="Enable LLM-based prompt rewriting for better results. Default is false."
-        ),
-    ] = False,
+        Field(description="Enable LLM-based prompt rewriting for better results. Default is true."),
+    ] = True,
     size: Annotated[
         str | None,
         Field(description="The size of the generated video (e.g., '1280x720')."),
@@ -143,16 +141,16 @@ async def wan_generate_video_from_image(
     ] = None,
     audio: Annotated[
         bool,
-        Field(description="Whether the generated video should include audio. Default is false."),
-    ] = False,
+        Field(description="Whether the generated video should include audio. Default is true."),
+    ] = True,
     audio_url: Annotated[
         str | None,
         Field(description="URL of reference audio to use in the video."),
     ] = None,
     prompt_extend: Annotated[
         bool,
-        Field(description="Enable LLM-based prompt rewriting. Default is false."),
-    ] = False,
+        Field(description="Enable LLM-based prompt rewriting. Default is true."),
+    ] = True,
     size: Annotated[
         str | None,
         Field(description="The size of the generated video (e.g., '1280x720')."),

--- a/webextrator/core/client.py
+++ b/webextrator/core/client.py
@@ -99,6 +99,10 @@ class WebExtraterClient:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        cookies: list[dict[str, Any]] | None = None,
+        bypass_cache: bool | None = None,
+        cache_ttl_seconds: float | None = None,
+        mode: str | None = None,
     ) -> dict[str, Any]:
         """Extract structured content from a web page.
 
@@ -139,6 +143,14 @@ class WebExtraterClient:
             payload["user_agent"] = user_agent
         if callback_url is not None:
             payload["callback_url"] = callback_url
+        if cookies is not None:
+            payload["cookies"] = cookies
+        if bypass_cache is not None:
+            payload["bypass_cache"] = bypass_cache
+        if cache_ttl_seconds is not None:
+            payload["cache_ttl_seconds"] = cache_ttl_seconds
+        if mode is not None:
+            payload["mode"] = mode
 
         logger.info(f"Extracting content from: {url}")
         endpoint = f"{self.base_url}/webextrator/extract"
@@ -187,6 +199,10 @@ class WebExtraterClient:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        cookies: list[dict[str, Any]] | None = None,
+        bypass_cache: bool | None = None,
+        cache_ttl_seconds: float | None = None,
+        mode: str | None = None,
     ) -> dict[str, Any]:
         """Render a web page and return the rendered HTML.
 
@@ -221,6 +237,14 @@ class WebExtraterClient:
             payload["user_agent"] = user_agent
         if callback_url is not None:
             payload["callback_url"] = callback_url
+        if cookies is not None:
+            payload["cookies"] = cookies
+        if bypass_cache is not None:
+            payload["bypass_cache"] = bypass_cache
+        if cache_ttl_seconds is not None:
+            payload["cache_ttl_seconds"] = cache_ttl_seconds
+        if mode is not None:
+            payload["mode"] = mode
 
         logger.info(f"Rendering page: {url}")
         endpoint = f"{self.base_url}/webextrator/render"

--- a/webextrator/core/types.py
+++ b/webextrator/core/types.py
@@ -13,3 +13,6 @@ ExpectedType = Literal["product", "article", "general"]
 
 # Task action options
 TaskAction = Literal["retrieve", "retrieve_batch"]
+
+# Processing mode: synchronous (wait for the result) or asynchronous (return a task_id)
+TaskMode = Literal["sync", "async"]

--- a/webextrator/tools/extract_tools.py
+++ b/webextrator/tools/extract_tools.py
@@ -1,14 +1,14 @@
 """Extract and render tools for WebExtrator API."""
 
 import json
-from typing import Annotated, cast
+from typing import Annotated, Any, cast
 
 from pydantic import Field
 
 from core.client import client
 from core.exceptions import WebExtraterAPIError, WebExtraterAuthError
 from core.server import mcp
-from core.types import BlockResource, ExpectedType, WaitUntil
+from core.types import BlockResource, ExpectedType, TaskMode, WaitUntil
 
 
 @mcp.tool()
@@ -82,6 +82,43 @@ async def webextrator_extract(
             )
         ),
     ] = None,
+    cookies: Annotated[
+        list[dict[str, Any]] | None,
+        Field(
+            description=(
+                "Cookies to install before navigation. Each cookie is an object with at least "
+                "'name' and 'value', plus optional 'domain', 'path', 'expires', 'httpOnly', "
+                "'secure', 'sameSite'. Useful for authenticated pages."
+            )
+        ),
+    ] = None,
+    bypass_cache: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "Skip the Redis result cache for this request (still writes the fresh result "
+                "back). Default is false."
+            )
+        ),
+    ] = None,
+    cache_ttl_seconds: Annotated[
+        float | None,
+        Field(
+            description=(
+                "Override the global cache TTL (seconds) for this entry. 0 means do not cache "
+                "this response. Default is 3600."
+            )
+        ),
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description=(
+                "Processing mode. 'sync' (default) waits for the result; 'async' returns "
+                "immediately with a task_id to poll via the Tasks API."
+            )
+        ),
+    ] = None,
 ) -> str:
     """Extract structured content from a web page using the WebExtrator API.
 
@@ -112,6 +149,10 @@ async def webextrator_extract(
             headers=headers,
             user_agent=user_agent,
             callback_url=callback_url,
+            cookies=cookies,
+            bypass_cache=bypass_cache,
+            cache_ttl_seconds=cache_ttl_seconds,
+            mode=mode,
         )
 
         if not result:
@@ -180,6 +221,43 @@ async def webextrator_render(
             )
         ),
     ] = None,
+    cookies: Annotated[
+        list[dict[str, Any]] | None,
+        Field(
+            description=(
+                "Cookies to install before navigation. Each cookie is an object with at least "
+                "'name' and 'value', plus optional 'domain', 'path', 'expires', 'httpOnly', "
+                "'secure', 'sameSite'. Useful for authenticated pages."
+            )
+        ),
+    ] = None,
+    bypass_cache: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "Skip the Redis result cache for this request (still writes the fresh result "
+                "back). Default is false."
+            )
+        ),
+    ] = None,
+    cache_ttl_seconds: Annotated[
+        float | None,
+        Field(
+            description=(
+                "Override the global cache TTL (seconds) for this entry. 0 means do not cache "
+                "this response. Default is 3600."
+            )
+        ),
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description=(
+                "Processing mode. 'sync' (default) waits for the result; 'async' returns "
+                "immediately with a task_id to poll via the Tasks API."
+            )
+        ),
+    ] = None,
 ) -> str:
     """Render a web page and return the fully rendered HTML.
 
@@ -208,6 +286,10 @@ async def webextrator_render(
             headers=headers,
             user_agent=user_agent,
             callback_url=callback_url,
+            cookies=cookies,
+            bypass_cache=bypass_cache,
+            cache_ttl_seconds=cache_ttl_seconds,
+            mode=mode,
         )
 
         if not result:

--- a/webextrator/tools/task_tools.py
+++ b/webextrator/tools/task_tools.py
@@ -81,7 +81,7 @@ async def webextrator_get_tasks_batch(
     ] = None,
     limit: Annotated[
         int | None,
-        Field(description="Pagination limit for batch retrieval. Default is 12."),
+        Field(description="Pagination limit for batch retrieval, 1-100. Default is 50."),
     ] = None,
 ) -> str:
     """Retrieve the results of multiple previously created extract or render tasks.


### PR DESCRIPTION
## Summary

Systematic gap analysis across all 21 MCP↔API pairs (dispatched via read-only subagents) surfaced eight MCP servers whose tool surface had drifted from the current API docs. This PR closes those gaps in a single monorepo change. The remaining 13 providers (suno, serp, luma, hailuo, seedance, aichat, glm, grok, sora, fish, face, openai, shorturl) were verified in sync or already ahead of the docs — no MCP-side change needed there.

## Per-provider changes

**Missing required parameters (would 400 today)**
- `kling`: `kling_extend_video` now accepts `duration` (5/10) — required for the extend action per [Kling extend docs](../APIs/kling/docs/kling_videos_generation_api_integration_guide.md).
- `veo`: `veo_get_1080p` (and `client.get_1080p`) now accept `model` — required for the `get1080p` action per [Veo docs, "Get 1080p Video Function"](../APIs/veo/docs/veo_videos_generation_api_integration_guide.md).

**Missing model / enum**
- `seedream`: added `doubao-seedream-5.0-lite` to `SeedreamModel` (docs list it in the generation endpoint spec).
- `flux`: `info_tools` and `image_tools` docstrings were still advertising phantom `flux-pro-1.1` / `flux-pro-1.1-ultra` models that were removed from `FluxModel`. Replaced with the real `flux-2-flex` / `flux-2-pro` / `flux-2-max` models. Same fix in `flux/vscode/README.md`.

**Wrong defaults (silently overriding API defaults)**
- `wan`: `audio` and `prompt_extend` now default `True` in both `wan_generate_video` and `wan_generate_video_from_image`. The API docs explicitly state both default `true`, but the MCP was hard-coding `False` and always sending it, so callers silently got no-audio / no-prompt-rewrite outputs.

**Missing optional params documented as first-class**
- `producer`: added `lyrics_strength`, `sound_strength`, `weirdness` (0–1) and `seed` to both `producer_generate_music` and `producer_generate_custom_music`.
- `webextrator`: added `cookies`, `bypass_cache`, `cache_ttl_seconds`, `mode` (sync/async — new `TaskMode` type) to both `webextrator_extract` and `webextrator_render` and threaded them through `client.extract` / `client.render`. Also corrected the `webextrator_get_tasks_batch` `limit` description ("Default is 12" → "Default is 50, 1-100") to match the docs.
- `nanobanana`: added `aspect_ratio` and `resolution` (nano-banana-pro only) to `nanobanana_edit_image`. The docs explicitly list these as valid optional params for edit as well as generate.

## Validation (all 8 changed packages)

Ran locally in the worktree:

- `ruff check .` — All checks passed
- `ruff format --check .` — All files formatted
- `mypy core tools main.py` — Success: no issues found (strict mode)
- `pytest -q` — All existing tests green:
  - seedream 16 passed / 2 skipped
  - wan 22 passed / 3 skipped
  - kling 31 passed / 3 skipped
  - veo 14 passed / 2 skipped
  - producer 26 passed / 6 skipped
  - webextrator 3 passed
  - flux 13 passed / 2 skipped
  - nanobanana 11 passed / 2 skipped

No test asserted the specific behaviors changed (payload keys for extend/get_1080p, `False` defaults on wan) so no existing tests needed updating.

## Explicitly out of scope

- Providers where the MCP is legitimately ahead of the docs (grok video endpoints, aichat v2 endpoint, hailuo `minimax-i2v-director`, seedance `service_tier`/`return_last_frame`, face's 5 extra tools) — the fix belongs in the API docs, not the MCP.
- Providers with only cosmetic / doc-only discrepancies (suno default model, luma internals, glm/openai advanced params also documented as OpenAI-compatible passthroughs).
- The kling extend section's mention of `kling-v1-5`: NOT added to `KlingModel` because the authoritative "currently supported models" list at the top of the same doc does not include it, and the current enum matches that top list exactly.

## 🤖 对抗评审

Reviewer: Explore subagent (Codex not installed on this machine).

Round 1 — the reviewer independently verified each change against `APIs/<provider>/docs/*.md`, confirmed payload keys equal the wire fields, the type enums, both signature-AND-payload wiring for every added param, and that no other in-tree caller depends on `client.get_1080p`'s old arity. One HIGH-severity note was raised about the `client.get_1080p(video_id)` → `(video_id, model)` arity change; a follow-up grep confirmed the only in-tree caller is the updated `veo_get_1080p` tool, so it is a safe internal contract change. Reviewer's final line: `VERDICT: CLEAN`. Also caught by a post-review grep and fixed in this same commit: leftover `flux-pro-1.1` references in `flux/vscode/README.md`.
