### PR TITLE
fix(openai): 图片生成改异步提交，修复 60s 超时截断

### DIFF
--- a/openai/.env.example
+++ b/openai/.env.example
@@ -6,7 +6,7 @@ ACEDATACLOUD_API_TOKEN=your_api_token_here
 ACEDATACLOUD_API_BASE_URL=https://api.acedata.cloud
 
 # OpenAI MCP Configuration (Optional)
-OPENAI_REQUEST_TIMEOUT=60
+OPENAI_REQUEST_TIMEOUT=180
 
 # MCP Server Configuration (Optional)
 MCP_SERVER_NAME=openai

--- a/openai/core/client.py
+++ b/openai/core/client.py
@@ -161,6 +161,21 @@ class OpenAIClient:
         logger.info(f"Image edit with model: {kwargs.get('model', 'unknown')}")
         return await self.request("/openai/images/edits", kwargs)
 
+    def _with_async_callback(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Ensure long-running image operations are submitted asynchronously."""
+        request_payload = dict(payload)
+        if not request_payload.get("callback_url"):
+            request_payload["async"] = True
+        return request_payload
+
+    async def images_generations_async(self, **kwargs: Any) -> dict[str, Any]:
+        """Generate images in async mode and return the submission response immediately."""
+        return await self.images_generations(**self._with_async_callback(kwargs))
+
+    async def images_edits_async(self, **kwargs: Any) -> dict[str, Any]:
+        """Edit images in async mode and return the submission response immediately."""
+        return await self.images_edits(**self._with_async_callback(kwargs))
+
     async def responses(self, **kwargs: Any) -> dict[str, Any]:
         """Create a response using the Responses API."""
         logger.info(f"Responses API with model: {kwargs.get('model', 'unknown')}")

--- a/openai/core/config.py
+++ b/openai/core/config.py
@@ -23,7 +23,7 @@ class Settings:
 
     # Request Configuration
     request_timeout: float = field(
-        default_factory=lambda: float(os.getenv("OPENAI_REQUEST_TIMEOUT", "60"))
+        default_factory=lambda: float(os.getenv("OPENAI_REQUEST_TIMEOUT", "180"))
     )
 
     # Server Configuration

--- a/openai/tests/test_config.py
+++ b/openai/tests/test_config.py
@@ -17,7 +17,7 @@ class TestSettings:
             settings = Settings()
             assert settings.api_base_url == "https://api.acedata.cloud"
             assert settings.api_token == ""
-            assert settings.request_timeout == 60.0
+            assert settings.request_timeout == 180.0
             assert settings.server_name == "openai"
             assert settings.log_level == "INFO"
 

--- a/openai/tests/test_image_tools.py
+++ b/openai/tests/test_image_tools.py
@@ -49,3 +49,40 @@ async def test_openai_edit_image_forwards_image_array(monkeypatch):
 
     assert captured_payload["image"] == images
     assert json.loads(response) == {"data": [{"url": "https://example.com/edited.png"}]}
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_image_submits_async(monkeypatch):
+    """Generation must be submitted asynchronously so slow models don't time out."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_images_generations(**kwargs):
+        captured_payload.update(kwargs)
+        return {"task_id": "t-1"}
+
+    monkeypatch.setattr(image_tools.client, "images_generations", mock_images_generations)
+
+    await image_tools.openai_generate_image(prompt="a panda", model="gpt-image-1")
+
+    assert captured_payload["async"] is True
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_image_defers_to_explicit_callback_url(monkeypatch):
+    """An explicit callback_url already implies async upstream — don't double-flag it."""
+    captured_payload: dict[str, object] = {}
+
+    async def mock_images_generations(**kwargs):
+        captured_payload.update(kwargs)
+        return {"task_id": "t-2"}
+
+    monkeypatch.setattr(image_tools.client, "images_generations", mock_images_generations)
+
+    await image_tools.openai_generate_image(
+        prompt="a panda",
+        model="gpt-image-1",
+        callback_url="https://example.com/hook",
+    )
+
+    assert "async" not in captured_payload
+    assert captured_payload["callback_url"] == "https://example.com/hook"

--- a/openai/tests/test_tasks_tools.py
+++ b/openai/tests/test_tasks_tools.py
@@ -23,3 +23,42 @@ async def test_openai_list_tasks_accepts_images_type(monkeypatch):
     assert captured_payload["action"] == "retrieve_batch"
     assert captured_payload["type"] == "images"
     assert json.loads(response) == {"items": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_openai_get_task_throttles_while_running(monkeypatch):
+    """An unfinished task should back off so pollers don't spin."""
+    slept: list[float] = []
+
+    async def mock_tasks(**_kwargs):
+        return {"id": "t-1", "finished_at": None}
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(tasks_tools.client, "tasks", mock_tasks)
+    monkeypatch.setattr(tasks_tools.asyncio, "sleep", fake_sleep)
+
+    await tasks_tools.openai_get_task(id="t-1")
+
+    assert slept == [5]
+
+
+@pytest.mark.asyncio
+async def test_openai_get_task_returns_immediately_when_finished(monkeypatch):
+    """A finished task must not add latency."""
+    slept: list[float] = []
+
+    async def mock_tasks(**_kwargs):
+        return {"id": "t-1", "finished_at": 1785123456.0, "response": {"data": []}}
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(tasks_tools.client, "tasks", mock_tasks)
+    monkeypatch.setattr(tasks_tools.asyncio, "sleep", fake_sleep)
+
+    result = await tasks_tools.openai_get_task(id="t-1")
+
+    assert slept == []
+    assert json.loads(result)["finished_at"] == 1785123456.0

--- a/openai/tools/image_tools.py
+++ b/openai/tools/image_tools.py
@@ -155,7 +155,10 @@ async def openai_generate_image(
     - You want to generate product mockups or visual concepts
 
     Returns:
-        JSON response containing image URLs or base64 data.
+        JSON with a `task_id`. Generation runs asynchronously — poll
+        `openai_get_task` with that id until it reports `finished_at`, then
+        read the image URLs from its `response`. When `callback_url` is set the
+        result is POSTed there instead.
     """
     try:
         payload: dict[str, Any] = {
@@ -182,7 +185,7 @@ async def openai_generate_image(
         if callback_url is not None:
             payload["callback_url"] = callback_url
 
-        result = await client.images_generations(**payload)
+        result = await client.images_generations_async(**payload)
 
         if not result:
             return json.dumps({"error": "No response received."})
@@ -311,7 +314,10 @@ async def openai_edit_image(
     - You want to apply a specific style or transformation to an image
 
     Returns:
-        JSON response containing the edited image URL(s) or base64 data.
+        JSON with a `task_id`. Editing runs asynchronously — poll
+        `openai_get_task` with that id until it reports `finished_at`, then
+        read the image URLs from its `response`. When `callback_url` is set the
+        result is POSTed there instead.
     """
     try:
         payload: dict[str, Any] = {
@@ -335,7 +341,7 @@ async def openai_edit_image(
         if callback_url is not None:
             payload["callback_url"] = callback_url
 
-        result = await client.images_edits(**payload)
+        result = await client.images_edits_async(**payload)
 
         if not result:
             return json.dumps({"error": "No response received."})

--- a/openai/tools/info_tools.py
+++ b/openai/tools/info_tools.py
@@ -178,7 +178,7 @@ async def openai_get_usage_guide() -> str:
 - background: Run in background mode
 
 ### Image Generation
-**openai_generate_image** - Create images from text descriptions
+**openai_generate_image** - Create images from text descriptions (async: returns a task_id, poll openai_get_task)
 - prompt: Image description (required)
 - model: Image model (default: gpt-image-1)
 - size: Image dimensions (default: 1024x1024)
@@ -187,7 +187,7 @@ async def openai_get_usage_guide() -> str:
 - style: vivid or natural (dall-e-3)
 
 ### Image Editing
-**openai_edit_image** - Modify existing images
+**openai_edit_image** - Modify existing images (async: returns a task_id, poll openai_get_task)
 - image: Reference image URL (required)
 - prompt: Edit description (required)
 - model: Image model (default: gpt-image-1)
@@ -242,20 +242,24 @@ openai_chat_completion(
 
 ### Generate Image
 ```
-openai_generate_image(
+# Image work is asynchronous: this returns a task_id, not the image itself.
+result = openai_generate_image(
     prompt="A futuristic city with flying cars at sunset, photorealistic",
     model="gpt-image-1",
     size="1792x1024"
 )
+# Poll until the task reports finished_at, then read response.data[].url
+openai_get_task(id=result["task_id"])
 ```
 
 ### Edit Image
 ```
-openai_edit_image(
+result = openai_edit_image(
     image="https://example.com/photo.jpg",
     prompt="Add a rainbow in the sky",
     model="gpt-image-1"
 )
+openai_get_task(id=result["task_id"])
 ```
 
 ### Create Embeddings
@@ -268,14 +272,21 @@ openai_create_embedding(
 
 ### Retrieve Async Task
 ```
-# Generate an image with a callback URL and a custom trace_id
+# Every image call is async. Poll by the returned task_id...
+result = openai_generate_image(
+    prompt="A watercolor cat on a desk",
+    model="gpt-image-1"
+)
+openai_get_task(id=result["task_id"])
+
+# ...or tag it with your own trace_id and poll by that instead.
+# Supplying callback_url additionally POSTs the result to your webhook.
 openai_generate_image(
     prompt="A watercolor cat on a desk",
     model="gpt-image-1",
     callback_url="https://webhook.site/your-uuid",
     trace_id="my-custom-trace-001"
 )
-# The task is persisted server-side; poll for the result later
 openai_get_task(trace_id="my-custom-trace-001")
 ```
 

--- a/openai/tools/tasks_tools.py
+++ b/openai/tools/tasks_tools.py
@@ -1,5 +1,6 @@
 """Tasks API tools for OpenAI."""
 
+import asyncio
 import json
 from typing import Annotated, Any, Literal
 
@@ -10,6 +11,11 @@ from core.exceptions import OpenAIAPIError, OpenAIAuthError
 from core.server import mcp
 
 
+def _is_task_finished(result: dict[str, Any]) -> bool:
+    """A task is done once the worker has stamped `finished_at` on it."""
+    return result.get("finished_at") is not None
+
+
 @mcp.tool()
 async def openai_get_task(
     id: Annotated[
@@ -17,7 +23,7 @@ async def openai_get_task(
         Field(
             description=(
                 "Task ID returned by the original image request (e.g. from "
-                "openai_generate_image or openai_edit_image when callback_url was set). "
+                "openai_generate_image or openai_edit_image). "
                 "At least one of 'id' or 'trace_id' must be provided."
             )
         ),
@@ -35,17 +41,16 @@ async def openai_get_task(
 ) -> str:
     """Retrieve a single async image task by its task ID or custom trace ID.
 
-    Image generation and editing requests submitted with a callback_url are
-    processed asynchronously and produce a persistent task record. Use this
-    tool to check whether the task has finished and to retrieve the final
-    result.
+    Image generation and editing requests are submitted asynchronously and
+    return a task_id immediately. Use this tool to poll until the task
+    finishes and to retrieve the final image URLs.
 
-    Note: tasks are only created when the original request included a
-    callback_url. Synchronous (non-callback) calls are not stored.
+    A task is complete once it carries a `finished_at` timestamp. While it is
+    still running this tool waits ~5s before returning, so repeated calls
+    poll at a sane rate.
 
     Use this when:
-    - You previously called openai_generate_image or openai_edit_image with a
-      callback_url and want to retrieve the result
+    - You called openai_generate_image or openai_edit_image and got a task_id
     - You want to check the status of an async image task
 
     Returns:
@@ -64,8 +69,21 @@ async def openai_get_task(
 
         result = await client.tasks(**payload)
 
+        # The worker answers `{}` for an unknown id — say so plainly instead of
+        # reporting it as a transport failure the model would retry forever.
         if not result:
-            return json.dumps({"error": "No response received."})
+            return json.dumps(
+                {
+                    "error": "Task not found",
+                    "message": "No task matches that id or trace_id. Check the id returned by the original image request.",
+                }
+            )
+
+        # Throttle polling: sleep 5s while the task is still running so LLM
+        # clients don't burn through poll attempts in seconds. The worker only
+        # writes `finished_at` once the upstream call returns.
+        if not _is_task_finished(result):
+            await asyncio.sleep(5)
 
         return json.dumps(result, ensure_ascii=False, indent=2)
 
@@ -126,8 +144,8 @@ async def openai_list_tasks(
     least one filter: ids, trace_ids, application_id, user_id, or a
     created_at_min / created_at_max time window.
 
-    Note: tasks are only created when the original request included a
-    callback_url. Synchronous (non-callback) calls are not stored.
+    Every image generation and edit produces a task record, so this lists
+    recent image work regardless of whether a callback_url was used.
 
     Use this when:
     - You want to list multiple tasks at once


### PR DESCRIPTION
## 问题

studio.acedata.cloud 的 AI Chat 调 `openai_generate_image` 配图，模型连试 3 次都失败，每次恰好卡满 60.0 秒。

CLS 日志（conversation `5c16a41a`，req-66m）：

| 时刻 | 事件 |
|---|---|
| 11:34:28 | turn2 结束，调用 `mcp__OpenAI__openai_generate_image` |
| **11:35:28** | turn3 开始 ← 整整 60.0s |
| 11:35:39 | 再次调用（trace `cbcbd9e4`） |
| **11:36:39** | turn4 开始 ← 又是 60.0s，网关记一条 **499 client disconnect** |
| 11:36:48 | turn5 放弃，只吐 52 字符 |
| **11:37:05** | 上游**成功返回**，同一 trace `cbcbd9e4` |

**上游没坏，只是慢**——那次 `gpt-image-1` 耗时 86 秒并成功出图。网关额度很宽裕（`header_timeout_ms: 360000` / `request_timeout_ms: 3600000`），是我们这边先掐断的。对照组 `serp_google_images` 2 秒返回，一次成功。

链路上有两层 60s：aichat2 工具执行器（另一个 PR 修）+ 本仓 httpx `request_timeout`。

## 改动

对齐 `MCPs/nanobanana` 已经验证过的做法：

- **`core/client.py`** — 加 `_with_async_callback()`，无 `callback_url` 时注入 `async: true`；加 `images_generations_async` / `images_edits_async`
- **`tools/image_tools.py`** — 两个图片工具改调 `*_async`，立即拿 `task_id`
- **`tools/tasks_tools.py`** — 未完成任务 `sleep(5)` 节流；任务不存在时返回明确的 `Task not found`，而非会被模型误当网络故障重试的 `No response received`
- **超时 60s → 180s** — 提交已异步，不需要 nano 那样的 1800s；chat/responses 共用同一超时，1800s 会让卡死的请求挂 30 分钟
- **文档修正** — `info_tools.py` 的 usage guide 和示例、`tasks_tools.py` 的 docstring 都还在说"直接返回图片""只有带 callback_url 才建任务"。模型常先读 usage guide，错的指南会让它拿到 task_id 就当结果汇报

## 前提核实

`PlatformService/openai/worker/handlers/image_base.py:54` 的 `if callback_url or is_async` 是**或**关系，且 `_persist_task_initial` / `_persist_task_final` 的门槛都是 `if not self.async_mode: return` —— 所以 `async:true` 不带 callback 会正常落库、可轮询。（`tasks.py` 的 docstring 说"只有 callback_url 才落库"已过时。）

## 验证

**端到端实测**（真实生产 API）：

```
SUBMIT 0.77s -> {"task_id": "44986636-...", "trace_id": "6d7e9f8b-..."}
DONE at 35.6s elapsed=29.56 urls=['https://platform2.cdn.acedata.cloud/gpt-image/44986636-..._0.png']
```

提交 0.77 秒返回，轮询 5s 一次，35.6 秒拿到图。同样这张图在旧路径下若碰上 86 秒的慢响应就会 499。

单测 27 passed / ruff clean / mypy clean。新增 4 条测试覆盖：异步标志注入、显式 callback_url 不重复打标、未完成时节流、已完成时零延迟。

## 🤖 对抗评审

codex 额度耗尽，回退 Claude `general-purpose` subagent。评审提了 6 条，处理如下：

| findings | 处理 |
|---|---|
| **RISK 1**：async 失败仍按 200 全额扣费，比原 bug 更糟 | **驳回（已实测证伪）**。评审和我都误判了：我构造的"失败"用例（`size:9999x9999`）实际**成功了**——任务 `status: success`、`elapsed 29.1s`、正常出图，非法 size 被上游纠正。扣费 0.184 是正常收费。提交拿 task_id 时不扣费，真正扣费在 `/record`，错误不扣 |
| **RISK 2**：`_is_task_finished` 空 dict 分支不可达，会让模型无限轮询 | **已修**。worker 找不到任务返回 `{}`，被上游 `if not result` 当成"没收到响应"。改为返回明确的 `Task not found`；同时删掉 `_is_task_finished` 里那段不可达的空 dict 处理 |
| **RISK 4**：breaking change，但文档/提示词未同步 | **已修**。`info_tools.py` 的工具清单、生成/编辑示例、"Retrieve Async Task" 段落，`tasks_tools.py` 的两处 docstring 全部更新 |
| **RISK 5**：测试名 `keeps_callback_url_sync` 与实现背离 | **已修**。有 callback_url 时 worker 侧 `callback_url or is_async` 决定了它照样异步，"sync" 是错的心智模型。改名为 `defers_to_explicit_callback_url` |
| **RISK 6**：1800s 已无意义且掩盖故障 | **已采纳**，改为 180s |
| **RISK 3**：`images_edits` 的 JSON `async` 可能被 `initialize_callback_from_form` 丢掉 | **保留观察**。评审自己实测线上确实立即返回 task_id（由 TS worker 承接该路由），本仓 Python handler 未生效。已端到端验证 generations 路径；edits 若将来切回该 handler 需补测 |

评审同时核实无问题：`finished_at` 层级与字段名正确、失败任务也会写 `finished_at`（不会无限轮询）、`/tasks` 轮询免费（api_id 在 `SKIP_AUTH_API_IDS`）不重复扣费、monkeypatch 打在正确对象上无假绿、`agents/contracts/openai-mcp.tools.json` 只列工具名无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)