### PR TITLE
fix(webextrator): set OAuth client_id env so /authorize is valid

### DIFF
--- a/webextrator/deploy/production/deployment.yaml
+++ b/webextrator/deploy/production/deployment.yaml
@@ -31,6 +31,8 @@ spec:
           env:
             - name: MCP_SERVER_URL
               value: "https://webextrator.mcp.acedata.cloud"
+            - name: ACEDATACLOUD_OAUTH_CLIENT_ID
+              value: "HV9Sj5_5C30-56jI72WHcFrWk62RKRNdcIiW14hMvGA"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## Problem

Opening the webextrator MCP OAuth flow (e.g. connecting `webextrator.mcp.acedata.cloud` from a client) redirected to:

```
https://auth.acedata.cloud/oauth2/authorize?client_id=&redirect_uri=https%3A%2F%2Fwebextrator.mcp.acedata.cloud%2Foauth%2Fcallback&response_type=code&scope=profile+platform&...
```

Note the **empty `client_id=`** → auth.acedata.cloud rejected it with **授权请求无效** (invalid authorization request).

## Root cause

The webextrator MCP builds its `/authorize` redirect from `settings.oauth_client_id` (`ACEDATACLOUD_OAUTH_CLIENT_ID`, default `""`). Two gaps:

1. No **`MCP WebExtrator`** `OAuthApplication` existed in AuthBackend (all 19 other MCPs — flux, grok, glm, openai, … — have one: `public`/PKCE, redirect `https://<alias>.mcp.acedata.cloud/oauth/callback`, scopes `profile platform`).
2. `webextrator/deploy/production/deployment.yaml` never set `ACEDATACLOUD_OAUTH_CLIENT_ID`, so the empty default was forwarded.

## Fix

- **Registered** the missing `MCP WebExtrator` OAuth application in the AuthBackend production DB (`public` client, PKCE, redirect `https://webextrator.mcp.acedata.cloud/oauth/callback`, scopes `profile platform`) → `client_id = HV9Sj5_5C30-56jI72WHcFrWk62RKRNdcIiW14hMvGA` (public, non-secret).
- **Wired** that `client_id` into `deployment.yaml`, matching all sibling MCPs.
- **Applied live** via `kubectl set env` + rollout on the HK cluster so the flow is already unblocked; this PR makes the config permanent so future redeploys keep it.

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`).

**VERDICT: CLEAN**
- Public non-secret client_id in a PKCE flow (`token_endpoint_auth_method="none"`, S256); no client secret present.
- Redirect URI matches the deployment/ingress/server host pattern.
- Low commit risk; value is a public OAuth client_id, not an API token or credential.