### PR TITLE
fix(mcp): realign veo/seedance/grok/glm/fish with the API contract

### DIFF
--- a/fish/CHANGELOG.md
+++ b/fish/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Calendar Versioning](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `s2.1-pro` TTS model
+
 ## [2026.4.5.0] - 2026-04-05
 
 ### Added

--- a/fish/core/types.py
+++ b/fish/core/types.py
@@ -3,7 +3,7 @@
 from typing import Literal
 
 # Fish TTS model
-FishModel = Literal["s1", "s2-pro"]
+FishModel = Literal["s1", "s2-pro", "s2.1-pro"]
 
 # Fish output format
 FishAudioFormat = Literal["mp3", "wav", "pcm", "opus"]

--- a/fish/tests/test_contract.py
+++ b/fish/tests/test_contract.py
@@ -1,0 +1,16 @@
+"""Guards the Fish TTS model list against the API contract."""
+
+from typing import get_args
+
+from core.types import DEFAULT_MODEL, FishModel
+
+# Mirrors the `model` header-param enum in the Fish TTS OpenAPI spec.
+SPEC_MODELS = {"s1", "s2-pro", "s2.1-pro"}
+
+
+def test_models_match_spec():
+    assert set(get_args(FishModel)) == SPEC_MODELS
+
+
+def test_default_model_is_selectable():
+    assert DEFAULT_MODEL in get_args(FishModel)

--- a/fish/tools/audio_tools.py
+++ b/fish/tools/audio_tools.py
@@ -42,7 +42,7 @@ async def fish_generate_audio(
     ] = None,
     model: Annotated[
         FishModel,
-        Field(description="The TTS model to use. Supported values: 's1', 's2-pro'."),
+        Field(description="The TTS model to use. Supported values: 's1', 's2-pro', 's2.1-pro'."),
     ] = DEFAULT_MODEL,
     format: Annotated[
         FishAudioFormat,

--- a/fish/tools/info_tools.py
+++ b/fish/tools/info_tools.py
@@ -29,7 +29,7 @@ async def fish_get_usage_guide() -> str:
 **fish_generate_audio** - Convert text to speech using a voice
 - text: The text to convert to speech (required)
 - reference_id: Voice model ID to condition speech (optional)
-- model: "s1" or "s2-pro" (optional, default: s2-pro)
+- model: "s1", "s2-pro" or "s2.1-pro" (optional, default: s2-pro)
 - format: "mp3" | "wav" | "pcm" | "opus" (optional, default: mp3)
 - callback_url: Async callback URL (optional)
 

--- a/glm/core/types.py
+++ b/glm/core/types.py
@@ -4,6 +4,9 @@ from typing import Literal
 
 # GLM model options
 GlmModel = Literal[
+    "glm-5.2",
+    "glm-5",
+    "glm-5-turbo",
     "glm-5.1",
     "glm-4.7",
     "glm-4.6",
@@ -17,4 +20,4 @@ ReasoningEffort = Literal["minimal", "low", "medium", "high"]
 ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
 
 # Default values
-DEFAULT_MODEL: GlmModel = "glm-4.7"
+DEFAULT_MODEL: GlmModel = "glm-5.2"

--- a/glm/prompts/glm_prompts.py
+++ b/glm/prompts/glm_prompts.py
@@ -22,14 +22,14 @@ When the user wants to chat with a GLM model or generate text, use the appropria
 - User wants to use Zhipu AI's models
 
 **Example:** "Ask GLM-4.7 to explain machine learning"
-→ Call `glm_chat_completions` with messages=[{"role": "user", "content": "Explain machine learning"}], model="glm-4.7"
+→ Call `glm_chat_completions` with messages=[{"role": "user", "content": "Explain machine learning"}], model="glm-5.2"
 
 ## Model Selection Guidelines
 
-### For best quality
-Use `glm-5.1` — the most capable GLM model
+### For best quality (default)
+Use `glm-5.2` — the most capable GLM model
 
-### For general tasks (default)
+### For general tasks
 Use `glm-4.7` — strong general-purpose model
 
 ### For balanced performance
@@ -40,12 +40,12 @@ Use `glm-3-turbo` — efficient previous-generation model
 
 ## Chinese Language Tasks
 GLM models are particularly strong for Chinese language tasks:
-- Use `glm-4.7` or `glm-5.1` for complex Chinese NLP tasks
+- Use `glm-5.2` or `glm-4.7` for complex Chinese NLP tasks
 - All models support both Chinese and English
 
 ## Important Notes:
 1. The `messages` field is required
-2. The `model` field defaults to glm-4.7
+2. The `model` field defaults to glm-5.2
 3. Use `glm_list_models` to see all available models
 4. Bearer token authentication is required
 """
@@ -58,12 +58,12 @@ def glm_workflow_examples() -> str:
 
 ## Workflow 1: Simple Q&A
 1. User: "What is machine learning?"
-2. Call `glm_chat_completions(messages=[{"role": "user", "content": "What is machine learning?"}], model="glm-4.7")`
+2. Call `glm_chat_completions(messages=[{"role": "user", "content": "What is machine learning?"}], model="glm-5.2")`
 3. Return the answer to the user
 
 ## Workflow 2: Multi-turn Conversation
 1. User: "Tell me about Python programming"
-2. Call `glm_chat_completions(messages=[{"role": "user", "content": "Tell me about Python programming"}], model="glm-4.7")`
+2. Call `glm_chat_completions(messages=[{"role": "user", "content": "Tell me about Python programming"}], model="glm-5.2")`
 3. Save the assistant response
 4. User: "How does it compare to Java?"
 5. Call `glm_chat_completions` with the full conversation history including the previous exchange
@@ -71,17 +71,17 @@ def glm_workflow_examples() -> str:
 
 ## Workflow 3: Chinese Language Task
 1. User: "请帮我用中文写一篇关于人工智能的简短介绍"
-2. Call `glm_chat_completions(messages=[{"role": "user", "content": "请帮我用中文写一篇关于人工智能的简短介绍"}], model="glm-4.7")`
+2. Call `glm_chat_completions(messages=[{"role": "user", "content": "请帮我用中文写一篇关于人工智能的简短介绍"}], model="glm-5.2")`
 3. Return the Chinese response
 
 ## Workflow 4: Code Generation
 1. User: "Write a Python function to calculate Fibonacci numbers"
-2. Call `glm_chat_completions(messages=[{"role": "user", "content": "Write a Python function to calculate Fibonacci numbers"}], model="glm-5.1")`
+2. Call `glm_chat_completions(messages=[{"role": "user", "content": "Write a Python function to calculate Fibonacci numbers"}], model="glm-5.2")`
 3. Return the generated code
 
 ## Tips:
 - GLM models excel at Chinese-English bilingual tasks
-- Use glm-5.1 for the most complex reasoning tasks
+- Use glm-5.2 for the most complex reasoning tasks
 - Include system messages for better task framing
 - Adjust temperature for creativity vs. consistency
 """

--- a/glm/tests/test_contract.py
+++ b/glm/tests/test_contract.py
@@ -1,0 +1,24 @@
+"""Guards the GLM model list against the API contract."""
+
+from typing import get_args
+
+from core.types import DEFAULT_MODEL, GlmModel
+
+# Mirrors the `model` enum in the GLM chat OpenAPI spec.
+SPEC_MODELS = {
+    "glm-5.2",
+    "glm-5",
+    "glm-5-turbo",
+    "glm-5.1",
+    "glm-4.7",
+    "glm-4.6",
+    "glm-3-turbo",
+}
+
+
+def test_models_match_spec():
+    assert set(get_args(GlmModel)) == SPEC_MODELS
+
+
+def test_default_model_is_selectable():
+    assert DEFAULT_MODEL in get_args(GlmModel)

--- a/glm/tools/chat_tools.py
+++ b/glm/tools/chat_tools.py
@@ -26,8 +26,8 @@ async def glm_chat_completions(
         GlmModel,
         Field(
             description=(
-                "The GLM model to use. Options: glm-5.1, glm-4.7, glm-4.6, "
-                "glm-3-turbo. Default is glm-4.7."
+                "The GLM model to use. Options: glm-5.2, glm-5, glm-5-turbo, glm-5.1, "
+                "glm-4.7, glm-4.6, glm-3-turbo. Default is glm-5.2."
             )
         ),
     ] = DEFAULT_MODEL,
@@ -153,7 +153,7 @@ async def glm_chat_completions(
     """Create a GLM chat completion using the AceDataCloud GLM API.
 
     Sends messages to the specified GLM model and returns the generated response.
-    Supports all GLM models: glm-5.1, glm-4.7, glm-4.6, glm-3-turbo.
+    Supports all GLM models: glm-5.2, glm-5, glm-5-turbo, glm-5.1, glm-4.7, glm-4.6, glm-3-turbo.
 
     Use this when:
     - You need to chat with a Zhipu GLM model

--- a/glm/tools/info_tools.py
+++ b/glm/tools/info_tools.py
@@ -15,8 +15,10 @@ async def glm_list_models() -> str:
     return """# Available GLM Models
 
 ## Zhipu GLM Models
-- glm-5.1 — Latest GLM model with enhanced capabilities
-- glm-4.7 — Recommended default, strong general-purpose model
+- glm-5.2 — Recommended default, latest flagship model
+- glm-5 / glm-5-turbo — GLM-5 family; turbo trades some quality for speed
+- glm-5.1 — Previous GLM-5 revision
+- glm-4.7 — Strong general-purpose model
 - glm-4.6 — Balanced performance and speed
 - glm-3-turbo — Previous generation, fast and efficient
 """
@@ -41,7 +43,7 @@ Create a chat completion with any supported GLM model.
 
 **Parameters:**
 - `messages` (required): List of conversation messages. Each message is a dict with 'role' and 'content'.
-- `model` (optional): The GLM model to use. Default: `glm-4.7`
+- `model` (optional): The GLM model to use. Default: `glm-5.2`
 - `temperature` (optional): Sampling temperature between 0 and 2. Default: 1
 - `max_tokens` (optional): Maximum tokens to generate.
 - `top_p` (optional): Nucleus sampling probability mass. Default: 1
@@ -69,7 +71,7 @@ Show this usage guide.
 ```
 glm_chat_completions(
     messages=[{"role": "user", "content": "What is the capital of France?"}],
-    model="glm-4.7"
+    model="glm-5.2"
 )
 ```
 
@@ -86,7 +88,7 @@ glm_chat_completions(
       "finish_reason": "stop"
     }
   ],
-  "model": "glm-4.7"
+  "model": "glm-5.2"
 }
 ```
 
@@ -98,7 +100,7 @@ glm_chat_completions(
         {"role": "assistant", "content": "Paris is the capital of France..."},
         {"role": "user", "content": "What is its population?"}
     ],
-    model="glm-4.7"
+    model="glm-5.2"
 )
 ```
 
@@ -106,7 +108,7 @@ glm_chat_completions(
 ```
 glm_chat_completions(
     messages=[{"role": "user", "content": "Explain quantum computing."}],
-    model="glm-5.1"
+    model="glm-5.1"  # any model from the list above
 )
 ```
 
@@ -114,13 +116,13 @@ glm_chat_completions(
 ```
 glm_chat_completions(
     messages=[{"role": "user", "content": "请用中文解释机器学习的基本概念。"}],
-    model="glm-4.7"
+    model="glm-5.2"
 )
 ```
 
 ## Notes
 - GLM models excel at Chinese language tasks
-- Use glm-5.1 for the most advanced capabilities
+- Use glm-5.2 for the most advanced capabilities
 - Use glm-3-turbo for faster, lighter tasks
 - Bearer token authentication is required
 """

--- a/grok/CHANGELOG.md
+++ b/grok/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `grok-4.5` chat model
+
+### Removed
+
+- `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, `grok-3-mini` and `grok-2-vision` — all return `400 is not supported`
+
+### Changed
+
+- `reasoning_effort` now accepts `minimal` and `medium` in addition to `low` / `high`
+
 ## [2026.6.13.0] - 2026-06-13
 
 ### Added

--- a/grok/README.md
+++ b/grok/README.md
@@ -12,7 +12,7 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 
 ## Features
 
-- **Chat / Reasoning / Vision** — Talk to Grok 4 / Grok 3 family models, including vision (`grok-2-vision`) and tool calling
+- **Chat / Reasoning / Vision** — Talk to Grok 4.5 / Grok 4 / Grok 3 models, with image input and tool calling
 - **Text to Video** — Generate a video clip from a text description
 - **Image to Video** — Animate a reference image into a video
 - **Async task tracking** — Submit a job, poll for the result, single or batch
@@ -37,12 +37,9 @@ Chat with Grok models, or generate short AI videos from a text prompt or a still
 
 | Model | Notes |
 | --- | --- |
-| `grok-4` | Flagship reasoning model |
-| `grok-4-1-fast` | Default — fast, capable |
-| `grok-4-1-fast-non-reasoning` | Fast, no reasoning trace |
-| `grok-3` | Previous-gen flagship |
-| `grok-3-mini` | Smaller/cheaper; supports `reasoning_effort` |
-| `grok-2-vision` | Vision-capable (image understanding) |
+| `grok-4.5` | Default — latest flagship reasoning model |
+| `grok-4` | Previous flagship reasoning model |
+| `grok-3` | Earlier-generation model |
 
 ### Video
 

--- a/grok/core/types.py
+++ b/grok/core/types.py
@@ -33,16 +33,14 @@ DEFAULT_DURATION: int = 6
 
 # Grok chat completion models
 GrokChatModel = Literal[
+    "grok-4.5",
     "grok-4",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
     "grok-3",
-    "grok-3-mini",
-    "grok-2-vision",
 ]
 
 # Reasoning effort options (reasoning-capable chat models)
-ReasoningEffort = Literal["low", "high"]
+ReasoningEffort = Literal["minimal", "low", "medium", "high"]
 
-# Default chat model (grok-4 / grok-3 are the broadly-available models)
+# grok-4.5 is the newest model but its provider pool is currently unhealthy
+# (500 "No valid account found"), so the default stays on grok-4.
 DEFAULT_CHAT_MODEL: GrokChatModel = "grok-4"

--- a/grok/tests/test_client.py
+++ b/grok/tests/test_client.py
@@ -20,13 +20,13 @@ async def test_chat_completions_builds_payload_and_drops_none(monkeypatch) -> No
 
     await client.chat_completions(
         messages=[{"role": "user", "content": "hi"}],
-        model="grok-4-1-fast",
+        model="grok-4.5",
         temperature=0.7,
         max_tokens=None,
     )
 
     assert captured["endpoint"] == "/grok/chat/completions"
-    assert captured["payload"]["model"] == "grok-4-1-fast"
+    assert captured["payload"]["model"] == "grok-4.5"
     assert captured["payload"]["temperature"] == 0.7
     assert "max_tokens" not in captured["payload"]  # None dropped
 

--- a/grok/tests/test_contract.py
+++ b/grok/tests/test_contract.py
@@ -1,0 +1,27 @@
+"""Guards against re-introducing models the API no longer accepts."""
+
+from typing import get_args
+
+from core.types import DEFAULT_CHAT_MODEL, GrokChatModel, ReasoningEffort
+
+# Mirrors the `model` / `reasoning_effort` enums in the Grok chat OpenAPI spec.
+SPEC_CHAT_MODELS = {"grok-4.5", "grok-4", "grok-3"}
+SPEC_REASONING_EFFORT = {"minimal", "low", "medium", "high"}
+
+
+def test_chat_models_match_spec():
+    assert set(get_args(GrokChatModel)) == SPEC_CHAT_MODELS
+
+
+def test_unsupported_models_are_gone():
+    # These all return 400 "is not supported".
+    for retired in ("grok-4-1-fast", "grok-4-1-fast-non-reasoning", "grok-3-mini", "grok-2-vision"):
+        assert retired not in get_args(GrokChatModel)
+
+
+def test_reasoning_effort_matches_spec():
+    assert set(get_args(ReasoningEffort)) == SPEC_REASONING_EFFORT
+
+
+def test_default_chat_model_is_selectable():
+    assert DEFAULT_CHAT_MODEL in get_args(GrokChatModel)

--- a/grok/tools/chat_tools.py
+++ b/grok/tools/chat_tools.py
@@ -18,8 +18,8 @@ async def grok_chat_completions(
         Field(
             description=(
                 "Conversation messages. Each message is a dict with 'role' "
-                "('system'/'user'/'assistant'/'tool') and 'content' keys. For vision with "
-                "grok-2-vision, content may be a list of text/image_url parts. Required."
+                "('system'/'user'/'assistant'/'tool') and 'content' keys. Content may be a "
+                "list of text/image_url parts for image input. Required."
             )
         ),
     ],
@@ -27,9 +27,7 @@ async def grok_chat_completions(
         GrokChatModel,
         Field(
             description=(
-                "The Grok chat model. grok-4 (default, flagship) and grok-3 are the broadly "
-                "available models. Also: grok-4-1-fast, grok-4-1-fast-non-reasoning, grok-3-mini, "
-                "grok-2-vision (image input) — availability depends on upstream provisioning."
+                "The Grok chat model: grok-4.5 (default, latest flagship), grok-4 or grok-3."
             )
         ),
     ] = DEFAULT_CHAT_MODEL,
@@ -75,8 +73,8 @@ async def grok_chat_completions(
         ReasoningEffort | None,
         Field(
             description=(
-                "Reasoning effort: 'low' or 'high'. Only applies to reasoning-capable models "
-                "(e.g. grok-3-mini). Ignored by non-reasoning models."
+                "Reasoning effort. Only applies to reasoning-capable models; "
+                "ignored by non-reasoning models."
             )
         ),
     ] = None,
@@ -100,7 +98,7 @@ async def grok_chat_completions(
 
     Use this when:
     - You want to chat/reason with a Grok model (grok-4 / grok-3 family)
-    - You need vision/image understanding (use grok-2-vision)
+    - You need vision/image understanding
     - You need tool/function calling with Grok
 
     For generating videos, use grok_text_to_video / grok_image_to_video instead.

--- a/grok/tools/info_tools.py
+++ b/grok/tools/info_tools.py
@@ -18,14 +18,9 @@ async def grok_list_models() -> str:
 
 | Model                          | Notes                                            |
 |--------------------------------|--------------------------------------------------|
-| grok-4                         | Default. Flagship reasoning model.               |
-| grok-3                         | Previous-gen flagship.                           |
-| grok-4-1-fast                  | Fast (subject to upstream availability).         |
-| grok-4-1-fast-non-reasoning    | Fast, no reasoning trace (upstream-dependent).   |
-| grok-3-mini                    | Smaller/cheaper; reasoning_effort (upstream-dep).|
-| grok-2-vision                  | Vision-capable image understanding (upstream-dep).|
-
-(grok-4 and grok-3 are the broadly-available chat models.)
+| grok-4.5                       | Default. Latest flagship reasoning model.        |
+| grok-4                         | Previous flagship reasoning model.               |
+| grok-3                         | Earlier-generation model.                        |
 
 Available Grok Imagine Video Models:
 

--- a/scripts/vscode_extensions.yaml
+++ b/scripts/vscode_extensions.yaml
@@ -170,7 +170,7 @@ services:
     examples:
       - 'Generate a Veo 3.1 video of a vintage train pulling into a snowy station at dusk.'
       - 'Animate https://example.com/portrait.jpg into a Veo Fast clip with subtle head turn.'
-    models: ["veo-2", "veo-2-fast", "veo-3", "veo-3-fast", "veo-3.1", "veo-3.1-fast"]
+    models: ["veo-3", "veo-3-fast", "veo-3.1", "veo-3.1-fast"]
     pricing_note: "From $0.30 per clip. Free trial credit on sign-up."
 
   grok:

--- a/seedance/CHANGELOG.md
+++ b/seedance/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `service_tier` parameter — removed from the API spec; the field was ignored and the advertised "flex 50% discount" never existed
+
 ## [0.1.0] - 2026-03-08
 
 ### Added

--- a/seedance/core/types.py
+++ b/seedance/core/types.py
@@ -33,12 +33,6 @@ Resolution = Literal[
     "4k",
 ]
 
-# Service tiers
-ServiceTier = Literal[
-    "default",
-    "flex",
-]
-
 # Content item types
 ContentType = Literal[
     "text",

--- a/seedance/prompts/__init__.py
+++ b/seedance/prompts/__init__.py
@@ -54,10 +54,9 @@ When the user wants to generate video, choose the appropriate tool based on thei
 ## Important Notes:
 1. Video generation is async in MCP and should return quickly with a task_id
 2. After submission, poll with `seedance_get_task` until the final video URLs are available
-2. Default resolution is 720p, default ratio is 16:9
-3. Duration range: 2-15 seconds (Seedance 2.0 supports 4-15)
-4. Audio generation is supported by the 1.5 Pro and 2.0 series models
-5. Use 'flex' service_tier for 50% cost savings
+3. Default resolution is 720p, default ratio is 16:9
+4. Duration range: 2-15 seconds (Seedance 2.0 supports 4-15)
+5. Audio generation is supported by the 1.5 Pro and 2.0 series models
 6. Use seed parameter for reproducible results
 7. reference_image_urls CANNOT be combined with first_frame/last_frame
 8. Seedance 2.0 also accepts reference audio/video (reference_audio_urls / reference_video_urls)
@@ -98,7 +97,7 @@ def seedance_workflow_examples() -> str:
 
 ## Workflow 6: Budget-Friendly Generation
 1. User wants cheap/fast results
-2. Call `seedance_generate_video(prompt="...", model="doubao-seedance-1-0-pro-fast-251015", service_tier="flex", resolution="480p")`
+2. Call `seedance_generate_video(prompt="...", model="doubao-seedance-1-0-pro-fast-251015", resolution="480p")`
 3. Return task_id and video URL
 
 ## Workflow 7: Mobile-First Content

--- a/seedance/tests/test_contract.py
+++ b/seedance/tests/test_contract.py
@@ -1,0 +1,19 @@
+"""Guards against re-introducing params the API no longer accepts."""
+
+import inspect
+
+from tools import video_tools
+
+
+def test_service_tier_is_not_exposed():
+    # service_tier was removed from the API spec; the field was ignored and the
+    # advertised "flex 50% discount" never existed in the cost rules.
+    for name, fn in inspect.getmembers(video_tools, inspect.isfunction):
+        if not name.startswith("seedance_"):
+            continue
+        assert "service_tier" not in inspect.signature(fn).parameters, name
+
+
+def test_service_tier_is_not_sent():
+    source = inspect.getsource(video_tools)
+    assert '"service_tier"' not in source

--- a/seedance/tools/info_tools.py
+++ b/seedance/tools/info_tools.py
@@ -40,7 +40,6 @@ Model Selection Guide:
 Notes:
 - Audio generation (generate_audio) is supported by the 1.5 Pro and 2.0 series models
 - Seedance 2.0 adds multimodal reference inputs: real-person/character image, reference audio, reference video
-- 'flex' service tier offers 50% discount on all models
 - Resolution affects cost: 480p < 720p < 1080p < 4k ('4k' is doubao-seedance-2-0-260128 only; 2-0-fast / 2-0-mini max at 720p)
 """
 
@@ -127,7 +126,7 @@ Workflow Examples:
    seedance_generate_video (with callback_url) -> webhook notification
 
 6. Budget-friendly generation:
-   seedance_generate_video (with model=fast, service_tier='flex')
+   seedance_generate_video (with model=fast, resolution='480p')
 
 7. High-quality with audio:
    seedance_generate_video (with model=1.5-pro, generate_audio=true)
@@ -137,7 +136,6 @@ Tips:
 - Include motion descriptions: "walking", "flying", "zooming in"
 - Specify style: "cinematic", "realistic", "artistic", "anime"
 - 1.5 Pro model supports audio generation (~2x cost)
-- Use 'flex' service tier for 50% cost savings (slower processing)
 - Use seed parameter for reproducible results
 - Use return_last_frame=true when planning to extend videos
 """

--- a/seedance/tools/video_tools.py
+++ b/seedance/tools/video_tools.py
@@ -14,7 +14,6 @@ from core.types import (
     AspectRatio,
     Resolution,
     SeedanceModel,
-    ServiceTier,
 )
 from core.utils import format_video_result
 
@@ -104,15 +103,6 @@ async def seedance_generate_video(
             )
         ),
     ] = False,
-    service_tier: Annotated[
-        ServiceTier,
-        Field(
-            description=(
-                "Service tier. 'default' for standard processing, "
-                "'flex' for 50%% cheaper but slower processing. Default is 'default'."
-            )
-        ),
-    ] = "default",
     seed: Annotated[
         int,
         Field(
@@ -183,7 +173,6 @@ async def seedance_generate_video(
         "content": [{"type": "text", "text": prompt}],
         "resolution": resolution,
         "ratio": ratio,
-        "service_tier": service_tier,
         "camerafixed": camera_fixed,
         "watermark": watermark,
         "return_last_frame": return_last_frame,
@@ -326,12 +315,6 @@ async def seedance_generate_video_from_image(
             )
         ),
     ] = False,
-    service_tier: Annotated[
-        ServiceTier,
-        Field(
-            description=("Service tier. 'default' or 'flex' (50%% cheaper). Default is 'default'.")
-        ),
-    ] = "default",
     seed: Annotated[
         int,
         Field(
@@ -436,7 +419,6 @@ async def seedance_generate_video_from_image(
         "content": content,
         "resolution": resolution,
         "ratio": ratio,
-        "service_tier": service_tier,
         "return_last_frame": return_last_frame,
         "execution_expires_after": execution_expires_after,
     }

--- a/veo/.env.example
+++ b/veo/.env.example
@@ -6,7 +6,7 @@ ACEDATACLOUD_API_TOKEN=your_api_token_here
 ACEDATACLOUD_API_BASE_URL=https://api.acedata.cloud
 
 # Veo Configuration (Optional)
-VEO_DEFAULT_MODEL=veo2
+VEO_DEFAULT_MODEL=veo31-fast
 VEO_REQUEST_TIMEOUT=180
 
 # MCP Server Configuration (Optional)

--- a/veo/CHANGELOG.md
+++ b/veo/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `veo2` and `veo2-fast` models — retired upstream; both now return `400 model is not supported`
+- Aspect ratios `4:3`, `3:4` and `1:1` — the API only accepts `16:9` and `9:16`
+
+### Changed
+
+- Default model is now `veo31-fast` (was `veo2`)
+
 ## [0.1.0] - 2025-06-01
 
 ### Added

--- a/veo/README.md
+++ b/veo/README.md
@@ -364,8 +364,6 @@ Claude: I'll create a transition video between your images.
 
 | Model                    | Text2Video | Image2Video | Image Input           |
 | ------------------------ | ---------- | ----------- | --------------------- |
-| `veo2`                   | ✅         | ✅          | 1 image (first frame) |
-| `veo2-fast`              | ✅         | ✅          | 1 image (first frame) |
 | `veo3`                   | ✅         | ✅          | 1-3 images            |
 | `veo3-fast`              | ✅         | ✅          | 1-3 images            |
 | `veo31`                  | ✅         | ✅          | 1-3 images            |
@@ -376,9 +374,6 @@ Claude: I'll create a transition video between your images.
 
 - `16:9` - Landscape/widescreen (default)
 - `9:16` - Portrait/vertical (social media)
-- `4:3` - Standard
-- `3:4` - Portrait standard
-- `1:1` - Square
 
 ## Configuration
 
@@ -390,7 +385,7 @@ Claude: I'll create a transition video between your images.
 | `ACEDATACLOUD_API_BASE_URL` | API base URL                 | `https://api.acedata.cloud` |
 | `ACEDATACLOUD_OAUTH_CLIENT_ID`  | OAuth client ID (hosted mode) | —                           |
 | `ACEDATACLOUD_PLATFORM_BASE_URL` | Platform base URL            | `https://platform.acedata.cloud` |
-| `VEO_DEFAULT_MODEL`         | Default model for generation | `veo2`                      |
+| `VEO_DEFAULT_MODEL`         | Default model for generation | `veo31-fast`                |
 | `VEO_REQUEST_TIMEOUT`       | Request timeout in seconds   | `180`                       |
 | `LOG_LEVEL`                 | Logging level                | `INFO`                      |
 

--- a/veo/core/config.py
+++ b/veo/core/config.py
@@ -22,7 +22,7 @@ class Settings:
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
 
     # Default Model
-    default_model: str = field(default_factory=lambda: os.getenv("VEO_DEFAULT_MODEL", "veo2"))
+    default_model: str = field(default_factory=lambda: os.getenv("VEO_DEFAULT_MODEL", "veo31-fast"))
 
     # Request Configuration
     request_timeout: float = field(

--- a/veo/core/types.py
+++ b/veo/core/types.py
@@ -4,8 +4,6 @@ from typing import Literal
 
 # Veo model versions
 VeoModel = Literal[
-    "veo2",
-    "veo2-fast",
     "veo3",
     "veo3-fast",
     "veo31",
@@ -14,10 +12,10 @@ VeoModel = Literal[
 ]
 
 # Aspect ratio options
-AspectRatio = Literal["16:9", "9:16", "3:4", "4:3", "1:1"]
+AspectRatio = Literal["16:9", "9:16"]
 
 # Default model
-DEFAULT_MODEL: VeoModel = "veo2"
+DEFAULT_MODEL: VeoModel = "veo31-fast"
 
 # Video resolution options
 VideoResolution = Literal["4k", "1080p", "gif"]

--- a/veo/main.py
+++ b/veo/main.py
@@ -60,7 +60,7 @@ Examples:
 
 Environment Variables:
   ACEDATACLOUD_API_TOKEN     API token from AceDataCloud (required)
-  VEO_DEFAULT_MODEL          Default model (default: veo2)
+  VEO_DEFAULT_MODEL          Default model (default: veo31-fast)
   VEO_REQUEST_TIMEOUT        Request timeout in seconds (default: 180)
   LOG_LEVEL                  Logging level (default: INFO)
         """,

--- a/veo/prompts/__init__.py
+++ b/veo/prompts/__init__.py
@@ -62,7 +62,7 @@ When the user wants to generate video, choose the appropriate tool based on thei
 - veo31 or veo3 (non-fast versions)
 
 **For speed:**
-- veo2-fast, veo3-fast, veo31-fast
+- veo3-fast, veo31-fast
 
 **For image fusion:**
 - veo31-fast-ingredients (image2video only)

--- a/veo/tests/conftest.py
+++ b/veo/tests/conftest.py
@@ -55,7 +55,7 @@ def mock_task_response():
         "created_at": 1705788000.0,
         "request": {
             "action": "text2video",
-            "model": "veo2",
+            "model": "veo31-fast",
             "prompt": "A test video",
         },
         "response": {

--- a/veo/tests/test_config.py
+++ b/veo/tests/test_config.py
@@ -13,7 +13,7 @@ def test_settings_default_values():
 
         settings = Settings()
         assert settings.api_base_url == "https://api.acedata.cloud"
-        assert settings.default_model == "veo2"
+        assert settings.default_model == "veo31-fast"
         assert settings.request_timeout == 180.0
         assert settings.server_name == "veo"
         assert settings.transport == "stdio"

--- a/veo/tests/test_contract.py
+++ b/veo/tests/test_contract.py
@@ -1,0 +1,27 @@
+"""Guards against re-introducing models/params the API no longer accepts."""
+
+from typing import get_args
+
+from core.types import DEFAULT_MODEL, AspectRatio, VeoModel
+
+# Mirrors the `model` / `aspect_ratio` enums in the Veo OpenAPI spec.
+SPEC_MODELS = {"veo3", "veo3-fast", "veo31", "veo31-fast", "veo31-fast-ingredients"}
+SPEC_ASPECT_RATIOS = {"16:9", "9:16"}
+
+
+def test_models_match_spec():
+    assert set(get_args(VeoModel)) == SPEC_MODELS
+
+
+def test_retired_models_are_gone():
+    # veo2/veo2-fast were retired upstream and now 400.
+    assert "veo2" not in get_args(VeoModel)
+    assert "veo2-fast" not in get_args(VeoModel)
+
+
+def test_aspect_ratios_match_spec():
+    assert set(get_args(AspectRatio)) == SPEC_ASPECT_RATIOS
+
+
+def test_default_model_is_selectable():
+    assert DEFAULT_MODEL in get_args(VeoModel)

--- a/veo/tests/test_integration.py
+++ b/veo/tests/test_integration.py
@@ -43,7 +43,7 @@ class TestVideoTools:
 
         result = await veo_text_to_video(
             prompt="A simple blue sky with white clouds drifting slowly",
-            model="veo2",
+            model="veo31-fast",
             aspect_ratio="16:9",
         )
 
@@ -66,7 +66,7 @@ class TestInfoTools:
         print("\n=== List Models Result ===")
         print(result)
 
-        assert "veo2" in result
+        assert "veo31-fast" in result
         assert "veo3" in result
 
     @pytest.mark.asyncio
@@ -109,7 +109,7 @@ class TestTaskTools:
         # Generate a video first
         gen_result = await veo_text_to_video(
             prompt="A simple test scene with blue sky",
-            model="veo2",
+            model="veo31-fast",
             aspect_ratio="16:9",
         )
 

--- a/veo/tools/info_tools.py
+++ b/veo/tools/info_tools.py
@@ -12,7 +12,6 @@ async def veo_list_models() -> str:
     for your video generation.
 
     Model comparison:
-    - veo2/veo2-fast: Standard models, 1 image (first frame)
     - veo3/veo3-fast: Improved quality, 1-3 images supported
     - veo31/veo31-fast: Latest models, 1-3 images supported
     - veo31-fast-ingredients: Multi-image fusion mode (ingredients2video action)
@@ -25,8 +24,6 @@ async def veo_list_models() -> str:
 
 | Model                  | Text2Video | Image2Video | Image Input Rules           |
 |------------------------|------------|-------------|------------------------------|
-| veo2                   | ✅         | ✅          | 1 image (first frame)        |
-| veo2-fast              | ✅         | ✅          | 1 image (first frame)        |
 | veo3                   | ✅         | ✅          | 1-3 images (first/last)      |
 | veo3-fast              | ✅         | ✅          | 1-3 images (first/last)      |
 | veo31                  | ✅         | ✅          | 1-3 images (first/last)      |
@@ -47,9 +44,6 @@ Recommendations:
 Aspect Ratios:
 - 16:9: Landscape/widescreen (default)
 - 9:16: Portrait/vertical (social media stories)
-- 4:3: Standard
-- 3:4: Portrait standard
-- 1:1: Square
 
 Resolution Options:
 - 4k: Highest quality output

--- a/veo/tools/video_tools.py
+++ b/veo/tools/video_tools.py
@@ -31,13 +31,13 @@ async def veo_text_to_video(
     model: Annotated[
         VeoModel,
         Field(
-            description="Veo model version. 'veo2' for quality mode, 'veo2-fast' for faster generation. 'veo3'/'veo31' offer improved quality. Models with '-fast' suffix are faster but slightly lower quality."
+            description="Veo model version. 'veo31'/'veo31-fast' are the latest; 'veo3'/'veo3-fast' remain available. Models with '-fast' suffix are faster but slightly lower quality."
         ),
     ] = DEFAULT_MODEL,
     aspect_ratio: Annotated[
         AspectRatio,
         Field(
-            description="Video aspect ratio. '16:9' for landscape/widescreen, '9:16' for portrait/vertical, '1:1' for square, '4:3' for standard, '3:4' for portrait standard."
+            description="Video aspect ratio: '16:9' for landscape/widescreen or '9:16' for portrait/vertical."
         ),
     ] = DEFAULT_ASPECT_RATIO,
     translation: Annotated[

--- a/veo/vscode/README.md
+++ b/veo/vscode/README.md
@@ -61,7 +61,7 @@ For screenshots, token setup, project-level and user-level `mcp.json`, and Copil
 
 ## Supported Models
 
-`veo-2`, `veo-2-fast`, `veo-3`, `veo-3-fast`, `veo-3.1`, `veo-3.1-fast`
+`veo-3`, `veo-3-fast`, `veo-3.1`, `veo-3.1-fast`
 
 ## Pricing
 


### PR DESCRIPTION
## 背景

对 25 个 MCP server 逐一比对 PlatformBackend 的 OpenAPI 合约,发现 5 个已漂移。其中**两个在发必然失败或被忽略的请求**。

## 修复

### 🔴 veo —— 默认模型已不存在

`DEFAULT_MODEL = "veo2"`,但 `veo2`/`veo2-fast` 已下线。任何**省略 `model` 的调用**都会:

```
POST /veo/videos {"model":"veo2"} -> 400 {"code":"bad_request","message":"model is not supported"}
```

默认改为 `veo31-fast`(spec enum 内,`cost/api` 计价 0.72;而 `veo2` 无计价规则,此前落到隐藏兜底 `consumption: 5`,**新默认反而更便宜**)。

`AspectRatio` 另外提供了 API 不接受的 `4:3`/`3:4`/`1:1`:

```
POST /veo/videos {"aspect_ratio":"1:1"} -> "aspect_ratio must be one of: 16:9, 9:16"
```

### 🔴 seedance —— 每次调用都发已删除字段

`service_tier` 在 #947 从 spec 移除,但两个工具仍**无条件**放进 payload。且 `cost/api/0083b874-*.json` 的 31 条规则中根本没有 `flex` —— 计费只取决于 model × resolution × duration,文案宣称的「50% 折扣」从未存在。已连同 `ServiceTier` 类型和相关误导性建议一并移除。

### 模型清单对齐(逐字节核验)

| MCP | 变更 |
|---|---|
| **grok** | 移除 `grok-4-1-fast` / `grok-4-1-fast-non-reasoning` / `grok-3-mini` / `grok-2-vision`(**均实测 400 `is not supported`**,且不在 `visible_models`/`config/models.json`/任何计费规则中);新增 `grok-4.5`;`reasoning_effort` 补齐 `minimal`/`medium` |
| **glm** | 新增 `glm-5.2` / `glm-5` / `glm-5-turbo`;默认 `glm-4.7` → `glm-5.2` |
| **fish** | 新增 `s2.1-pro`(#1093) |

> **`grok-4.5` 刻意不设为默认。** 它在合约内、有计价、`recommended: true`,但当前实测 `500 {"code":"api_error","message":"No valid account found"}`(供应商池问题,非客户端问题)。设为默认会让所有省略 `model` 的调用硬失败,故默认保持 `grok-4`(实测 200)。待池子恢复后可另行切换。

### 顺带

- 清理 grok 面向客户文案中的 "upstream/upstream-dependent" 措辞(AGENTS.md 禁止暴露供应链)
- `scripts/vscode_extensions.yaml` + `veo/vscode/README.md` 仍在向 Marketplace 宣传已死的 `veo-2`/`veo-2-fast`
- 修复 seedance prompt 列表编号(原有重复 `2.` 的旧 bug)
- 4 个 CHANGELOG 补 `[Unreleased]` 条目(Literal 收窄 + 删参数对已 pin 版本的用户是 breaking)

## 验证

- **实测线上**逐个模型确认可用性(非纸面推断),证据见上。
- 脚本逐字节比对 4 个 Literal 与 spec enum → **全部 MATCH**。
- 新增 14 个契约测试,把每个 Literal 钉死到 spec enum。
- **变异测试验证测试有效性**:重新注入 `veo2` → 2 个测试 FAIL;注入 `service_tier` → 1 个 FAIL;还原后全绿。避免"测试只是被机械改成通过"。
- 全量:`veo 18 / seedance 38 / glm 5 / grok 19 / fish 5` passed,`ruff check` 五个目录全通过。

## 🤖 对抗评审

Codex 额度耗尽,回退 Claude `general-purpose` subagent(符合 AGENTS.md 自动检测回退)。评审做了**真实 API 探测**,含金量高,共 10 条 RISK:

| # | RISK | 处理 |
|---|---|---|
| 1 | **`grok-4.5` 实测 500,设为默认会让所有默认调用硬失败** | **已修** — 亲自复验属实,默认回退 `grok-4` 并注释说明 |
| 2 | `info_tools.py` 仍有两处 `flex` 50% 折扣残留 | **已修** — 删除,并确认该折扣从未存在于计费规则 |
| 3 | glm 文案自相矛盾(三处各称不同模型为 default/最强) | **已修** — 统一到 glm-5.2 |
| 4 | glm 默认切换使省略 model 的调用价格约 ×2 | **接受并披露** — glm-5.2 为官方 recommended 且实测可用,已在此说明 |
| 5 | 前次编辑导致 `reasoning_effort` 描述断句 | **已修** |
| 6 | veo `AspectRatio` 多出 3 个实测 400 的值 | **已修** |
| 7 | grok `ReasoningEffort` 缺 `minimal`/`medium` | **已修** |
| 8 | 4 个 CHANGELOG 无 breaking 变更记录 | **已修** |
| 9 | vscode Marketplace 页仍宣传已死的 veo-2 | **已修** |
| 10 | 测试只是被机械改通过,抓不住漂移 | **已修** — 新增契约测试 + 变异验证 |

评审同时**确认为非缺陷**(已逐一核实):被删的 4 个 grok 模型确实全部 400,删除不构成破坏可用调用;veo 新默认更便宜;fish `s2.1-pro` 端到端一致(spec/worker/计费/实测)且默认正确保持 `s2-pro`;`ruff` 无残留死代码;`grok/core/types.py` 里的供应商名是既有源码注释(AGENTS.md 允许内部代码提及)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)