### PR TITLE
feat(aichat): expose Kimi K3 models

### DIFF
--- a/aichat/core/types.py
+++ b/aichat/core/types.py
@@ -141,6 +141,8 @@ AiChatV2Model = Literal[
     "deepseek-v3-250324",
     "deepseek-v3.2-exp",
     "deepseek-v4-flash",
+    "kimi-k3",
+    "kimi-k2.6",
     "kimi-k2-0711-preview",
     "kimi-k2-0905-preview",
     "kimi-k2-instruct-0905",

--- a/aichat/tests/test_types.py
+++ b/aichat/tests/test_types.py
@@ -1,0 +1,12 @@
+"""Contract tests for public MCP input types."""
+
+from typing import get_args
+
+from core.types import AiChatV2Model
+
+
+def test_kimi_k3_models_are_available_in_aichat_v2() -> None:
+    models = set(get_args(AiChatV2Model))
+
+    assert "kimi-k3" in models
+    assert "kimi-k2.6" in models


### PR DESCRIPTION
## Summary

- expose `kimi-k3` and `kimi-k2.6` in the AiChat V2 MCP public model Literal
- add a contract test for both model identifiers

## Validation

- Python compile -> passed
- ruff -> passed
- AST/type contract -> passed (`AiChatV2Model` contains both IDs)
- `git diff --check` -> passed
- full local pytest was unavailable because the host Python lacks the package's optional runtime dependencies; CI installs them

## 🤖 对抗评审

- model identifiers, public type placement, and no-fallback behavior reviewed
- no additional MCP hardcoded Kimi lists or runtime fallback paths found
- VERDICT: CLEAN
