### PR TITLE
fix(maestro,grok): use their own OAuth client_id instead of another MCP's

### DIFF
--- a/grok/deploy/production/deployment.yaml
+++ b/grok/deploy/production/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: MCP_SERVER_URL
               value: "https://grok.mcp.acedata.cloud"
             - name: ACEDATACLOUD_OAUTH_CLIENT_ID
-              value: "svtJ6eNjQAUuUrKMdWo7uKCGq_NEpiKQQfn4JsMBXmQ"
+              value: "Dq3GuZVxsZv3qLc9qM3_60EmiDZbHGKFamR2D-H8Yok"
           resources:
             limits:
               cpu: 500m

--- a/maestro/deploy/production/deployment.yaml
+++ b/maestro/deploy/production/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - name: MCP_SERVER_URL
               value: "https://maestro.mcp.acedata.cloud"
             - name: ACEDATACLOUD_OAUTH_CLIENT_ID
-              value: "ebTMgx6xsrzzmRDjSgTdkwsA0mVqV8Grn0x3yvjq7o4"
+              value: "pP8NMWtKF1-Q4V-1osHUk_PgYYVh5RB_il2FvgahW38"
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## 问题

maestro 的 connector 授权直接失败：

```json
{"error": "invalid_request", "error_description": "redirect_uri is not allowed"}
```

而且同意页显示的是 **MCP ShortURL**，不是 Maestro。

## 原因

`maestro/deploy/production/deployment.yaml` 里的 `ACEDATACLOUD_OAUTH_CLIENT_ID` 填的是 **MCP ShortURL 的 client_id**。

- 同意页按 `client_id` 查应用名 → 显示 "MCP ShortURL"（`OAuthApplicationInfoView`）
- `redirect_uri` 按该 client 自己的白名单校验 → ShortURL 的白名单里只有 `https://shorturl.mcp.acedata.cloud/oauth/callback`，maestro 的回调当然不在里面 → `redirect_uri is not allowed`

顺手排查了全部 25 个 MCP，发现**同样的复制粘贴还有第二处**：`grok` 用的是 **MCP Veo** 的 client_id（`svtJ6eNj…`）。grok 的 OAuth 同样是坏的，只是还没人报。

线上复现（当前 pod）：

```
$ curl -sI '.../authorize?...' | grep location
https://auth.acedata.cloud/oauth2/authorize
  ?client_id=ebTMgx6xsrzzmRDjSgTdkwsA0mVqV8Grn0x3yvjq7o4   ← ShortURL 的
  &redirect_uri=https%3A%2F%2Fmaestro.mcp.acedata.cloud%2Foauth%2Fcallback  ← maestro 的
```

## 改动

在 AuthBackend 注册了两个独立的 OAuth 应用（`public` client + PKCE、`profile platform`，与其余 23 个形状一致），然后把两个 deployment 指向各自的 client_id：

| MCP | 之前（借用） | 现在 |
|---|---|---|
| maestro | `ebTMgx6x…`（MCP ShortURL） | `pP8NMWtK…`（MCP Maestro） |
| grok | `svtJ6eNj…`（MCP Veo） | `Dq3GuZVx…`（MCP Grok） |

`veo` / `shorturl` 保持原 client_id 不动 —— 那本来就是它们自己的。

## 验证

- 两个新应用线上可查：`GET /api/v1/oauth2/application/<client_id>/` 分别返回 `MCP Maestro` / `MCP Grok`，scope `profile+platform`
- 25 个 MCP 的 client_id 现已两两不重复（脚本全量比对）
- **不影响存量用户**：这两个应用的 `app_oauthgrant` 记录数为 **0**（授权在第一步就失败了，从来没成功过），所以换 client_id 不会让任何已授权用户掉线

生效需要 merge 后走 sync → downstream deploy，pod 重启加载新的环境变量。

## 配套 PR

client_id 之前是纯手工在生产库里插的，git 里没有任何记录 —— 这正是当初能抄错的原因。AuthBackend 侧补了 seed + 幂等同步命令，把这 25 个 client 纳入版本管理，并让"两个 client 共用 client_id / redirect_uri"直接同步失败：AceDataCloud/AuthBackend#TBD

## 🤖 对抗评审

评审器：`codex exec --sandbox read-only`（gpt-5.5, xhigh），2 轮收敛。

**Round 1 — RISK：修复依赖只存在于生产库的行，仓库里无法复现。**
两个 deployment 指向了新 client_id，但没有任何 migration / seed / config 定义对应的 `OAuthApplication` 行和 redirect 白名单。一旦重建 auth 库、回滚恢复，或别人重新部署，同样的 OAuth 故障会静默重现。

**已修（配套 PR）**：接受。这条其实点中了根因——正因为没有版本化的登记表，加 maestro / grok 的人才会顺手抄邻居的 client_id。AuthBackend 侧新增 `app/seeds/oauth_applications.yaml`（25 个一等公民 client）+ 幂等的 `sync_oauth_applications` 命令，并加了重复 client_id / 重复 redirect_uri 的硬校验（用原始 bug 的 manifest 实测会直接 `CommandError` 中止）。对线上库 `--dry-run` 结果为 `0 created, 0 updated, 25 unchanged`，证明 manifest 与生产完全一致。

**Round 2/3** 的发现均针对配套 PR，已在该 PR 内修复并记录。本 PR 无遗留 RISK。