### PR TITLE
fix(maestro): add MCP Registry ownership name to README

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -1,5 +1,7 @@
 # Maestro MCP Server
 
+<!-- mcp-name: io.github.AceDataCloud/mcp-maestro -->
+
 Produce complete videos from a natural-language brief with [Maestro](https://studio.acedata.cloud/maestro) through the Ace Data Cloud API. Maestro plans the script, creates or sources media, generates voiceover and music, edits, captions, renders, and returns finished video variants.
 
 ## Install


### PR DESCRIPTION
The initial Maestro MCP publish succeeded on PyPI but the **MCP Registry** step failed 400: it validates PyPI ownership by requiring `mcp-name: io.github.AceDataCloud/mcp-maestro` in the package README. This adds that comment under the H1, matching the shorturl/seedance/suno convention. Once synced to `AceDataCloud/MaestroMCP`, the Publish workflow re-publishes to PyPI with the ownership line and the registry step passes.

## 🤖 对抗评审 (reviewer: n/a, trivial)
Metadata-only doc line; no logic. VERDICT: CLEAN.