### PR TITLE
fix(seedream): drop invalid dot-form model IDs (worker 400s them)

### DIFF
--- a/seedream/core/types.py
+++ b/seedream/core/types.py
@@ -5,9 +5,7 @@ from typing import Literal
 # Seedream model types
 SeedreamModel = Literal[
     "doubao-seedream-5-0-pro-260628",
-    "doubao-seedream-5.0-pro",
     "doubao-seedream-5-0-260128",
-    "doubao-seedream-5.0-lite",
     "doubao-seedream-4-5-251128",
     "doubao-seedream-4-0-250828",
     "doubao-seedream-3-0-t2i-250415",

--- a/seedream/tools/image_tools.py
+++ b/seedream/tools/image_tools.py
@@ -35,7 +35,6 @@ async def seedream_generate_image(
             "'doubao-seedream-5-0-pro-260628' (v5.0 Pro, flagship single image, highest quality; "
             "no sequential generation, streaming, or web search). "
             "'doubao-seedream-5-0-260128' (v5.0 Lite, latest flagship, sequential generation, streaming, web search). "
-            "'doubao-seedream-5.0-lite' (v5.0 economy variant, faster and lower cost). "
             "'doubao-seedream-4-5-251128' (v4.5, previous flagship, great quality). "
             "'doubao-seedream-4-0-250828' (v4.0, stable, best value). "
             "'doubao-seedream-3-0-t2i-250415' (v3 text-to-image, supports seed and guidance_scale). "

--- a/seedream/tools/info_tools.py
+++ b/seedream/tools/info_tools.py
@@ -22,7 +22,6 @@ async def seedream_list_models() -> str:
 |-------|---------|------|----------|-------|
 | `doubao-seedream-5-0-pro-260628` | v5.0 Pro | Text-to-Image | Flagship single image, highest quality. No sequential/streaming/web search | ~$0.044-0.088/image |
 | `doubao-seedream-5-0-260128` | v5.0 Lite | Text-to-Image | Latest flagship, highest quality, sequential generation, streaming, web search | ~$0.040/image |
-| `doubao-seedream-5.0-lite` | v5.0 | Text-to-Image | Economy v5.0 variant, faster and lower cost | lower cost |
 | `doubao-seedream-4-5-251128` | v4.5 | Text-to-Image | Previous flagship, great quality, sequential generation, streaming | ~$0.037/image |
 | `doubao-seedream-4-0-250828` | v4.0 | Text-to-Image | Stable, cost-effective, sequential generation, streaming | ~$0.030/image |
 | `doubao-seedream-3-0-t2i-250415` | v3.0 | Text-to-Image | Seed control, guidance scale, reproducible results | ~$0.038/image |


### PR DESCRIPTION
## Problem
The `SeedreamModel` Literal exposed two **dot short-form** IDs — `doubao-seedream-5.0-pro` and `doubao-seedream-5.0-lite` — that the upstream worker does NOT accept. Live proof:

```
model=doubao-seedream-5.0-lite → HTTP 400 "model must be one of doubao-seedream-5-0-pro-260628, doubao-seedream-5-0-260128, ..."
model=doubao-seedream-5.0-pro  → HTTP 400 (same)
```

Volcengine's canonical image model IDs all carry the date suffix (model-list doc 82379/1330310). An LLM picking a dot form from the Literal would always 400.

## Fix
- `core/types.py`: `SeedreamModel` now lists only the 6 canonical date-suffixed IDs the worker accepts (matches PlatformService `ALLOWED_MODELS`, OpenAPI enum, and Clis).
- `tools/image_tools.py` / `tools/info_tools.py`: drop the `doubao-seedream-5.0-lite` description/row.

`ruff check` passes.

## 🤖 对抗评审
Alignment fix removing dead IDs; the remaining 6 IDs were live-verified against the deployed worker whitelist. No behavior change for valid inputs. **VERDICT: CLEAN.**