### PR TITLE
Remove Claude Fable 5 from AI Chat MCP

### DIFF
--- a/aichat/core/types.py
+++ b/aichat/core/types.py
@@ -112,7 +112,6 @@ AiChatV2Model = Literal[
     "claude-3-haiku-20240307",
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
-    "claude-fable-5",
     "claude-haiku-4-5-20251001",
     "claude-opus-4-1-20250805",
     "claude-opus-4-20250514",

--- a/aichat/tests/test_types.py
+++ b/aichat/tests/test_types.py
@@ -12,7 +12,7 @@ def test_kimi_k3_models_are_available_in_aichat_v2() -> None:
     assert "kimi-k2.6" in models
 
 
-def test_claude_fable_5_is_available_in_aichat_v2() -> None:
+def test_claude_fable_5_is_not_available_in_aichat_v2() -> None:
     models = set(get_args(AiChatV2Model))
 
-    assert "claude-fable-5" in models
+    assert "claude-fable-5" not in models


### PR DESCRIPTION
## Summary
- remove `claude-fable-5` from the AI Chat v2 public `Literal` schema
- replace the positive availability assertion with a negative contract test

## Dependency graph
- PlatformBackend contract removal -> this MCP schema removal

## Validation
- direct `AiChatV2Model` contract assertion confirms Fable is absent and Opus 4.8 remains
- `ruff check core/types.py tests/test_types.py`
- `python3 -m py_compile core/types.py tests/test_types.py`
- repository-wide search confirms no active Fable references remain except the intentional negative assertion
- `git diff --check`
- full pytest dependency bootstrap was interrupted by network/package download instability; CI runs the standard package suite

## Rollout and rollback
- publish the MCP package after Backend removal
- revert together with Backend and provider-route restoration if support returns

## Out of scope
- no deprecation alias is retained because it would preserve support contrary to the requested removal

## 🤖 对抗评审 (reviewer: claude-subagent, 2 rounds)
- Initial concerns about rejection coverage were addressed/rebutted: the negative Literal contract exists and FastMCP/Pydantic validates tool arguments before client calls.
- Unrelated pre-existing V1/V2 Kimi differences were not changed.
- VERDICT: CLEAN
- Codex was attempted first but unavailable because its account usage limit was exhausted.
