### PR TITLE
Fix array input schemas across MCP tools

### DIFF
--- a/openai/core/types.py
+++ b/openai/core/types.py
@@ -1,6 +1,8 @@
 """Type definitions for OpenAI MCP server."""
 
-from typing import Literal
+from typing import Annotated, Literal
+
+from pydantic import Field
 
 # Chat completion model options
 ChatModel = Literal[
@@ -112,6 +114,18 @@ EmbeddingModel = Literal[
 
 # Embedding encoding format options
 EmbeddingEncodingFormat = Literal["float", "base64"]
+
+# Embedding inputs accepted by the OpenAI API: one text, a text batch,
+# one token sequence, or a batch of token sequences.
+EmbeddingText = Annotated[str, Field(min_length=1)]
+EmbeddingToken = Annotated[int, Field(ge=0)]
+EmbeddingTokenSequence = Annotated[list[EmbeddingToken], Field(min_length=1)]
+EmbeddingInput = (
+    EmbeddingText
+    | Annotated[list[EmbeddingText], Field(min_length=1, max_length=2048)]
+    | EmbeddingTokenSequence
+    | Annotated[list[EmbeddingTokenSequence], Field(min_length=1, max_length=2048)]
+)
 
 # Image generation/edit model options
 ImageModel = Literal[

--- a/openai/tests/test_embedding_tools.py
+++ b/openai/tests/test_embedding_tools.py
@@ -1,0 +1,67 @@
+"""Unit tests for embedding tools."""
+
+import json
+
+import pytest
+
+from core.server import mcp
+from tools import embedding_tools
+
+
+def test_openai_embedding_schema_accepts_text_and_token_batches():
+    """The MCP schema must expose every input shape accepted by the API."""
+    tool = next(
+        tool for tool in mcp._tool_manager.list_tools() if tool.name == "openai_create_embedding"
+    )
+    input_schema = tool.parameters["properties"]["input"]
+
+    assert input_schema["anyOf"] == [
+        {"minLength": 1, "type": "string"},
+        {
+            "items": {"minLength": 1, "type": "string"},
+            "maxItems": 2048,
+            "minItems": 1,
+            "type": "array",
+        },
+        {
+            "items": {"minimum": 0, "type": "integer"},
+            "minItems": 1,
+            "type": "array",
+        },
+        {
+            "items": {
+                "items": {"minimum": 0, "type": "integer"},
+                "minItems": 1,
+                "type": "array",
+            },
+            "maxItems": 2048,
+            "minItems": 1,
+            "type": "array",
+        },
+    ]
+    assert "Never JSON-stringify an array" in input_schema["description"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "embedding_input",
+    [
+        ["first document", "second document"],
+        [101, 102, 103],
+        [[101, 102], [201, 202]],
+    ],
+)
+async def test_openai_embedding_forwards_array_inputs(monkeypatch, embedding_input):
+    """Text and token arrays must retain their shape in the API payload."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_embeddings(**kwargs):
+        captured_payload.update(kwargs)
+        return {"data": [{"embedding": [0.1]}, {"embedding": [0.2]}]}
+
+    monkeypatch.setattr(embedding_tools.client, "embeddings", mock_embeddings)
+
+    response = await embedding_tools.openai_create_embedding(input=embedding_input)
+
+    assert captured_payload["input"] == embedding_input
+    assert json.loads(response) == {"data": [{"embedding": [0.1]}, {"embedding": [0.2]}]}

--- a/openai/tests/test_image_tools.py
+++ b/openai/tests/test_image_tools.py
@@ -1,0 +1,51 @@
+"""Unit tests for image tools."""
+
+import json
+
+import pytest
+
+from core.server import mcp
+from tools import image_tools
+
+
+def test_openai_edit_image_schema_accepts_single_or_multiple_images():
+    """The MCP schema must expose the API's string-or-array contract."""
+    tool = next(tool for tool in mcp._tool_manager.list_tools() if tool.name == "openai_edit_image")
+    image_schema = tool.parameters["properties"]["image"]
+
+    assert image_schema["anyOf"] == [
+        {"type": "string"},
+        {
+            "items": {"type": "string"},
+            "maxItems": 16,
+            "minItems": 1,
+            "type": "array",
+        },
+    ]
+    assert "Never join multiple URLs with commas" in image_schema["description"]
+    assert "never JSON-stringify the array" in image_schema["description"]
+
+
+@pytest.mark.asyncio
+async def test_openai_edit_image_forwards_image_array(monkeypatch):
+    """Multiple image URLs must remain an array in the API payload."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_images_edits(**kwargs):
+        captured_payload.update(kwargs)
+        return {"data": [{"url": "https://example.com/edited.png"}]}
+
+    monkeypatch.setattr(image_tools.client, "images_edits", mock_images_edits)
+    images = [
+        "https://example.com/base.png",
+        "https://example.com/logo.png",
+    ]
+
+    response = await image_tools.openai_edit_image(
+        image=images,
+        prompt="Replace the base image logo with the reference logo.",
+        model="gpt-image-2",
+    )
+
+    assert captured_payload["image"] == images
+    assert json.loads(response) == {"data": [{"url": "https://example.com/edited.png"}]}

--- a/openai/tools/embedding_tools.py
+++ b/openai/tools/embedding_tools.py
@@ -12,6 +12,7 @@ from core.types import (
     DEFAULT_EMBEDDING_ENCODING_FORMAT,
     DEFAULT_EMBEDDING_MODEL,
     EmbeddingEncodingFormat,
+    EmbeddingInput,
     EmbeddingModel,
 )
 
@@ -19,11 +20,12 @@ from core.types import (
 @mcp.tool()
 async def openai_create_embedding(
     input: Annotated[
-        str,
+        EmbeddingInput,
         Field(
             description=(
-                "Input text to embed. Can be a single string, an array of strings, "
-                "or token arrays. The text to embed into a numerical vector representation."
+                "Input to embed. Pass one text as a string, multiple texts as a real JSON array "
+                "of strings, one token sequence as an integer array, or multiple token sequences "
+                "as an array of integer arrays. Never JSON-stringify an array."
             )
         ),
     ],

--- a/openai/tools/image_tools.py
+++ b/openai/tools/image_tools.py
@@ -200,11 +200,14 @@ async def openai_generate_image(
 @mcp.tool()
 async def openai_edit_image(
     image: Annotated[
-        str,
+        str | Annotated[list[str], Field(min_length=1, max_length=16)],
         Field(
             description=(
-                "Reference image URL(s). Accepts a single URL string or an array of URLs "
-                "for multi-image editing. The image(s) to use as the starting point for edits."
+                "Reference image URL(s). Pass one URL as a string, or multiple URLs as a real "
+                "JSON array of strings (maximum 16) in the intended reference order. For example: "
+                '["https://example.com/base.png", "https://example.com/logo.png"]. Never join '
+                "multiple URLs with commas and never JSON-stringify the array. The first image "
+                "should normally be the base image; describe the role of later references in prompt."
             )
         ),
     ],

--- a/wan/prompts/__init__.py
+++ b/wan/prompts/__init__.py
@@ -91,7 +91,7 @@ def wan_workflow_examples() -> str:
 
 ## Workflow 6: Character Transfer
 1. User has a reference video with a character they want to transfer
-2. Call `wan_generate_video_from_image(prompt="...", image_url=url, model="wan2.6-r2v", reference_video_urls="video1_url,video2_url")`
+2. Call `wan_generate_video_from_image(prompt="...", image_url=url, model="wan2.6-r2v", reference_video_urls=["video1_url", "video2_url"])`
 3. Return task_id
 
 ## Tips:

--- a/wan/tests/test_video_tools.py
+++ b/wan/tests/test_video_tools.py
@@ -1,0 +1,101 @@
+"""Unit tests for video tools."""
+
+import json
+
+import pytest
+
+from core.server import mcp
+from tools import video_tools
+
+
+def test_wan_reference_video_schema_requires_url_array():
+    """Reference videos must be represented as an array, not a joined string."""
+    tool = next(
+        tool
+        for tool in mcp._tool_manager.list_tools()
+        if tool.name == "wan_generate_video_from_image"
+    )
+    reference_schema = tool.parameters["properties"]["reference_video_urls"]
+
+    assert reference_schema["anyOf"] == [
+        {"items": {"type": "string"}, "minItems": 1, "type": "array"},
+        {"type": "null"},
+    ]
+    assert "never join URLs with commas" in reference_schema["description"]
+    assert "never JSON-stringify the array" in reference_schema["description"]
+
+
+@pytest.mark.asyncio
+async def test_wan_forwards_reference_video_array(monkeypatch):
+    """Reference video URLs must remain an array in the API payload."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_generate_video(**kwargs):
+        captured_payload.update(kwargs)
+        return {"task_id": "task-123"}
+
+    monkeypatch.setattr(video_tools.client, "generate_video", mock_generate_video)
+    references = [
+        " https://example.com/reference-one.mp4 ",
+        "https://example.com/reference-two.mp4",
+        " ",
+    ]
+
+    response = await video_tools.wan_generate_video_from_image(
+        prompt="Keep the same character appearance.",
+        image_url="https://example.com/start.png",
+        model="wan2.6-r2v",
+        reference_video_urls=references,
+    )
+
+    assert captured_payload["reference_video_urls"] == [
+        "https://example.com/reference-one.mp4",
+        "https://example.com/reference-two.mp4",
+    ]
+    assert json.loads(response)["task_id"] == "task-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("legacy_value", "expected"),
+    [
+        (
+            "https://example.com/reference-one.mp4, https://example.com/reference-two.mp4",
+            [
+                "https://example.com/reference-one.mp4",
+                "https://example.com/reference-two.mp4",
+            ],
+        ),
+        (
+            "https://example.com/reference.mp4?signature=part-one,part-two",
+            ["https://example.com/reference.mp4?signature=part-one,part-two"],
+        ),
+    ],
+)
+async def test_wan_normalizes_legacy_comma_separated_references(
+    monkeypatch, legacy_value, expected
+):
+    """FastMCP keeps legacy comma strings compatible but sends API arrays."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_generate_video(**kwargs):
+        captured_payload.update(kwargs)
+        return {"task_id": "task-legacy"}
+
+    monkeypatch.setattr(video_tools.client, "generate_video", mock_generate_video)
+    tool = next(
+        tool
+        for tool in mcp._tool_manager.list_tools()
+        if tool.name == "wan_generate_video_from_image"
+    )
+
+    await tool.run(
+        {
+            "prompt": "Keep the same character appearance.",
+            "image_url": "https://example.com/start.png",
+            "model": "wan2.6-r2v",
+            "reference_video_urls": legacy_value,
+        }
+    )
+
+    assert captured_payload["reference_video_urls"] == expected

--- a/wan/tools/video_tools.py
+++ b/wan/tools/video_tools.py
@@ -1,13 +1,29 @@
 """Video generation tools for Wan API."""
 
+import re
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 
 from core.client import client
 from core.server import mcp
 from core.types import DEFAULT_RESOLUTION, Duration, Resolution, ShotType
 from core.utils import format_video_result
+
+_LEGACY_REFERENCE_SEPARATOR = re.compile(r",\s*(?=https?://)", re.IGNORECASE)
+
+
+def _normalize_reference_video_urls(value: list[str] | str) -> list[str]:
+    if isinstance(value, str):
+        value = _LEGACY_REFERENCE_SEPARATOR.split(value)
+    return [url.strip() for url in value if url.strip()]
+
+
+ReferenceVideoURLs = Annotated[
+    list[str],
+    BeforeValidator(_normalize_reference_video_urls),
+    Field(min_length=1),
+]
 
 
 @mcp.tool()
@@ -128,9 +144,14 @@ async def wan_generate_video_from_image(
         Field(description="Video resolution. Options: '480P', '720P' (default), '1080P'."),
     ] = DEFAULT_RESOLUTION,
     reference_video_urls: Annotated[
-        str | None,
+        ReferenceVideoURLs | None,
         Field(
-            description="Comma-separated URLs of reference videos for character/timbre extraction. Used with wan2.6-r2v model."
+            description=(
+                "JSON array of reference video URLs for character/timbre extraction. Used with "
+                "the wan2.6-r2v model. Pass each URL as a separate array item; never join URLs "
+                "with commas and never JSON-stringify the array. Legacy comma-separated strings "
+                "are still accepted for backward compatibility."
+            )
         ),
     ] = None,
     shot_type: Annotated[
@@ -189,7 +210,7 @@ async def wan_generate_video_from_image(
     if duration is not None:
         payload["duration"] = duration
     if reference_video_urls:
-        payload["reference_video_urls"] = [url.strip() for url in reference_video_urls.split(",")]
+        payload["reference_video_urls"] = _normalize_reference_video_urls(reference_video_urls)
     if shot_type is not None:
         payload["shot_type"] = shot_type
     if audio_url:


### PR DESCRIPTION
## Summary

- expose `openai_edit_image.image` as one URL or a real array of 1-16 URLs
- expose `openai_create_embedding.input` as text, text batch, token sequence, or token-sequence batch
- expose Wan `reference_video_urls` as a real non-empty URL array while retaining compatibility with the previously documented comma-separated format
- add generated FastMCP schema and payload-forwarding regressions for all three paths

## Root cause and audit

Production conversation `3735f816-f602-4a54-b7d5-e41458adaa74` showed the model trying OpenAI multi-image edits first as a comma-joined string and then as a JSON-array string. The human description said arrays were supported, but FastMCP exposed `image.type = string`, so the model was structurally steered into the wrong shape.

A repository-wide audit of MCP tool descriptions, annotations, plural URL/ID parameters, and manual comma parsing found two more mismatches:

1. OpenAI embeddings described string/token arrays but exposed only `str`.
2. Wan reference videos required a comma-separated string and manually split it even though the API consumes an array.

No additional scalar-versus-array mismatches remain in `*/tools/*.py`.

## Compatibility and constraints

- Wan's published schema now shows only `array<string>`, but a Pydantic pre-validator still accepts old comma-separated calls through FastMCP `Tool.run`.
- Legacy splitting occurs only before another absolute HTTP(S) URL, so commas inside signed URLs are preserved.
- Both legacy strings and preferred arrays are trimmed and blank entries are dropped.
- Embedding text/token inputs are non-empty, token IDs are non-negative, and batch inputs are capped at 2048.

## Validation

- OpenAI: `pytest tests -q` (23 passed)
- OpenAI: `ruff check . && ruff format --check . && mypy core tools`
- Wan: `pytest tests -q` (26 passed, 3 credential-gated integration tests skipped)
- Wan: `ruff check . && ruff format --check . && mypy core tools`
- FastMCP `Tool.run` regression covers the legacy Wan string path

## 🤖 对抗评审 (reviewer: claude-subagent + codex, 3 rounds)

- RISK: Wan scalar-to-array change could break released comma-string callers → fixed with an array-only schema plus runtime compatibility validator.
- RISK: comma splitting could corrupt URLs containing commas → fixed by splitting only before another absolute HTTP(S) URL.
- RISK: preferred URL arrays were not trimmed like legacy strings → fixed by shared normalization for both paths.
- RISK: embedding token schema allowed negative IDs → fixed with non-negative token constraints.
- Final verdict: `VERDICT: CLEAN`.
