### PR TITLE
feat(grok): expose ttapi :reverse/:official video models

### DIFF
--- a/grok/README.md
+++ b/grok/README.md
@@ -23,7 +23,7 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 | Tool | Description |
 | --- | --- |
 | `grok_chat_completions` | Chat completion (reasoning / vision / tool calling) with Grok chat models. |
-| `grok_text_to_video` | Generate a video from a text prompt (model `grok-imagine-video`). |
+| `grok_text_to_video` | Generate a video from a text prompt (any model except `grok-imagine-video-1.5:official`). |
 | `grok_image_to_video` | Generate a video from an input image (+ optional motion prompt). |
 | `grok_get_task` | Query the status/result of a single generation task. |
 | `grok_get_tasks_batch` | Query the status/result of multiple tasks at once. |
@@ -48,8 +48,10 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 
 | Model | Text→Video | Image→Video | Notes |
 | --- | --- | --- | --- |
-| `grok-imagine-video` | ✅ | ✅ | Default. Lower price. Up to 30s, duration-banded billing. |
-| `grok-imagine-video-1.5-preview` | ❌ | ✅ | Image-to-video only (requires `image_url`). Up to 15s, billed per second. |
+| `grok-imagine-video-1.5-fast:reverse` | ✅ | ✅ | Default. Fastest & cheapest. 6-30s, duration-banded billing. |
+| `grok-imagine-video:reverse` | ✅ | ✅ | Standard. 1-15s, billed per output second. |
+| `grok-imagine-video:official` | ✅ | ✅ | Official endpoint, higher fidelity. 1-15s, per second. |
+| `grok-imagine-video-1.5:official` | ❌ | ✅ | Official image-to-video only (requires `image_url`). Up to 1080p, per second. |
 
 ## Parameters
 
@@ -60,7 +62,7 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 | `reference_image_urls` | image-to-video | Optional list of style/content reference images |
 | `aspect_ratio` | both | `1:1`, `16:9` (default), `9:16`, `4:3`, `3:4`, `3:2`, `2:3` |
 | `resolution` | both | `480p` (default), `720p`, `1080p` |
-| `duration` | both | `grok-imagine-video`: `1`–`30`s; `grok-imagine-video-1.5-preview`: `1`–`15`s (default `8`) |
+| `duration` | both | `grok-imagine-video-1.5-fast:reverse`: `6`–`30`s; other models: `1`–`15`s (default `6`) |
 | `callback_url` | both | Optional async webhook |
 
 ## Installation
@@ -118,7 +120,7 @@ https://grok.mcp.acedata.cloud/mcp
 | --- | --- | --- |
 | `ACEDATACLOUD_API_TOKEN` | API token (required) | — |
 | `ACEDATACLOUD_API_BASE_URL` | API base URL | `https://api.acedata.cloud` |
-| `GROK_DEFAULT_MODEL` | Default model | `grok-imagine-video` |
+| `GROK_DEFAULT_MODEL` | Default model | `grok-imagine-video-1.5-fast:reverse` |
 | `GROK_REQUEST_TIMEOUT` | Request timeout (seconds) | `180` |
 | `MCP_SERVER_NAME` | MCP server name | `grok` |
 | `MCP_TRANSPORT` | Transport mode (`stdio`/`http`) | `stdio` |

--- a/grok/core/config.py
+++ b/grok/core/config.py
@@ -23,7 +23,9 @@ class Settings:
 
     # Default Model
     default_model: str = field(
-        default_factory=lambda: os.getenv("GROK_DEFAULT_MODEL", "grok-imagine-video")
+        default_factory=lambda: os.getenv(
+            "GROK_DEFAULT_MODEL", "grok-imagine-video-1.5-fast:reverse"
+        )
     )
 
     # Request Configuration

--- a/grok/core/types.py
+++ b/grok/core/types.py
@@ -2,10 +2,14 @@
 
 from typing import Literal
 
-# Grok Imagine video models
+# Grok Imagine video models. The suffix selects the ttapi endpoint:
+#   :reverse  -> UnOfficial (fast/standard, cheaper)
+#   :official -> Official (higher fidelity, per-second pricing)
 GrokVideoModel = Literal[
-    "grok-imagine-video",
-    "grok-imagine-video-1.5-preview",
+    "grok-imagine-video-1.5-fast:reverse",
+    "grok-imagine-video:reverse",
+    "grok-imagine-video:official",
+    "grok-imagine-video-1.5:official",
 ]
 
 # Aspect ratio options
@@ -14,8 +18,8 @@ AspectRatio = Literal["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
 # Output resolution options
 VideoResolution = Literal["480p", "720p", "1080p"]
 
-# Default model
-DEFAULT_MODEL: GrokVideoModel = "grok-imagine-video"
+# Default model (cheap fast/reverse tier)
+DEFAULT_MODEL: GrokVideoModel = "grok-imagine-video-1.5-fast:reverse"
 
 # Default aspect ratio
 DEFAULT_ASPECT_RATIO: AspectRatio = "16:9"
@@ -23,9 +27,9 @@ DEFAULT_ASPECT_RATIO: AspectRatio = "16:9"
 # Default resolution
 DEFAULT_RESOLUTION: VideoResolution = "480p"
 
-# Default video duration (seconds); valid range 1-30 for grok-imagine-video,
-# 1-15 for grok-imagine-video-1.5-preview
-DEFAULT_DURATION: int = 8
+# Default video duration (seconds). Valid range 6-30 for
+# grok-imagine-video-1.5-fast:reverse; 1-15 for every other variant.
+DEFAULT_DURATION: int = 6
 
 # Grok chat completion models
 GrokChatModel = Literal[

--- a/grok/tests/conftest.py
+++ b/grok/tests/conftest.py
@@ -53,7 +53,7 @@ def mock_task_response():
         "id": "task-123",
         "created_at": 1705788000.0,
         "request": {
-            "model": "grok-imagine-video",
+            "model": "grok-imagine-video-1.5-fast:reverse",
             "prompt": "A test video",
         },
         "response": {

--- a/grok/tests/test_client.py
+++ b/grok/tests/test_client.py
@@ -34,7 +34,7 @@ async def test_chat_completions_builds_payload_and_drops_none(monkeypatch) -> No
 def test_with_async_callback_injects_default_callback() -> None:
     """Long-running Grok operations should default to async submission."""
     client = GrokClient(api_token="test-token", base_url="https://api.test.com")
-    payload = client._with_async_callback({"model": "grok-imagine-video"})
+    payload = client._with_async_callback({"model": "grok-imagine-video-1.5-fast:reverse"})
     assert payload["async"] is True
 
 

--- a/grok/tests/test_config.py
+++ b/grok/tests/test_config.py
@@ -13,7 +13,7 @@ def test_settings_default_values():
 
         settings = Settings()
         assert settings.api_base_url == "https://api.acedata.cloud"
-        assert settings.default_model == "grok-imagine-video"
+        assert settings.default_model == "grok-imagine-video-1.5-fast:reverse"
         assert settings.request_timeout == 180.0
         assert settings.server_name == "grok"
         assert settings.transport == "stdio"
@@ -24,7 +24,7 @@ def test_settings_from_environment():
     env_vars = {
         "ACEDATACLOUD_API_TOKEN": "my-token",
         "ACEDATACLOUD_API_BASE_URL": "https://custom.api.com",
-        "GROK_DEFAULT_MODEL": "grok-imagine-video-1.5-preview",
+        "GROK_DEFAULT_MODEL": "grok-imagine-video:official",
         "GROK_REQUEST_TIMEOUT": "300",
         "MCP_SERVER_NAME": "my-grok",
         "LOG_LEVEL": "DEBUG",
@@ -36,7 +36,7 @@ def test_settings_from_environment():
         settings = Settings()
         assert settings.api_token == "my-token"
         assert settings.api_base_url == "https://custom.api.com"
-        assert settings.default_model == "grok-imagine-video-1.5-preview"
+        assert settings.default_model == "grok-imagine-video:official"
         assert settings.request_timeout == 300.0
         assert settings.server_name == "my-grok"
         assert settings.log_level == "DEBUG"

--- a/grok/tests/test_integration.py
+++ b/grok/tests/test_integration.py
@@ -43,7 +43,7 @@ class TestVideoTools:
 
         result = await grok_text_to_video(
             prompt="A simple blue sky with white clouds drifting slowly",
-            model="grok-imagine-video",
+            model="grok-imagine-video-1.5-fast:reverse",
             aspect_ratio="16:9",
             resolution="480p",
             duration=3,
@@ -89,8 +89,8 @@ class TestInfoTools:
         print("\n=== List Models Result ===")
         print(result)
 
-        assert "grok-imagine-video" in result
-        assert "grok-imagine-video-1.5-preview" in result
+        assert "grok-imagine-video-1.5-fast:reverse" in result
+        assert "grok-imagine-video-1.5:official" in result
 
     @pytest.mark.asyncio
     async def test_list_actions(self) -> None:
@@ -133,7 +133,7 @@ class TestTaskTools:
         # Generate a video first
         gen_result = await grok_text_to_video(
             prompt="A simple test scene with blue sky",
-            model="grok-imagine-video",
+            model="grok-imagine-video-1.5-fast:reverse",
             aspect_ratio="16:9",
             resolution="480p",
             duration=3,

--- a/grok/tests/test_utils.py
+++ b/grok/tests/test_utils.py
@@ -48,7 +48,7 @@ class TestFormatTaskResult:
         result = format_task_result(mock_task_response)
         data = json.loads(result)
         assert data["id"] == "task-123"
-        assert data["request"]["model"] == "grok-imagine-video"
+        assert data["request"]["model"] == "grok-imagine-video-1.5-fast:reverse"
         assert data["response"]["success"] is True
         assert data["response"]["data"][0]["id"] == "video-id-1"
         assert data["mcp_task_polling"]["poll_tool"] == "grok_get_task"

--- a/grok/tools/info_tools.py
+++ b/grok/tools/info_tools.py
@@ -29,15 +29,17 @@ async def grok_list_models() -> str:
 
 Available Grok Imagine Video Models:
 
-| Model                            | Text2Video | Image2Video | Notes                              |
-|----------------------------------|------------|-------------|------------------------------------|
-| grok-imagine-video               | ✅         | ✅          | Default. Lower price. Up to 30s, duration-banded billing. |
-| grok-imagine-video-1.5-preview   | ❌         | ✅          | Image-to-video ONLY (image_url required). Up to 15s, billed per second. |
+| Model                                | Text2Video | Image2Video | Notes                              |
+|--------------------------------------|------------|-------------|------------------------------------|
+| grok-imagine-video-1.5-fast:reverse  | ✅         | ✅          | Default. Fastest & cheapest. 6-30s, duration-banded billing. |
+| grok-imagine-video:reverse           | ✅         | ✅          | Standard. 1-15s, billed per output second. |
+| grok-imagine-video:official          | ✅         | ✅          | Official endpoint, higher fidelity. 1-15s, per second. |
+| grok-imagine-video-1.5:official      | ❌         | ✅          | Official image-to-video ONLY (image_url required). Up to 1080p, per second. |
 
 Usage:
 - grok_chat_completions: chat/reason/vision/tool-calling with the chat models
-- grok_text_to_video: use 'grok-imagine-video' (only model that supports text-to-video)
-- grok_image_to_video: either video model; '-1.5-preview' requires an input image
+- grok_text_to_video: any model EXCEPT grok-imagine-video-1.5:official (that one is image-only)
+- grok_image_to_video: any video model; grok-imagine-video-1.5:official requires an input image
 
 Aspect Ratios:
 - 16:9: Landscape/widescreen (default)
@@ -48,12 +50,12 @@ Aspect Ratios:
 Resolution Options:
 - 480p: Default, cheaper
 - 720p: Higher quality
-- 1080p: Highest quality (grok-imagine-video-1.5-preview costs more per second)
+- 1080p: Highest quality (per-second-priced models cost more)
 
 Duration:
-- grok-imagine-video: 1-30 seconds, billed in duration bands (1-10 / 11-20 / 21-30)
-- grok-imagine-video-1.5-preview: 1-15 seconds, billed per output second
-- Default 8 seconds
+- grok-imagine-video-1.5-fast:reverse: 6-30 seconds, billed in bands (6-10 / 11-20 / 21-30)
+- all other models: 1-15 seconds, billed per output second
+- Default 6 seconds
 """
 
 
@@ -73,7 +75,7 @@ Chat:
 - grok_chat_completions: Chat / reasoning / vision / tool-calling with Grok chat models
 
 Video Generation:
-- grok_text_to_video: Create video from a text prompt (grok-imagine-video only)
+- grok_text_to_video: Create video from a text prompt (any model except grok-imagine-video-1.5:official)
 - grok_image_to_video: Create video from an input image (+ optional prompt)
 
 Task Management:

--- a/grok/tools/video_tools.py
+++ b/grok/tools/video_tools.py
@@ -23,13 +23,13 @@ async def grok_text_to_video(
     prompt: Annotated[
         str,
         Field(
-            description="Description of the video to generate. Be descriptive about scene, subject, action, camera movement, lighting, and style. Examples: 'A cinematic shot of a kitten chasing a butterfly in a sunlit garden', 'Drone shot flying over a neon-lit cyberpunk city at night'. Required for text-to-video with the 'grok-imagine-video' model."
+            description="Description of the video to generate. Be descriptive about scene, subject, action, camera movement, lighting, and style. Examples: 'A cinematic shot of a kitten chasing a butterfly in a sunlit garden', 'Drone shot flying over a neon-lit cyberpunk city at night'. Required for text-to-video."
         ),
     ],
     model: Annotated[
         GrokVideoModel,
         Field(
-            description="Grok Imagine model. 'grok-imagine-video' (default) supports both text-to-video and image-to-video at a lower price. 'grok-imagine-video-1.5-preview' supports image-to-video ONLY and requires an image_url — do not use it here for text-to-video."
+            description="Grok Imagine model. Text-to-video is supported by 'grok-imagine-video-1.5-fast:reverse' (default, fast 6-30s), 'grok-imagine-video:reverse' (standard 1-15s), and 'grok-imagine-video:official' (official, higher fidelity). Do NOT use 'grok-imagine-video-1.5:official' here — it is image-to-video only."
         ),
     ] = DEFAULT_MODEL,
     aspect_ratio: Annotated[
@@ -41,7 +41,7 @@ async def grok_text_to_video(
     resolution: Annotated[
         VideoResolution,
         Field(
-            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p' (higher quality, costs more credits per second for grok-imagine-video-1.5-preview)."
+            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p'. Higher resolution costs more per second on the per-second-priced models."
         ),
     ] = DEFAULT_RESOLUTION,
     duration: Annotated[
@@ -49,7 +49,7 @@ async def grok_text_to_video(
         Field(
             ge=1,
             le=30,
-            description="Video duration in seconds (default 8). grok-imagine-video supports 1-30; grok-imagine-video-1.5-preview supports 1-15.",
+            description="Video duration in seconds (default 6). 'grok-imagine-video-1.5-fast:reverse' supports 6-30; every other model supports 1-15.",
         ),
     ] = DEFAULT_DURATION,
     callback_url: Annotated[
@@ -69,7 +69,8 @@ async def grok_text_to_video(
     - You don't have a reference image to use
     - You want maximum creative freedom
 
-    Only the 'grok-imagine-video' model supports text-to-video. For generating
+    Only the 'grok-imagine-video-1.5-fast:reverse', 'grok-imagine-video:reverse',
+    and 'grok-imagine-video:official' models support text-to-video. For generating
     a video from a reference image, use grok_image_to_video instead.
 
     Returns:
@@ -107,7 +108,7 @@ async def grok_image_to_video(
     model: Annotated[
         GrokVideoModel,
         Field(
-            description="Grok Imagine model. 'grok-imagine-video' (default) supports image-to-video at a lower price. 'grok-imagine-video-1.5-preview' is image-to-video only and may offer higher fidelity."
+            description="Grok Imagine model. All models support image-to-video. 'grok-imagine-video-1.5-fast:reverse' (default) is fastest and cheapest; 'grok-imagine-video-1.5:official' offers the highest fidelity (up to 1080p) and is image-to-video only."
         ),
     ] = DEFAULT_MODEL,
     reference_image_urls: Annotated[
@@ -125,7 +126,7 @@ async def grok_image_to_video(
     resolution: Annotated[
         VideoResolution,
         Field(
-            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p' (higher quality, costs more credits per second for grok-imagine-video-1.5-preview)."
+            description="Output resolution. '480p' (default, cheaper), '720p', or '1080p'. Higher resolution costs more per second on the per-second-priced models."
         ),
     ] = DEFAULT_RESOLUTION,
     duration: Annotated[
@@ -133,7 +134,7 @@ async def grok_image_to_video(
         Field(
             ge=1,
             le=30,
-            description="Video duration in seconds (default 8). grok-imagine-video supports 1-30; grok-imagine-video-1.5-preview supports 1-15.",
+            description="Video duration in seconds (default 6). 'grok-imagine-video-1.5-fast:reverse' supports 6-30; every other model supports 1-15.",
         ),
     ] = DEFAULT_DURATION,
     callback_url: Annotated[


### PR DESCRIPTION
## What

Updates **GrokMCP** video tools to the four endpoint-suffixed models the ttapi worker now routes:

- `grok-imagine-video-1.5-fast:reverse` (default), `grok-imagine-video:reverse`, `grok-imagine-video:official`, and `grok-imagine-video-1.5:official` (image-to-video only).

## Changes

- `core/types.py`: `GrokVideoModel` Literal + defaults (`DEFAULT_MODEL` = fast:reverse, `DEFAULT_DURATION` = 6).
- `core/config.py`: `GROK_DEFAULT_MODEL` default updated.
- `tools/video_tools.py`: tool param descriptions (which models support T2V vs I2V, per-model duration ranges).
- `tools/info_tools.py` + `README.md`: model table and usage notes.
- `tests/`: model literals updated.

`ruff check` clean, `mypy` clean (strict, 13 files), `pytest` 15 passed / 3 skipped.

Depends on the PlatformService worker + PlatformBackend cost/openapi PRs.
