### PR TITLE
ci(webextrator): 补上缺失的 deploy workflow

### DIFF
--- a/webextrator/.github/workflows/deploy.yaml
+++ b/webextrator/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - README.md
+      - CHANGELOG.md
+      - LICENSE
+      - ".github/ISSUE_TEMPLATE/**"
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Build Number
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{ secrets.github_token }}
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+
+      - name: Get Build Number
+        run: |
+          echo $BUILD_NUMBER
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install docker-compose
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Kubectl
+        uses: Azure/k8s-set-context@v4
+        with:
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+
+      - name: Build Docker images
+        run: docker-compose build
+
+      - name: Push Docker images
+        run: docker-compose push
+
+      - name: Deploy
+        run: sh ./deploy/run.sh

--- a/webextrator/deploy/run.sh
+++ b/webextrator/deploy/run.sh
@@ -1,0 +1,3 @@
+cat deploy/production/deployment.yaml | sed 's/\${TAG}/'"$BUILD_NUMBER"'/g' | kubectl apply -f - || true
+kubectl apply -f deploy/production/service.yaml || true
+kubectl apply -f deploy/production/ingress.yaml || true


### PR DESCRIPTION
## 问题

#449 合并后，我逐个进 pod 验证部署，发现：

```
mcp-fish-7cbcb54874-nvb9s          Running 2m52s   ✅ 新代码
mcp-happyhorse-854c85748-8s67l     Running 3m6s    ✅
mcp-maestro-6ccb76466c-4wb4d       Running 3m      ✅
mcp-webextrator-7f9b899f88-dd8hr   Running 20d     ❌ 还是旧代码
```

进 webextrator pod 确认：`grep _apply_submission_mode /app/core/client.py` 无输出 —— **#449 的异步改动发到了 PyPI，但从未上线**。

## 根因

`WebExtratorMCP` 子仓库的流水线只有 **Publish to PyPI**，没有 deploy：

```
2026-07-27T07:21:01Z  Publish to PyPI  success
2026-07-04T10:42:49Z  Publish to PyPI  success
...
```

对比 fish：`fish/.github/workflows/` 有 `deploy.yaml` + `publish.yml`，而 `webextrator/.github/workflows/` **只有 `publish.yml`**。连带 `deploy/run.sh` 也缺失。

线上镜像 tag 也印证了这点 —— webextrator 是 `:430e689`（commit SHA，手动部署的痕迹），而其他 MCP 都是 `:16` 这样的递增构建号。

## 改动

补上两个文件，内容照搬 fish（与具体服务无关）：

- `webextrator/.github/workflows/deploy.yaml` —— 与 fish 的逐字节一致
- `webextrator/deploy/run.sh` —— 同上

webextrator 的其余前提都已就位：`Dockerfile`、`docker-compose.yaml`（已用 `${BUILD_NUMBER}`）、`deploy/production/{deployment,service,ingress}.yaml`（已用 `${TAG}`）。只差这两个文件。

## 影响

合并后 `mcp-webextrator` 恢复自动部署，#449 的异步改动随之上线。

## 🤖 对抗评审

纯 CI 配置补齐，改动是对既有模板的逐字节复制，无业务逻辑。已核实：workflow 内容与服务无关（`diff` 结果为空）、`docker-compose.yaml` 的 service 名与镜像名匹配、`deploy/production/` 三个 yaml 齐备且已使用 `${TAG}` 占位符。`VERDICT: CLEAN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)