### PR TITLE
feat(kling): expose canonical Omni tools

### DIFF
--- a/kling/CHANGELOG.md
+++ b/kling/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Information tools:
   - `kling_list_models` - List available models
   - `kling_list_actions` - List available actions
-- Support for 6 models (kling-v1 through kling-video-o1)
+- Support for 9 models, including canonical `kling-o1`
 - Standard and Pro generation modes
 - Camera control support
 - stdio and HTTP transport modes

--- a/kling/README.md
+++ b/kling/README.md
@@ -18,7 +18,7 @@ Generate AI videos, extend clips, and transfer motion directly from Claude, VS C
 - **Image to Video** - Generate videos using reference start/end images
 - **Video Extension** - Extend existing videos with additional content
 - **Motion Transfer** - Transfer motion from a reference video to a character image
-- **Multiple Models** - Support for 6 Kling models (v1, v1-6, v2-master, v2-1-master, v2-5-turbo, video-o1)
+- **Multiple Models** - Support for 9 Kling models, including V3, V3 Omni, and canonical Kling O1
 - **Camera Control** - Fine-grained camera movement control
 - **Task Tracking** - Monitor generation progress and retrieve results
 
@@ -315,7 +315,7 @@ Clients connect with their own Bearer token — the server extracts the token fr
 | `kling-v2-master`  | V2 master (default)  | High-quality, balanced performance  |
 | `kling-v2-1-master`| V2.1 master          | Enhanced quality and consistency    |
 | `kling-v2-5-turbo` | V2.5 turbo           | Faster generation, good quality     |
-| `kling-video-o1`   | Video O1             | Advanced reasoning-based generation |
+| `kling-o1`         | Kling O1             | Omni image/video reference generation |
 
 ## Configuration
 

--- a/kling/core/types.py
+++ b/kling/core/types.py
@@ -2,6 +2,8 @@
 
 from typing import Literal
 
+from pydantic import BaseModel, Field, HttpUrl
+
 # Kling video models
 KlingModel = Literal[
     "kling-v1",
@@ -12,7 +14,7 @@ KlingModel = Literal[
     "kling-v2-6",
     "kling-v3",
     "kling-v3-omni",
-    "kling-video-o1",
+    "kling-o1",
 ]
 
 # Kling video actions
@@ -38,6 +40,40 @@ CameraControlType = Literal[
     "left_turn_forward",
     "right_turn_forward",
 ]
+
+
+class KlingCameraControlConfig(BaseModel):
+    """Numeric camera controls accepted by Kling's simple preset."""
+
+    horizontal: float | None = Field(default=None, ge=-1, le=1)
+    vertical: float | None = Field(default=None, ge=-1, le=1)
+    pan: float | None = Field(default=None, ge=-1, le=1)
+    tilt: float | None = Field(default=None, ge=-1, le=1)
+    roll: float | None = Field(default=None, ge=-1, le=1)
+    zoom: float | None = Field(default=None, ge=-1, le=1)
+
+
+class KlingCameraControl(BaseModel):
+    """Structured camera-control request."""
+
+    type: CameraControlType
+    config: KlingCameraControlConfig | None = None
+
+
+class KlingReferenceImage(BaseModel):
+    """Omni reference image, optionally used as a first or end frame."""
+
+    image_url: HttpUrl
+    type: Literal["first_frame", "end_frame"] | None = None
+
+
+class KlingReferenceVideo(BaseModel):
+    """Omni feature reference or editable base video."""
+
+    video_url: HttpUrl
+    refer_type: Literal["feature", "base"] = "feature"
+    keep_original_sound: Literal["yes", "no"] = "no"
+
 
 # Default values
 DEFAULT_MODEL: KlingModel = "kling-v2-master"

--- a/kling/prompts/__init__.py
+++ b/kling/prompts/__init__.py
@@ -180,7 +180,7 @@ Kling supports camera control with JSON config:
 - **kling-v2-master** (default): Best balance of quality and speed
 - **kling-v2-5-turbo**: Fastest generation
 - **kling-v2-1-master**: Enhanced quality
-- **kling-video-o1**: Advanced reasoning-based generation
+- **kling-o1**: Omni image/video reference generation (5 seconds)
 
 ## Tips for Better Results
 

--- a/kling/tests/test_video_tools.py
+++ b/kling/tests/test_video_tools.py
@@ -4,6 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from core.types import (
+    KlingCameraControl,
+    KlingCameraControlConfig,
+    KlingReferenceImage,
+    KlingReferenceVideo,
+)
+
 
 @pytest.fixture
 def mock_client_generate_video(mock_video_response):
@@ -17,90 +24,214 @@ class TestKlingGenerateVideo:
     """Tests for kling_generate_video tool."""
 
     @pytest.mark.asyncio
-    async def test_element_list_included_in_payload(self, mock_client_generate_video):
-        """Test that element_list is forwarded to the API when provided."""
+    async def test_image_list_included_in_canonical_o1_payload(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video
 
-        element_list = [{"element_id": "elem-001"}, {"element_id": "elem-002"}]
+        image_list = [KlingReferenceImage(image_url="https://example.com/ref.jpg")]
         await kling_generate_video(
-            prompt="A test video",
-            element_list=element_list,
+            prompt="Animate <<<image_1>>>",
+            model="kling-o1",
+            duration=5,
+            image_list=image_list,
         )
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert kwargs.get("element_list") == element_list
+        assert kwargs["model"] == "kling-o1"
+        assert kwargs["image_list"] == [{"image_url": "https://example.com/ref.jpg"}]
 
     @pytest.mark.asyncio
-    async def test_element_list_omitted_when_none(self, mock_client_generate_video):
-        """Test that element_list is not included when not provided."""
+    async def test_reference_lists_omitted_when_none(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video
 
         await kling_generate_video(prompt="A test video")
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert "element_list" not in kwargs
+        assert "image_list" not in kwargs
+        assert "video_list" not in kwargs
 
     @pytest.mark.asyncio
-    async def test_video_list_included_in_payload(self, mock_client_generate_video):
-        """Test that video_list is forwarded to the API when provided."""
+    async def test_video_list_included_in_v3_omni_payload(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video
 
-        video_list = [{"video_url": "https://example.com/ref.mp4", "refer_type": "feature"}]
+        video_list = [
+            KlingReferenceVideo(
+                video_url="https://example.com/ref.mp4",
+                refer_type="feature",
+                keep_original_sound="yes",
+            )
+        ]
         await kling_generate_video(
-            prompt="A test video",
+            prompt="Continue from <<<video_1>>>",
+            model="kling-v3-omni",
             video_list=video_list,
         )
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert kwargs.get("video_list") == video_list
+        assert kwargs["video_list"] == [
+            {
+                "video_url": "https://example.com/ref.mp4",
+                "refer_type": "feature",
+                "keep_original_sound": "yes",
+            }
+        ]
 
     @pytest.mark.asyncio
-    async def test_video_list_omitted_when_none(self, mock_client_generate_video):
-        """Test that video_list is not included when not provided."""
+    async def test_non_omni_model_rejects_references(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video
 
-        await kling_generate_video(prompt="A test video")
+        result = await kling_generate_video(
+            prompt="A test video",
+            model="kling-v2-master",
+            image_list=[KlingReferenceImage(image_url="https://example.com/ref.jpg")],
+        )
+
+        assert result == "Error: image_list and video_list are not supported by kling-v2-master."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_o1_rejects_unsupported_duration(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video
+
+        result = await kling_generate_video(prompt="A test video", model="kling-o1", duration=10)
+
+        assert result == "Error: kling-o1 supports duration=5 only."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_v3_rejects_duration_outside_range(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video
+
+        result = await kling_generate_video(prompt="A test video", model="kling-v3", duration=16)
+
+        assert result == "Error: kling-v3 duration must be an integer from 3 to 15."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_omni_references_reject_4k(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video
+
+        result = await kling_generate_video(
+            prompt="Use <<<image_1>>>",
+            model="kling-v3-omni",
+            mode="4k",
+            image_list=[KlingReferenceImage(image_url="https://example.com/ref.jpg")],
+        )
+
+        assert result == "Error: mode=4k is not supported with image_list or video_list."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reference_video_limits_images_to_four(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video
+
+        result = await kling_generate_video(
+            prompt="Use references",
+            model="kling-v3-omni",
+            image_list=[
+                KlingReferenceImage(image_url=f"https://example.com/ref-{index}.jpg")
+                for index in range(5)
+            ],
+            video_list=[KlingReferenceVideo(video_url="https://example.com/ref.mp4")],
+        )
+
+        assert (
+            result
+            == "Error: this request supports at most 4 reference images including first/end frames."
+        )
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_structured_camera_control_is_serialized(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video
+
+        await kling_generate_video(
+            prompt="Pan left",
+            model="kling-v3",
+            camera_control=KlingCameraControl(
+                type="simple",
+                config=KlingCameraControlConfig(horizontal=-0.5),
+            ),
+        )
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert "video_list" not in kwargs
+        assert kwargs["camera_control"] == {
+            "type": "simple",
+            "config": {"horizontal": -0.5},
+        }
 
 
 class TestKlingGenerateVideoFromImage:
     """Tests for kling_generate_video_from_image tool."""
 
     @pytest.mark.asyncio
-    async def test_element_list_included_in_payload(self, mock_client_generate_video):
-        """Test that element_list is forwarded when using image2video."""
+    async def test_start_image_is_required(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video_from_image
 
-        element_list = [{"element_id": "elem-001"}]
-        await kling_generate_video_from_image(
+        result = await kling_generate_video_from_image(
             prompt="Animate this image",
-            start_image_url="https://example.com/start.jpg",
-            element_list=element_list,
+            end_image_url="https://example.com/end.jpg",
         )
 
-        _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert kwargs.get("element_list") == element_list
+        assert result == "Error: start_image_url is required for image-to-video generation."
+        mock_client_generate_video.generate_video.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_video_list_included_in_payload(self, mock_client_generate_video):
-        """Test that video_list is forwarded when using image2video."""
+    async def test_duplicate_first_frame_sources_are_rejected(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video_from_image
 
-        video_list = [{"video_url": "https://example.com/ref.mp4", "refer_type": "base"}]
+        result = await kling_generate_video_from_image(
+            prompt="Animate this image",
+            start_image_url="https://example.com/start.jpg",
+            model="kling-v3-omni",
+            image_list=[
+                KlingReferenceImage(
+                    image_url="https://example.com/other-start.jpg",
+                    type="first_frame",
+                )
+            ],
+        )
+
+        assert result == "Error: provide at most one first frame and one end frame."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_feature_video_can_accompany_start_frame(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video_from_image
+
+        video_list = [
+            KlingReferenceVideo(video_url="https://example.com/ref.mp4", refer_type="feature")
+        ]
         await kling_generate_video_from_image(
             prompt="Animate this image",
             start_image_url="https://example.com/start.jpg",
+            model="kling-v3-omni",
             video_list=video_list,
         )
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert kwargs.get("video_list") == video_list
+        assert kwargs["start_image_url"] == "https://example.com/start.jpg"
+        assert kwargs["video_list"][0]["refer_type"] == "feature"
 
     @pytest.mark.asyncio
-    async def test_element_list_omitted_when_none(self, mock_client_generate_video):
-        """Test that element_list is not included when not provided."""
+    async def test_base_video_rejects_start_frame(self, mock_client_generate_video):
+        from tools.video_tools import kling_generate_video_from_image
+
+        result = await kling_generate_video_from_image(
+            prompt="Animate this image",
+            start_image_url="https://example.com/start.jpg",
+            model="kling-o1",
+            video_list=[
+                KlingReferenceVideo(video_url="https://example.com/ref.mp4", refer_type="base")
+            ],
+        )
+
+        assert (
+            result == "Error: an editable base video cannot be combined with first or end frames."
+        )
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reference_lists_omitted_when_none(self, mock_client_generate_video):
         from tools.video_tools import kling_generate_video_from_image
 
         await kling_generate_video_from_image(
@@ -109,17 +240,32 @@ class TestKlingGenerateVideoFromImage:
         )
 
         _, kwargs = mock_client_generate_video.generate_video.call_args
-        assert "element_list" not in kwargs
-
-    @pytest.mark.asyncio
-    async def test_video_list_omitted_when_none(self, mock_client_generate_video):
-        """Test that video_list is not included when not provided."""
-        from tools.video_tools import kling_generate_video_from_image
-
-        await kling_generate_video_from_image(
-            prompt="Animate this image",
-            start_image_url="https://example.com/start.jpg",
-        )
-
-        _, kwargs = mock_client_generate_video.generate_video.call_args
+        assert "image_list" not in kwargs
         assert "video_list" not in kwargs
+
+
+class TestKlingExtendVideo:
+    """Tests for kling_extend_video tool validation."""
+
+    @pytest.mark.asyncio
+    async def test_o1_extend_is_rejected(self, mock_client_generate_video):
+        from tools.video_tools import kling_extend_video
+
+        result = await kling_extend_video(video_id="video-id", prompt="Continue", model="kling-o1")
+
+        assert result == "Error: action=extend is not supported by kling-o1."
+        mock_client_generate_video.generate_video.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_legacy_duration_is_rejected(self, mock_client_generate_video):
+        from tools.video_tools import kling_extend_video
+
+        result = await kling_extend_video(
+            video_id="video-id",
+            prompt="Continue",
+            model="kling-v2-master",
+            duration=7,
+        )
+
+        assert result == "Error: kling-v2-master duration must be 5 or 10."
+        mock_client_generate_video.generate_video.assert_not_awaited()

--- a/kling/tools/info_tools.py
+++ b/kling/tools/info_tools.py
@@ -26,7 +26,7 @@ async def kling_list_models() -> str:
 | kling-v2-6         | V2.6                 | Latest V2 generation improvements     |
 | kling-v3           | V3                   | Next-gen quality, supports 4K mode    |
 | kling-v3-omni      | V3 Omni              | V3 with expanded capabilities, 4K     |
-| kling-video-o1     | Video O1             | Advanced reasoning-based generation   |
+| kling-o1           | Kling O1             | Omni image/video reference generation |
 
 Recommended: kling-v2-master for most video content, kling-v2-5-turbo for faster results.
 """

--- a/kling/tools/video_tools.py
+++ b/kling/tools/video_tools.py
@@ -1,8 +1,9 @@
 """Video generation tools for Kling API."""
 
+from collections.abc import Sequence
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from core.client import client
 from core.server import mcp
@@ -13,10 +14,86 @@ from core.types import (
     DEFAULT_MODEL,
     AspectRatio,
     Duration,
+    KlingCameraControl,
     KlingModel,
+    KlingReferenceImage,
+    KlingReferenceVideo,
     Mode,
 )
 from core.utils import format_video_result
+
+
+def _dump_models(items: Sequence[BaseModel] | None) -> list[dict] | None:
+    if items is None:
+        return None
+    return [item.model_dump(mode="json", exclude_none=True) for item in items]
+
+
+def _validate_video_request(
+    *,
+    model: KlingModel,
+    mode: Mode,
+    duration: Duration,
+    generate_audio: bool,
+    negative_prompt: str | None,
+    cfg_scale: float | None,
+    camera_control: KlingCameraControl | None,
+    image_list: list[KlingReferenceImage] | None,
+    video_list: list[KlingReferenceVideo] | None,
+    start_image_url: str | None = None,
+    end_image_url: str | None = None,
+) -> str | None:
+    has_references = bool(image_list or video_list)
+    uses_omni = model == "kling-o1" or has_references
+
+    if model == "kling-o1":
+        if duration != 5:
+            return "Error: kling-o1 supports duration=5 only."
+        if mode not in ("std", "pro"):
+            return "Error: kling-o1 supports std and pro modes only."
+        if generate_audio:
+            return "Error: generate_audio is not supported by kling-o1."
+    elif model in ("kling-v3", "kling-v3-omni"):
+        if not 3 <= duration <= 15:
+            return f"Error: {model} duration must be an integer from 3 to 15."
+    elif duration not in (5, 10):
+        return f"Error: {model} duration must be 5 or 10."
+
+    if has_references and model not in ("kling-o1", "kling-v3-omni"):
+        return f"Error: image_list and video_list are not supported by {model}."
+    if uses_omni and any(
+        value is not None for value in (negative_prompt, cfg_scale, camera_control)
+    ):
+        return "Error: negative_prompt, cfg_scale, and camera_control are not supported by Omni generation."
+    if has_references and mode == "4k":
+        return "Error: mode=4k is not supported with image_list or video_list."
+
+    frame_count = int(bool(start_image_url)) + int(bool(end_image_url))
+    reference_image_count = frame_count + len(image_list or [])
+    max_images = 4 if video_list else 7
+    if reference_image_count > max_images:
+        return f"Error: this request supports at most {max_images} reference images including first/end frames."
+
+    first_frame_count = int(bool(start_image_url)) + sum(
+        item.type == "first_frame" for item in image_list or []
+    )
+    end_frame_count = int(bool(end_image_url)) + sum(
+        item.type == "end_frame" for item in image_list or []
+    )
+    if first_frame_count > 1 or end_frame_count > 1:
+        return "Error: provide at most one first frame and one end frame."
+    if end_frame_count and not first_frame_count:
+        return "Error: a first frame is required when an end frame is provided."
+
+    if video_list:
+        if len(video_list) != 1:
+            return "Error: video_list must contain exactly one reference video."
+        if generate_audio:
+            return "Error: generate_audio cannot be used with video_list."
+        if video_list[0].refer_type == "base" and (first_frame_count or end_frame_count):
+            return "Error: an editable base video cannot be combined with first or end frames."
+
+    return None
 
 
 @mcp.tool()
@@ -30,7 +107,7 @@ async def kling_generate_video(
     model: Annotated[
         KlingModel,
         Field(
-            description="Kling model to use. Options: 'kling-v1', 'kling-v1-6', 'kling-v2-master' (default), 'kling-v2-1-master', 'kling-v2-5-turbo', 'kling-v2-6', 'kling-v3', 'kling-v3-omni', 'kling-video-o1'."
+            description="Kling model to use. Options: 'kling-v1', 'kling-v1-6', 'kling-v2-master' (default), 'kling-v2-1-master', 'kling-v2-5-turbo', 'kling-v2-6', 'kling-v3', 'kling-v3-omni', 'kling-o1'."
         ),
     ] = DEFAULT_MODEL,
     mode: Annotated[
@@ -48,7 +125,7 @@ async def kling_generate_video(
     duration: Annotated[
         Duration,
         Field(
-            description="Video duration in seconds. For kling-v3/kling-v3-omni: 3-15 (integer). Other models: 5 or 10."
+            description="Video duration in seconds. kling-v3/kling-v3-omni: 3-15; kling-o1: 5 only; other models: 5 or 10."
         ),
     ] = DEFAULT_DURATION,
     generate_audio: Annotated[
@@ -66,25 +143,25 @@ async def kling_generate_video(
     cfg_scale: Annotated[
         float | None,
         Field(
-            description="Classifier-free guidance scale. Higher values follow the prompt more strictly. Typical range: 0.0-1.0."
+            ge=0,
+            le=1,
+            description="Classifier-free guidance scale from 0 to 1. Not supported by Omni generation.",
         ),
     ] = None,
     camera_control: Annotated[
-        str | None,
-        Field(
-            description='Camera control as JSON string. Example: \'{"type": "simple", "config": {"horizontal": 5, "vertical": 0, "pan": 0, "tilt": 0, "roll": 0, "zoom": 0}}\'. Types: \'simple\', \'down_back\', \'forward_up\', \'left_turn_forward\', \'right_turn_forward\'.'
-        ),
+        KlingCameraControl | None,
+        Field(description="Structured camera control. Not supported by Omni generation."),
     ] = None,
-    element_list: Annotated[
-        list | None,
+    image_list: Annotated[
+        list[KlingReferenceImage] | None,
         Field(
-            description="List of reference subjects from the subject library. Each item should contain an 'element_id'. If a reference video is present, reference subjects + reference images must be ≤ 4; otherwise ≤ 7."
+            description="Omni reference images for kling-o1 or kling-v3-omni. Cite them as <<<image_1>>>, <<<image_2>>>, and so on."
         ),
     ] = None,
     video_list: Annotated[
-        list | None,
+        list[KlingReferenceVideo] | None,
         Field(
-            description="List of reference videos. Each item should contain a 'video_url' (MP4/MOV, 3-10s, 720-2160px, 24-60fps, ≤200MB, max 1 video) and optionally 'refer_type' ('feature' or 'base', default 'base') and 'keep_original_sound' ('yes' or 'no')."
+            description="One Omni reference video for kling-o1 or kling-v3-omni. Cite it as <<<video_1>>>. Use refer_type='feature' to reference it or 'base' to edit it."
         ),
     ] = None,
     timeout: Annotated[
@@ -113,6 +190,20 @@ async def kling_generate_video(
     Returns:
         Task ID and generated video information including URLs and state.
     """
+    validation_error = _validate_video_request(
+        model=model,
+        mode=mode,
+        duration=duration,
+        generate_audio=generate_audio,
+        negative_prompt=negative_prompt,
+        cfg_scale=cfg_scale,
+        camera_control=camera_control,
+        image_list=image_list,
+        video_list=video_list,
+    )
+    if validation_error:
+        return validation_error
+
     payload: dict = {
         "action": "text2video",
         "model": model,
@@ -131,11 +222,13 @@ async def kling_generate_video(
     if cfg_scale is not None:
         payload["cfg_scale"] = cfg_scale
     if camera_control:
-        payload["camera_control"] = camera_control
-    if element_list is not None:
-        payload["element_list"] = element_list
-    if video_list is not None:
-        payload["video_list"] = video_list
+        payload["camera_control"] = camera_control.model_dump(exclude_none=True)
+    dumped_images = _dump_models(image_list)
+    if dumped_images is not None:
+        payload["image_list"] = dumped_images
+    dumped_videos = _dump_models(video_list)
+    if dumped_videos is not None:
+        payload["video_list"] = dumped_videos
 
     result = await client.generate_video(**payload)
     return format_video_result(result)
@@ -151,9 +244,7 @@ async def kling_generate_video_from_image(
     ],
     start_image_url: Annotated[
         str,
-        Field(
-            description="URL of the image to use as the first frame of the video. The video will animate from this image."
-        ),
+        Field(description="Required URL of the image to use as the first frame of the video."),
     ] = "",
     end_image_url: Annotated[
         str,
@@ -178,7 +269,7 @@ async def kling_generate_video_from_image(
     duration: Annotated[
         Duration,
         Field(
-            description="Video duration in seconds. For kling-v3/kling-v3-omni: 3-15 (integer). Other models: 5 or 10."
+            description="Video duration in seconds. kling-v3/kling-v3-omni: 3-15; kling-o1: 5 only; other models: 5 or 10."
         ),
     ] = DEFAULT_DURATION,
     generate_audio: Annotated[
@@ -194,24 +285,24 @@ async def kling_generate_video_from_image(
     cfg_scale: Annotated[
         float | None,
         Field(
-            description="Classifier-free guidance scale. Higher values follow the prompt more strictly."
+            ge=0,
+            le=1,
+            description="Classifier-free guidance scale from 0 to 1. Not supported by Omni generation.",
         ),
     ] = None,
     camera_control: Annotated[
-        str | None,
-        Field(description="Camera control as JSON string."),
+        KlingCameraControl | None,
+        Field(description="Structured camera control. Not supported by Omni generation."),
     ] = None,
-    element_list: Annotated[
-        list | None,
+    image_list: Annotated[
+        list[KlingReferenceImage] | None,
         Field(
-            description="List of reference subjects from the subject library. Each item should contain an 'element_id'. If a reference video is present, reference subjects + reference images must be ≤ 4; otherwise ≤ 7."
+            description="Additional Omni reference images for kling-o1 or kling-v3-omni. Do not set type='first_frame' or 'end_frame' when the same frame is already supplied through start_image_url or end_image_url."
         ),
     ] = None,
     video_list: Annotated[
-        list | None,
-        Field(
-            description="List of reference videos. Each item should contain a 'video_url' (MP4/MOV, 3-10s, 720-2160px, 24-60fps, ≤200MB, max 1 video) and optionally 'refer_type' ('feature' or 'base', default 'base') and 'keep_original_sound' ('yes' or 'no')."
-        ),
+        list[KlingReferenceVideo] | None,
+        Field(description="One Omni reference video for kling-o1 or kling-v3-omni."),
     ] = None,
     timeout: Annotated[
         int | None,
@@ -232,13 +323,29 @@ async def kling_generate_video_from_image(
     - You want to create a video transition between two images
     - You need precise control over the video's visual content
 
-    At least one of start_image_url or end_image_url must be provided.
+    start_image_url is required. end_image_url is optional.
 
     Returns:
         Task ID and generated video information including URLs and state.
     """
-    if not start_image_url and not end_image_url:
-        return "Error: At least one of start_image_url or end_image_url must be provided."
+    if not start_image_url:
+        return "Error: start_image_url is required for image-to-video generation."
+
+    validation_error = _validate_video_request(
+        model=model,
+        mode=mode,
+        duration=duration,
+        generate_audio=generate_audio,
+        negative_prompt=negative_prompt,
+        cfg_scale=cfg_scale,
+        camera_control=camera_control,
+        image_list=image_list,
+        video_list=video_list,
+        start_image_url=start_image_url,
+        end_image_url=end_image_url or None,
+    )
+    if validation_error:
+        return validation_error
 
     payload: dict = {
         "action": "image2video",
@@ -262,11 +369,13 @@ async def kling_generate_video_from_image(
     if cfg_scale is not None:
         payload["cfg_scale"] = cfg_scale
     if camera_control:
-        payload["camera_control"] = camera_control
-    if element_list is not None:
-        payload["element_list"] = element_list
-    if video_list is not None:
-        payload["video_list"] = video_list
+        payload["camera_control"] = camera_control.model_dump(exclude_none=True)
+    dumped_images = _dump_models(image_list)
+    if dumped_images is not None:
+        payload["image_list"] = dumped_images
+    dumped_videos = _dump_models(video_list)
+    if dumped_videos is not None:
+        payload["video_list"] = dumped_videos
 
     result = await client.generate_video(**payload)
     return format_video_result(result)
@@ -322,6 +431,16 @@ async def kling_extend_video(
     Returns:
         Task ID and the extended video information.
     """
+    if model == "kling-o1":
+        return "Error: action=extend is not supported by kling-o1."
+    if model in ("kling-v3", "kling-v3-omni"):
+        if not 3 <= duration <= 15:
+            return f"Error: {model} duration must be an integer from 3 to 15."
+    elif duration not in (5, 10):
+        return f"Error: {model} duration must be 5 or 10."
+    if mode == "4k" and model not in ("kling-v3", "kling-v3-omni"):
+        return f"Error: mode=4k is not supported by {model}."
+
     payload: dict = {
         "action": "extend",
         "video_id": video_id,


### PR DESCRIPTION
## Summary
- replace the unlaunched legacy O1 identifier with canonical `kling-o1`
- remove tenant-unsafe `element_list` and add typed Omni `image_list`/`video_list` Pydantic schemas
- replace stringified camera controls with validated structured models
- reject unsupported model/mode/duration/frame/reference combinations before HTTP calls
- align README, model-info output, prompts, and changelog with the nine-model canonical catalog

## Validation
- full Kling MCP pytest: 39 passed, 3 skipped
- `ruff check .`
- `mypy core tools main.py`
- legacy ID/Element documentation and source cleanup checks
- `git diff --check`

## Rollout dependency
Publish this MCP only after PlatformService PR #1500 and PlatformBackend PR #1007 are deployed, canonical billing is synced, worker gates pass live canary, and public OpenAPI/docs are available.

## Adversarial review
Reviewer: read-only Explore fallback, 3 rounds.
- added duration, 4K/reference, image-count, duplicate-frame, base-video, and extend validation tests
- clarified that typed frame references must not duplicate start/end URL fields
- fixed missing MCP-side extend validation for O1 and invalid durations/modes
- rebutted V3 Omni ordinary-route prompt-control finding: without references it intentionally uses standard generation
- ignored unrelated pre-existing motion/config findings outside this diff
- updated the stale README model count/name
- final review found no remaining code risk