### PR TITLE
feat(mcp): openai/fish/webextrator/maestro 补齐结构化轮询引导

### DIFF
--- a/fish/core/utils.py
+++ b/fish/core/utils.py
@@ -1,0 +1,108 @@
+"""Formatting helpers for MCP Fish server."""
+
+import json
+from typing import Any
+
+POLL_TOOL = "fish_get_task"
+BATCH_POLL_TOOL = "fish_get_tasks_batch"
+
+_POLLING_INTERVAL_SECONDS = 15
+_MAX_POLL_ATTEMPTS = 40
+_EXPECTED_WAIT_SECONDS = 300
+
+
+def _task_outcome(payload: dict[str, Any]) -> tuple[bool, bool]:
+    """Return (is_complete, is_failed) for an async audio task.
+
+    The worker stamps `finished_at` once the job settles — on success *and* on
+    failure — so it alone decides whether polling should stop. `response.error`
+    then tells the two terminal outcomes apart.
+    """
+    if payload.get("finished_at") is None:
+        return False, False
+
+    response = payload.get("response")
+    response = response if isinstance(response, dict) else {}
+    failed = bool(response.get("error")) or response.get("success") is False
+    return not failed, failed
+
+
+def _with_submission_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("task_id") or payload.get("id")
+    if not task_id:
+        return payload
+
+    # Defensive: never tell the model to poll a response that already settled.
+    is_complete, is_failed = _task_outcome(payload)
+    if is_complete or is_failed:
+        return payload
+
+    payload["mcp_async_submission"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll",
+        "should_poll": True,
+        "terminal_state_reached": False,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "expected_wait_seconds": _EXPECTED_WAIT_SECONDS,
+        "next_step": (
+            f'Call {POLL_TOOL}(task_id="{task_id}") until the task reports a '
+            f"`finished_at` timestamp, then read the audio URL from its `response`. "
+            f"Wait at least {_POLLING_INTERVAL_SECONDS} seconds between polls and keep "
+            f"polling for up to {_MAX_POLL_ATTEMPTS} attempts — do NOT stop early or "
+            f"tell the user it failed while the task is still running."
+        ),
+    }
+    return payload
+
+
+def _with_task_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("id") or payload.get("task_id")
+    if not task_id:
+        return payload
+
+    is_complete, is_failed = _task_outcome(payload)
+    should_poll = not (is_complete or is_failed)
+
+    if is_complete:
+        next_step = "Task is complete. Stop polling and present the audio URL to the user."
+    elif is_failed:
+        next_step = (
+            "Task failed. Stop polling and report the error to the user. "
+            "Polling again will not change the outcome."
+        )
+    else:
+        next_step = (
+            f"The task is still running. Wait {_POLLING_INTERVAL_SECONDS} seconds, then call "
+            f'{POLL_TOOL}(task_id="{task_id}") again. '
+            f"Keep polling — do NOT give up or tell the user it failed."
+        )
+
+    payload["mcp_task_polling"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll" if should_poll else "stop",
+        "should_poll": should_poll,
+        "terminal_state_reached": not should_poll,
+        "is_complete": is_complete,
+        "is_failed": is_failed,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "next_step": next_step,
+    }
+    return payload
+
+
+def format_submission_result(data: dict[str, Any]) -> str:
+    """Serialize an async submission response with polling guidance."""
+    return json.dumps(_with_submission_guidance(data), ensure_ascii=False, indent=2)
+
+
+def format_task_result(data: dict[str, Any]) -> str:
+    """Serialize a task query response with polling guidance."""
+    return json.dumps(_with_task_guidance(data), ensure_ascii=False, indent=2)

--- a/fish/tests/test_task_guidance.py
+++ b/fish/tests/test_task_guidance.py
@@ -1,0 +1,40 @@
+"""Polling-guidance blocks attached to fish task responses."""
+
+import json
+
+from core.utils import format_task_result
+
+_RUNNING = {"id": "t-1", "finished_at": None, "response": None}
+_DONE = {"id": "t-1", "finished_at": 1785136982.29, "response": {"success": True}}
+_FAILED = {
+    "id": "t-1",
+    "finished_at": 1785137086.22,
+    "response": {"success": False, "error": {"code": "bad_request", "message": "nope"}},
+}
+
+
+def _guidance(payload):
+    return json.loads(format_task_result(payload))["mcp_task_polling"]
+
+
+def test_running_task_keeps_polling():
+    block = _guidance(_RUNNING)
+    assert block["should_poll"] is True
+    assert block["recommended_action"] == "poll"
+
+
+def test_completed_task_stops():
+    block = _guidance(_DONE)
+    assert block["should_poll"] is False
+    assert block["is_complete"] is True
+
+
+def test_failed_task_stops_instead_of_polling_forever():
+    """A failed task carries `finished_at`; polling it again cannot help."""
+    block = _guidance(_FAILED)
+    assert block["should_poll"] is False
+    assert block["is_failed"] is True
+
+
+def test_payload_without_id_is_left_untouched():
+    assert "mcp_task_polling" not in json.loads(format_task_result({"error": "nope"}))

--- a/fish/tools/audio_tools.py
+++ b/fish/tools/audio_tools.py
@@ -15,6 +15,7 @@ from core.types import (
     FishLatency,
     FishModel,
 )
+from core.utils import format_submission_result
 
 
 @mcp.tool()
@@ -174,7 +175,7 @@ async def fish_generate_audio(
         if not result:
             return json.dumps({"error": "No response received from the API."})
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_submission_result(result)
 
     except FishAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/fish/tools/task_tools.py
+++ b/fish/tools/task_tools.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from core.client import client
 from core.exceptions import FishAPIError, FishAuthError
 from core.server import mcp
+from core.utils import _task_outcome, format_task_result
 
 
 @mcp.tool()
@@ -53,10 +54,11 @@ async def fish_get_task(
         # Throttle polling: sleep 5s while the task is still running so LLM
         # clients don't burn through poll attempts in seconds. The worker only
         # stamps `finished_at` once the job settles.
-        if result.get("finished_at") is None:
+        is_complete, is_failed = _task_outcome(result)
+        if not (is_complete or is_failed):
             await asyncio.sleep(5)
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_task_result(result)
 
     except FishAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/maestro/core/utils.py
+++ b/maestro/core/utils.py
@@ -3,7 +3,117 @@
 import json
 from typing import Any
 
+POLL_TOOL = "maestro_get_task"
+# maestro_list_tasks takes no ids filter, so it cannot poll one task — advertise none.
+BATCH_POLL_TOOL = None
+
+# States that mean "still working". Anything else (succeeded, failed, dead, or
+# a status we don't know yet) is treated as terminal — an unknown state must
+# not strand the caller in an endless poll loop.
+IN_FLIGHT_STATES = {"queued", "pending", "planning", "producing", "running", "processing"}
+_FAILED_STATES = {"failed", "dead", "cancelled", "canceled", "error"}
+
+_POLLING_INTERVAL_SECONDS = 30
+# Cover the worker's own ceiling: AGENT_TIMEOUT=5400s plus queue wait before it
+# starts. Giving up at 60 min would abandon renders that are still alive.
+_MAX_POLL_ATTEMPTS = 220
+_EXPECTED_WAIT_SECONDS = 5400
+
+
+def _task_outcome(payload: dict[str, Any]) -> tuple[bool, bool, bool]:
+    """Return (is_in_flight, is_complete, is_failed) from the task `status`."""
+    status = str(payload.get("status", "")).lower()
+    if status in IN_FLIGHT_STATES:
+        return True, False, False
+    return False, status == "succeeded", status in _FAILED_STATES
+
+
+def _with_task_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("id") or payload.get("task_id")
+    if not task_id:
+        return payload
+
+    in_flight, is_complete, is_failed = _task_outcome(payload)
+    status = str(payload.get("status", "")).lower()
+
+    if is_complete:
+        next_step = "Task is complete. Stop polling and present the final video URL to the user."
+    elif is_failed:
+        next_step = (
+            f"Task reached terminal state '{status}'. Stop polling and report the failure "
+            f"to the user. Polling again will not change the outcome."
+        )
+    elif in_flight:
+        next_step = (
+            f"The task is still running (status '{status}'). Wait {_POLLING_INTERVAL_SECONDS} "
+            f'seconds, then call {POLL_TOOL}(task_id="{task_id}") again. '
+            f"Video production commonly takes 10-90 minutes — keep polling and do NOT "
+            f"give up or tell the user it failed."
+        )
+    else:
+        # Unknown status: stop rather than loop on a state we can't interpret.
+        next_step = (
+            f"Task reports an unrecognized status '{status}'. Stop polling and surface the "
+            f"raw task payload to the user instead of guessing."
+        )
+
+    payload["mcp_task_polling"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll" if in_flight else "stop",
+        "should_poll": in_flight,
+        "terminal_state_reached": not in_flight,
+        "is_complete": is_complete,
+        "is_failed": is_failed,
+        "status": status,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "expected_wait_seconds": _EXPECTED_WAIT_SECONDS,
+        "next_step": next_step,
+    }
+    return payload
+
+
+def _with_submission_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("task_id") or payload.get("id")
+    if not task_id:
+        return payload
+
+    payload["mcp_async_submission"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll",
+        "should_poll": True,
+        "terminal_state_reached": False,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "expected_wait_seconds": _EXPECTED_WAIT_SECONDS,
+        "next_step": (
+            f'Call {POLL_TOOL}(task_id="{task_id}") until its status leaves the in-flight set '
+            f"({', '.join(sorted(IN_FLIGHT_STATES))}). "
+            f"Video production commonly takes 10-90 minutes. "
+            f"Wait at least {_POLLING_INTERVAL_SECONDS} seconds between polls and keep polling "
+            f"for up to {_MAX_POLL_ATTEMPTS} attempts — do NOT stop early or tell the user it "
+            f"failed while the task is still running."
+        ),
+    }
+    return payload
+
 
 def format_result(data: dict[str, Any]) -> str:
     """Serialize an API response for MCP clients."""
     return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+def format_submission_result(data: dict[str, Any]) -> str:
+    """Serialize a task-creating response with polling guidance."""
+    return json.dumps(_with_submission_guidance(data), ensure_ascii=False, indent=2)
+
+
+def format_task_result(data: dict[str, Any]) -> str:
+    """Serialize a task query response with polling guidance."""
+    return json.dumps(_with_task_guidance(data), ensure_ascii=False, indent=2)

--- a/maestro/tests/test_task_guidance.py
+++ b/maestro/tests/test_task_guidance.py
@@ -1,0 +1,62 @@
+"""Polling-guidance blocks attached to Maestro task responses."""
+
+import json
+
+import pytest
+
+from core.utils import format_submission_result, format_task_result
+
+
+def _guidance(payload):
+    return json.loads(format_task_result(payload))["mcp_task_polling"]
+
+
+@pytest.mark.parametrize("status", ["queued", "pending", "planning", "producing", "running"])
+def test_in_flight_states_keep_polling(status):
+    block = _guidance({"id": "t-1", "status": status})
+    assert block["should_poll"] is True
+    assert block["recommended_action"] == "poll"
+
+
+def test_succeeded_stops():
+    block = _guidance({"id": "t-1", "status": "succeeded"})
+    assert block["should_poll"] is False
+    assert block["is_complete"] is True
+
+
+@pytest.mark.parametrize("status", ["failed", "dead", "cancelled"])
+def test_terminal_failures_stop(status):
+    block = _guidance({"id": "t-1", "status": status})
+    assert block["should_poll"] is False
+    assert block["is_failed"] is True
+
+
+def test_unknown_status_stops_rather_than_looping():
+    """An unrecognized status must not strand the model in an endless poll."""
+    block = _guidance({"id": "t-1", "status": "brand-new-state"})
+    assert block["should_poll"] is False
+    assert block["is_complete"] is False
+    assert block["is_failed"] is False
+    assert "unrecognized status" in block["next_step"]
+
+
+def test_submission_carries_polling_instructions():
+    block = json.loads(format_submission_result({"task_id": "t-9"}))["mcp_async_submission"]
+    assert block["poll_tool"] == "maestro_get_task"
+    assert block["should_poll"] is True
+
+
+def test_payload_without_id_is_left_untouched():
+    assert "mcp_task_polling" not in json.loads(format_task_result({"error": "nope"}))
+
+
+def test_batch_poll_tool_is_not_advertised():
+    """maestro_list_tasks has no ids filter, so it cannot poll a known task."""
+    block = _guidance({"id": "t-1", "status": "running"})
+    assert block["batch_poll_tool"] is None
+
+
+def test_poll_budget_covers_the_worker_timeout():
+    """AGENT_TIMEOUT is 5400s; the advertised budget must not give up sooner."""
+    block = _guidance({"id": "t-1", "status": "running"})
+    assert block["max_poll_attempts"] * block["polling_interval_seconds"] >= 5400

--- a/maestro/tools/task_tools.py
+++ b/maestro/tools/task_tools.py
@@ -7,12 +7,7 @@ from pydantic import Field
 
 from core.client import client
 from core.server import mcp
-from core.utils import format_result
-
-# States that mean "still working". Anything else (succeeded, failed, dead, or
-# a status we don't know yet) returns immediately — an unknown state must not
-# strand the caller in a sleep loop.
-_IN_FLIGHT_STATES = {"queued", "pending", "planning", "producing", "running", "processing"}
+from core.utils import IN_FLIGHT_STATES, format_result, format_task_result
 
 
 @mcp.tool()
@@ -26,9 +21,9 @@ async def maestro_get_task(
     data = await client.get_task(task_id)
     # Throttle polling: sleep 5s while the task is still running so LLM clients
     # don't burn through poll attempts in seconds.
-    if str(data.get("status", "")).lower() in _IN_FLIGHT_STATES:
+    if str(data.get("status", "")).lower() in IN_FLIGHT_STATES:
         await asyncio.sleep(5)
-    return format_result(data)
+    return format_task_result(data)
 
 
 @mcp.tool()

--- a/maestro/tools/video_tools.py
+++ b/maestro/tools/video_tools.py
@@ -13,7 +13,7 @@ from core.types import (
     MaestroScenario,
     MaestroVoice,
 )
-from core.utils import format_result
+from core.utils import format_submission_result
 
 
 @mcp.tool()
@@ -149,4 +149,4 @@ async def maestro_create_video(
     if callback_url:
         payload["callback_url"] = callback_url
 
-    return format_result(await client.create_video(payload))
+    return format_submission_result(await client.create_video(payload))

--- a/openai/core/utils.py
+++ b/openai/core/utils.py
@@ -1,0 +1,110 @@
+"""Formatting helpers for MCP OpenAI server."""
+
+import json
+from typing import Any
+
+POLL_TOOL = "openai_get_task"
+BATCH_POLL_TOOL = "openai_list_tasks"
+
+_POLLING_INTERVAL_SECONDS = 15
+_MAX_POLL_ATTEMPTS = 40
+_EXPECTED_WAIT_SECONDS = 300
+
+
+def _task_outcome(payload: dict[str, Any]) -> tuple[bool, bool]:
+    """Return (is_complete, is_failed) for an async image task.
+
+    The worker stamps `finished_at` once the job settles — on success *and* on
+    failure — so it alone decides whether polling should stop. `response.error`
+    then tells the two terminal outcomes apart.
+    """
+    if payload.get("finished_at") is None:
+        return False, False
+
+    response = payload.get("response")
+    response = response if isinstance(response, dict) else {}
+    failed = bool(response.get("error")) or response.get("success") is False
+    return not failed, failed
+
+
+def _with_submission_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("task_id") or payload.get("id")
+    if not task_id:
+        return payload
+
+    # Defensive: never tell the model to poll a response that already settled.
+    is_complete, is_failed = _task_outcome(payload)
+    if is_complete or is_failed:
+        return payload
+
+    payload["mcp_async_submission"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll",
+        "should_poll": True,
+        "terminal_state_reached": False,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "expected_wait_seconds": _EXPECTED_WAIT_SECONDS,
+        "next_step": (
+            f'Call {POLL_TOOL}(id="{task_id}") until the task reports a '
+            f"`finished_at` timestamp, then read the image URLs from its `response`. "
+            f"Image generation typically takes 30-120 seconds. "
+            f"Wait at least {_POLLING_INTERVAL_SECONDS} seconds between polls and keep "
+            f"polling for up to {_MAX_POLL_ATTEMPTS} attempts — do NOT stop early or "
+            f"tell the user it failed while the task is still running."
+        ),
+    }
+    return payload
+
+
+def _with_task_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("id") or payload.get("task_id")
+    if not task_id:
+        return payload
+
+    is_complete, is_failed = _task_outcome(payload)
+    should_poll = not (is_complete or is_failed)
+
+    if is_complete:
+        next_step = "Task is complete. Stop polling and present the image URLs from `response.data` to the user."
+    elif is_failed:
+        next_step = (
+            "Task failed. Stop polling and report `response.error.message` to the user. "
+            "Polling again will not change the outcome."
+        )
+    else:
+        next_step = (
+            f"The task is still running. Wait {_POLLING_INTERVAL_SECONDS} seconds, then call "
+            f'{POLL_TOOL}(id="{task_id}") again. '
+            f"Image generation typically takes 30-120 seconds. "
+            f"Keep polling — do NOT give up or tell the user it failed."
+        )
+
+    payload["mcp_task_polling"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll" if should_poll else "stop",
+        "should_poll": should_poll,
+        "terminal_state_reached": not should_poll,
+        "is_complete": is_complete,
+        "is_failed": is_failed,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "next_step": next_step,
+    }
+    return payload
+
+
+def format_submission_result(data: dict[str, Any]) -> str:
+    """Serialize an async submission response with polling guidance."""
+    return json.dumps(_with_submission_guidance(data), ensure_ascii=False, indent=2)
+
+
+def format_task_result(data: dict[str, Any]) -> str:
+    """Serialize a task query response with polling guidance."""
+    return json.dumps(_with_task_guidance(data), ensure_ascii=False, indent=2)

--- a/openai/tests/test_task_guidance.py
+++ b/openai/tests/test_task_guidance.py
@@ -1,0 +1,95 @@
+"""Polling-guidance blocks attached to submission and task responses."""
+
+import json
+
+from core.utils import format_submission_result, format_task_result
+
+# Shape taken from a real production task (id cb4faeda…): the worker stamps
+# `finished_at` on success *and* on failure, so the failure case must stop.
+_RUNNING = {"id": "t-1", "finished_at": None, "response": None}
+_DONE = {
+    "id": "t-1",
+    "finished_at": 1785136982.296123,
+    "response": {"success": True, "data": [{"url": "https://cdn.example/img.png"}]},
+}
+_FAILED = {
+    "id": "t-1",
+    "finished_at": 1785137086.2247078,
+    "response": {
+        "success": False,
+        "error": {
+            "code": "bad_request",
+            "message": "size width and height must be multiples of 16",
+        },
+    },
+}
+
+
+def _guidance(payload):
+    return json.loads(format_task_result(payload))["mcp_task_polling"]
+
+
+def test_running_task_tells_the_model_to_keep_polling():
+    block = _guidance(_RUNNING)
+    assert block["should_poll"] is True
+    assert block["terminal_state_reached"] is False
+    assert block["recommended_action"] == "poll"
+    assert block["polling_interval_seconds"] == 15
+
+
+def test_completed_task_tells_the_model_to_stop():
+    block = _guidance(_DONE)
+    assert block["should_poll"] is False
+    assert block["is_complete"] is True
+    assert block["is_failed"] is False
+    assert block["recommended_action"] == "stop"
+
+
+def test_failed_task_stops_instead_of_polling_forever():
+    """A failed task carries `finished_at`; polling it again cannot help."""
+    block = _guidance(_FAILED)
+    assert block["should_poll"] is False
+    assert block["is_failed"] is True
+    assert block["is_complete"] is False
+    assert "will not change the outcome" in block["next_step"]
+
+
+def test_submission_response_carries_polling_instructions():
+    payload = json.loads(format_submission_result({"task_id": "t-9"}))
+    block = payload["mcp_async_submission"]
+    assert block["task_id"] == "t-9"
+    assert block["poll_tool"] == "openai_get_task"
+    assert block["should_poll"] is True
+
+
+def test_response_without_task_id_is_left_untouched():
+    """Sync/error responses must not grow a bogus polling block."""
+    payload = json.loads(format_submission_result({"error": "nope"}))
+    assert "mcp_async_submission" not in payload
+
+
+async def test_throttle_and_guidance_never_disagree(monkeypatch):
+    """The 5s sleep and the advertised `should_poll` share one predicate.
+
+    suno/producer drifted by computing these two independently; assert the
+    failed task neither sleeps nor advertises further polling.
+    """
+    from tools import tasks_tools
+
+    slept = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(tasks_tools.asyncio, "sleep", fake_sleep)
+
+    for payload, expect_sleep in ((_RUNNING, True), (_DONE, False), (_FAILED, False)):
+        slept.clear()
+
+        async def fake_tasks(_bound=payload, **_kwargs):
+            return _bound
+
+        monkeypatch.setattr(tasks_tools.client, "tasks", fake_tasks)
+        block = json.loads(await tasks_tools.openai_get_task(id="t-1"))["mcp_task_polling"]
+        assert bool(slept) is expect_sleep
+        assert block["should_poll"] is expect_sleep

--- a/openai/tools/image_tools.py
+++ b/openai/tools/image_tools.py
@@ -26,6 +26,7 @@ from core.types import (
     ImageSize,
     ImageStyle,
 )
+from core.utils import format_submission_result
 
 
 @mcp.tool()
@@ -190,7 +191,7 @@ async def openai_generate_image(
         if not result:
             return json.dumps({"error": "No response received."})
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_submission_result(result)
 
     except OpenAIAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})
@@ -346,7 +347,7 @@ async def openai_edit_image(
         if not result:
             return json.dumps({"error": "No response received."})
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_submission_result(result)
 
     except OpenAIAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/openai/tools/tasks_tools.py
+++ b/openai/tools/tasks_tools.py
@@ -9,11 +9,17 @@ from pydantic import Field
 from core.client import client
 from core.exceptions import OpenAIAPIError, OpenAIAuthError
 from core.server import mcp
+from core.utils import _task_outcome, format_task_result
 
 
 def _is_task_finished(result: dict[str, Any]) -> bool:
-    """A task is done once the worker has stamped `finished_at` on it."""
-    return result.get("finished_at") is not None
+    """A task is done once the worker has stamped `finished_at` on it.
+
+    Shares `_task_outcome` with the guidance block so the throttle and the
+    advertised `should_poll` can never disagree.
+    """
+    is_complete, is_failed = _task_outcome(result)
+    return is_complete or is_failed
 
 
 @mcp.tool()
@@ -85,7 +91,7 @@ async def openai_get_task(
         if not _is_task_finished(result):
             await asyncio.sleep(5)
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_task_result(result)
 
     except OpenAIAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/webextrator/core/utils.py
+++ b/webextrator/core/utils.py
@@ -1,0 +1,109 @@
+"""Formatting helpers for MCP WebExtrator server."""
+
+import json
+from typing import Any
+
+POLL_TOOL = "webextrator_get_task"
+BATCH_POLL_TOOL = "webextrator_get_tasks_batch"
+
+_POLLING_INTERVAL_SECONDS = 10
+_MAX_POLL_ATTEMPTS = 30
+_EXPECTED_WAIT_SECONDS = 180
+
+
+def _task_outcome(payload: dict[str, Any]) -> tuple[bool, bool]:
+    """Return (is_complete, is_failed) for an async extract/render task.
+
+    The worker stamps `finished_at` once the job settles — on success *and* on
+    failure — so it alone decides whether polling should stop. `response.error`
+    then tells the two terminal outcomes apart.
+    """
+    if payload.get("finished_at") is None:
+        return False, False
+
+    response = payload.get("response")
+    response = response if isinstance(response, dict) else {}
+    failed = bool(response.get("error")) or response.get("success") is False
+    return not failed, failed
+
+
+def _with_submission_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("task_id") or payload.get("id")
+    if not task_id:
+        return payload
+
+    # mode="sync" returns the finished result inline (already carries
+    # `finished_at` + `data`). Telling the model to poll that would be wrong.
+    is_complete, is_failed = _task_outcome(payload)
+    if is_complete or is_failed:
+        return payload
+
+    payload["mcp_async_submission"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll",
+        "should_poll": True,
+        "terminal_state_reached": False,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "expected_wait_seconds": _EXPECTED_WAIT_SECONDS,
+        "next_step": (
+            f'Call {POLL_TOOL}(task_id="{task_id}") until the task reports a '
+            f"`finished_at` timestamp, then read the extracted content from its `response`. "
+            f"Wait at least {_POLLING_INTERVAL_SECONDS} seconds between polls and keep "
+            f"polling for up to {_MAX_POLL_ATTEMPTS} attempts — do NOT stop early or "
+            f"tell the user it failed while the task is still running."
+        ),
+    }
+    return payload
+
+
+def _with_task_guidance(data: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(data)
+    task_id = payload.get("id") or payload.get("task_id")
+    if not task_id:
+        return payload
+
+    is_complete, is_failed = _task_outcome(payload)
+    should_poll = not (is_complete or is_failed)
+
+    if is_complete:
+        next_step = "Task is complete. Stop polling and use the extracted content from `response`."
+    elif is_failed:
+        next_step = (
+            "Task failed. Stop polling and report the error to the user. "
+            "Polling again will not change the outcome."
+        )
+    else:
+        next_step = (
+            f"The task is still running. Wait {_POLLING_INTERVAL_SECONDS} seconds, then call "
+            f'{POLL_TOOL}(task_id="{task_id}") again. '
+            f"Keep polling — do NOT give up or tell the user it failed."
+        )
+
+    payload["mcp_task_polling"] = {
+        "task_id": task_id,
+        "poll_tool": POLL_TOOL,
+        "batch_poll_tool": BATCH_POLL_TOOL,
+        "recommended_action": "poll" if should_poll else "stop",
+        "should_poll": should_poll,
+        "terminal_state_reached": not should_poll,
+        "is_complete": is_complete,
+        "is_failed": is_failed,
+        "polling_interval_seconds": _POLLING_INTERVAL_SECONDS,
+        "max_poll_attempts": _MAX_POLL_ATTEMPTS,
+        "next_step": next_step,
+    }
+    return payload
+
+
+def format_submission_result(data: dict[str, Any]) -> str:
+    """Serialize an async submission response with polling guidance."""
+    return json.dumps(_with_submission_guidance(data), ensure_ascii=False, indent=2)
+
+
+def format_task_result(data: dict[str, Any]) -> str:
+    """Serialize a task query response with polling guidance."""
+    return json.dumps(_with_task_guidance(data), ensure_ascii=False, indent=2)

--- a/webextrator/tests/test_task_guidance.py
+++ b/webextrator/tests/test_task_guidance.py
@@ -1,0 +1,65 @@
+"""Polling-guidance blocks attached to webextrator task responses."""
+
+import json
+
+from core.utils import format_task_result
+
+_RUNNING = {"id": "t-1", "finished_at": None, "response": None}
+_DONE = {"id": "t-1", "finished_at": 1785136982.29, "response": {"success": True}}
+_FAILED = {
+    "id": "t-1",
+    "finished_at": 1785137086.22,
+    "response": {"success": False, "error": {"code": "bad_request", "message": "nope"}},
+}
+
+
+def _guidance(payload):
+    return json.loads(format_task_result(payload))["mcp_task_polling"]
+
+
+def test_running_task_keeps_polling():
+    block = _guidance(_RUNNING)
+    assert block["should_poll"] is True
+    assert block["recommended_action"] == "poll"
+
+
+def test_completed_task_stops():
+    block = _guidance(_DONE)
+    assert block["should_poll"] is False
+    assert block["is_complete"] is True
+
+
+def test_failed_task_stops_instead_of_polling_forever():
+    """A failed task carries `finished_at`; polling it again cannot help."""
+    block = _guidance(_FAILED)
+    assert block["should_poll"] is False
+    assert block["is_failed"] is True
+
+
+def test_payload_without_id_is_left_untouched():
+    assert "mcp_task_polling" not in json.loads(format_task_result({"error": "nope"}))
+
+
+def test_sync_mode_result_is_not_told_to_poll():
+    """mode="sync" returns the finished result inline — it must not advertise polling.
+
+    Shape from the worker's buildSuccess(): task_id is present even though the
+    task already settled, so a task_id-only guard would wrongly attach guidance.
+    """
+    from core.utils import format_submission_result
+
+    sync_payload = {
+        "success": True,
+        "task_id": "t-1",
+        "finished_at": 1785137086.22,
+        "elapsed": 3.1,
+        "data": {"title": "hello"},
+    }
+    assert "mcp_async_submission" not in json.loads(format_submission_result(sync_payload))
+
+
+def test_async_submission_still_gets_guidance():
+    from core.utils import format_submission_result
+
+    payload = json.loads(format_submission_result({"task_id": "t-2"}))
+    assert payload["mcp_async_submission"]["should_poll"] is True

--- a/webextrator/tools/extract_tools.py
+++ b/webextrator/tools/extract_tools.py
@@ -9,6 +9,7 @@ from core.client import client
 from core.exceptions import WebExtraterAPIError, WebExtraterAuthError
 from core.server import mcp
 from core.types import BlockResource, ExpectedType, TaskMode, WaitUntil
+from core.utils import format_submission_result
 
 
 @mcp.tool()
@@ -162,7 +163,7 @@ async def webextrator_extract(
         if not result:
             return json.dumps({"error": "No response received from the API."})
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_submission_result(result)
 
     except WebExtraterAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})
@@ -303,7 +304,7 @@ async def webextrator_render(
         if not result:
             return json.dumps({"error": "No response received from the API."})
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_submission_result(result)
 
     except WebExtraterAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/webextrator/tools/task_tools.py
+++ b/webextrator/tools/task_tools.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from core.client import client
 from core.exceptions import WebExtraterAPIError, WebExtraterAuthError
 from core.server import mcp
+from core.utils import _task_outcome, format_task_result
 
 
 @mcp.tool()
@@ -64,10 +65,11 @@ async def webextrator_get_task(
         # Throttle polling: sleep 5s while the task is still running so LLM
         # clients don't burn through poll attempts in seconds. The worker only
         # stamps `finished_at` once the job settles.
-        if result.get("finished_at") is None:
+        is_complete, is_failed = _task_outcome(result)
+        if not (is_complete or is_failed):
             await asyncio.sleep(5)
 
-        return json.dumps(result, ensure_ascii=False, indent=2)
+        return format_task_result(result)
 
     except WebExtraterAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})


### PR DESCRIPTION
## 背景

15 个 MCP（nanobanana / flux / sora / kling / veo …）的任务响应里都带一个结构化引导块，告诉模型**该不该继续轮询、隔多久轮一次**：

```json
"mcp_task_polling": {
  "should_poll": true, "recommended_action": "poll",
  "polling_interval_seconds": 15, "max_poll_attempts": 40,
  "next_step": "…Keep polling — do NOT give up or tell the user it failed."
}
```

`openai` / `fish` / `webextrator` / `maestro` 这 4 个没有 —— 返回的是裸 task JSON，模型拿不到任何"该不该继续"的信号，只能靠 `asyncio.sleep(5)` 的物理延时兜着。（`openai/core/` 此前连 `utils.py` 都不存在。）

节流本身 19 个 MCP 都已就位（#449），这个 PR 只补引导。

## 关键：完成判定按各自 worker 的真实契约写，没有照抄参考实现

参考实现（nanobanana）用 `response.success`，直接抄到这 4 个会全错：

| MCP | 判定 | 依据 |
|---|---|---|
| openai / fish / webextrator | 顶层 `finished_at`，再用 `response.error` 区分成败 | worker 成功和失败都会写 `finished_at` |
| maestro | `status` 词表，未知状态一律**停止** | `IN_FLIGHT_STATES`；未知状态不能让模型空转 |

顺带修掉一类既有缺陷：**节流与 `should_poll` 共用同一个 `_task_outcome`**，不会出现 suno/producer 那种两处独立计算导致的漂移。

> 附带发现（本 PR 未处理）：其余 13 个 MCP 用 `response.success` 判定，而**失败任务的 `success` 也是 `false`** → 已经失败的任务会被引导"Do NOT give up"轮满 100 次。值得单独开 PR。

## 生产真实 payload 验证

```
真实提交 {task_id, trace_id}          → 引导正常附加（终结守卫不误伤）
真实完成 22eb965d…                    → should_poll: false / stop  ✅
真实失败 1ef8fcc4… (bad_request)      → should_poll: false / stop  ✅
```

各服务预算对齐真实上限：openai 600s（实测 69s）、webextrator 300s（worker async cap 300s）、maestro 6600s（`AGENT_TIMEOUT` 5400s + 队列余量）。

## 测试

86 passed（+30），`ruff check` / `mypy` 四仓全清。

## 🤖 对抗评审

Codex 额度耗尽，回退 Claude `general-purpose` subagent。首轮 **3 个 RISK，全部采纳修复**（无辩驳）：

| # | 问题 | 修复 |
|---|---|---|
| 1 | `webextrator` `mode="sync"` 返回的是**已完成的内联结果**（含 `finished_at` + `data`），却被贴上 `should_poll: true`，被告知去轮询 30 次 | 提交守卫改为复用 `_task_outcome`，已终结则不贴引导；openai/fish 一并加防回归守卫 |
| 2 | `maestro` 广告 `batch_poll_tool: maestro_list_tasks`，但该工具只接受 `limit`/`created_at_*`，**没有 ids 参数**，根本查不了指定任务 | 置为 `None`（与参考实现的 `str \| None = None` 签名一致） |
| 3 | `maestro` 预算 120×30s=60min，但 worker 真实上限 `AGENT_TIMEOUT=5400`(90min) → 任务还活着就被放弃，与引导自身"do NOT stop early"矛盾 | 提到 220×30s=6600s，`expected_wait_seconds` 对齐 5400，文案同步改 10-90 分钟 |

三处各配回归测试；`test_poll_budget_covers_the_worker_timeout` 断言的是 5400s 约束而非字面量 220，未来改 interval 仍能拦住。

复评 **`VERDICT: CLEAN`**，并额外验证了新守卫**不会误伤真实异步提交** —— 逐个追到 worker 源码确认三者的提交响应都不含 `finished_at`：`image_base.py:76` 写 `{task_id}`、`fish/tts.ts:83-86` 写 `{task_id, started_at}`、webextrator 异步分支写 `{success, task_id, trace_id, started_at}`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)