### PR TITLE
feat(aichat): expose Claude Fable 5

### DIFF
--- a/aichat/core/types.py
+++ b/aichat/core/types.py
@@ -112,6 +112,7 @@ AiChatV2Model = Literal[
     "claude-3-haiku-20240307",
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
+    "claude-fable-5",
     "claude-haiku-4-5-20251001",
     "claude-opus-4-1-20250805",
     "claude-opus-4-20250514",

--- a/aichat/tests/test_types.py
+++ b/aichat/tests/test_types.py
@@ -10,3 +10,9 @@ def test_kimi_k3_models_are_available_in_aichat_v2() -> None:
 
     assert "kimi-k3" in models
     assert "kimi-k2.6" in models
+
+
+def test_claude_fable_5_is_available_in_aichat_v2() -> None:
+    models = set(get_args(AiChatV2Model))
+
+    assert "claude-fable-5" in models


### PR DESCRIPTION
## Summary
- add `claude-fable-5` to the AiChat v2 public model Literal
- add an explicit model contract test

## Validation
- ruff and strict mypy passed
- 19 tests passed; focused contract tests passed after ordering fix

## Dependency
Merge after PlatformService Fable visibility. The rank-40000 Mongo route is already live.

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- RISK: Fable was placed after Haiku → fixed the Claude-family ordering
- VERDICT: CLEAN