### PR TITLE
fix(mcp): 给 mcp 依赖加 <2 上界，修复 fastmcp 模块缺失导致的 CrashLoopBackOff

### DIFF
--- a/acedatacloud/pyproject.toml
+++ b/acedatacloud/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/aichat/pyproject.toml
+++ b/aichat/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/face/pyproject.toml
+++ b/face/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/fish/pyproject.toml
+++ b/fish/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/flux/pyproject.toml
+++ b/flux/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/glm/pyproject.toml
+++ b/glm/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/grok/pyproject.toml
+++ b/grok/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/hailuo/pyproject.toml
+++ b/hailuo/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/happyhorse/pyproject.toml
+++ b/happyhorse/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/kling/pyproject.toml
+++ b/kling/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/luma/pyproject.toml
+++ b/luma/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/maestro/pyproject.toml
+++ b/maestro/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/midjourney/pyproject.toml
+++ b/midjourney/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/nanobanana/pyproject.toml
+++ b/nanobanana/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/openai/pyproject.toml
+++ b/openai/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/producer/pyproject.toml
+++ b/producer/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/seedance/pyproject.toml
+++ b/seedance/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/seedream/pyproject.toml
+++ b/seedream/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/serp/pyproject.toml
+++ b/serp/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/shorturl/pyproject.toml
+++ b/shorturl/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/sora/pyproject.toml
+++ b/sora/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/suno/pyproject.toml
+++ b/suno/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/suno/uv.lock
+++ b/suno/uv.lock
@@ -841,7 +841,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'release'", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.0" },
-    { name = "mcp", specifier = ">=1.2.0" },
+    { name = "mcp", specifier = ">=1.2.0,<2" },
     { name = "mcp-suno", extras = ["dev", "test", "release"], marker = "extra == 'all'" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },

--- a/veo/pyproject.toml
+++ b/veo/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/wan/pyproject.toml
+++ b/wan/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/webextrator/pyproject.toml
+++ b/webextrator/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "mcp>=1.2.0",
+    "mcp>=1.2.0,<2",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## 根因

`mcp` 2.0.0 于 **2026-07-28 13:45** 发布到 PyPI，v2 移除了 `mcp.server.fastmcp`（由 `mcp.server.mcpserver` 取代）。

25 个项目声明的都是**无上界**的 `mcp>=1.2.0`，而 Dockerfile 走裸 `pip install .`，因此 7/28 之后触发构建的镜像全部解析到 2.0.0，启动即：

```
File "/usr/local/lib/python3.12/site-packages/core/server.py", line 5, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

### 已受影响（生产 CrashLoopBackOff）

| 服务 | 状态 |
|---|---|
| `mcp-aichat` | 重启 **454** 次 |
| `mcp-seedance` | CrashLoopBackOff |

### 未受影响但同样有风险

其余 23 个项目**只是因为镜像构建于 7/28 之前**才还在跑，源码 import 路径完全相同，**下次重建就会同样崩**。全部 25 个都用了 v1-only 路径（`mcp.server.fastmcp` / `mcp.server.auth`），只有 `suno` 因为有 `uv.lock` 钉在 1.25.0 而多一层保护。

## 改动

- 25 个 `pyproject.toml`：`"mcp>=1.2.0"` → `"mcp>=1.2.0,<2"`
- `suno/uv.lock`：同步记录的 specifier

纯依赖约束变更，**零行为改动**。

## 验证

从 PyPI 直接核对：

| 检查项 | 结果 |
|---|---|
| `>=1.2.0,<2` 解析到 | **1.29.0** |
| 1.29.0 含 `mcp/server/fastmcp` | ✅ |
| 1.29.0 含 `mcp/server/auth/settings` | ✅ |
| 2.0.0 含 `fastmcp` | ❌（wheel 内已确认移除） |

## 后续

这是止血。上游 v2 README 建议的长期做法是迁移到 `mcp.server.mcpserver`，需要单独评估。另外 25 个项目里只有 suno 有 lock 文件，建议后续统一补齐以避免同类漂移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)