### PR TITLE
test: fixture 里的 started_at/finished_at 跟上服务端的数值化

### DIFF
--- a/fish/tests/test_task_guidance.py
+++ b/fish/tests/test_task_guidance.py
@@ -7,7 +7,7 @@ from core.utils import format_task_result
 _RUNNING = {"id": "t-1", "finished_at": None, "response": None}
 _DONE = {
     "id": "t-1",
-    "started_at": "2026-07-30T09:00:00Z",
+    "started_at": 1785136969.95,
     "finished_at": 1785136982.29,
     "elapsed": 12.34,
     "response": {"success": True},
@@ -34,7 +34,7 @@ def test_completed_task_stops():
     block = payload["mcp_task_polling"]
     assert block["should_poll"] is False
     assert block["is_complete"] is True
-    assert payload["started_at"] == "2026-07-30T09:00:00Z"
+    assert payload["started_at"] == 1785136969.95
     assert payload["elapsed"] == 12.34
 
 

--- a/midjourney/tests/conftest.py
+++ b/midjourney/tests/conftest.py
@@ -96,7 +96,7 @@ def mock_task_response():
         "id": "task-123",
         "type": "imagine",
         "created_at": "2025-01-21T00:00:00.000Z",
-        "finished_at": "2025-01-21T00:01:00.000Z",
+        "finished_at": 1737417660.0,
         "request": {
             "action": "generate",
             "prompt": "A test image",

--- a/openai/tests/test_task_guidance.py
+++ b/openai/tests/test_task_guidance.py
@@ -9,7 +9,7 @@ from core.utils import format_submission_result, format_task_result
 _RUNNING = {"id": "t-1", "finished_at": None, "response": None}
 _DONE = {
     "id": "t-1",
-    "started_at": "2026-07-30T09:00:00Z",
+    "started_at": 1785136969.96,
     "finished_at": 1785136982.296123,
     "elapsed": 12.34,
     "response": {"success": True, "data": [{"url": "https://cdn.example/img.png"}]},
@@ -46,7 +46,7 @@ def test_completed_task_tells_the_model_to_stop():
     assert block["is_complete"] is True
     assert block["is_failed"] is False
     assert block["recommended_action"] == "stop"
-    assert payload["started_at"] == "2026-07-30T09:00:00Z"
+    assert payload["started_at"] == 1785136969.96
     assert payload["elapsed"] == 12.34
 
 

--- a/webextrator/tests/test_task_guidance.py
+++ b/webextrator/tests/test_task_guidance.py
@@ -7,7 +7,7 @@ from core.utils import format_task_result
 _RUNNING = {"id": "t-1", "finished_at": None, "response": None}
 _DONE = {
     "id": "t-1",
-    "started_at": "2026-07-30T09:00:00Z",
+    "started_at": 1785136969.95,
     "finished_at": 1785136982.29,
     "elapsed": 12.34,
     "response": {"success": True},
@@ -34,7 +34,7 @@ def test_completed_task_stops():
     block = payload["mcp_task_polling"]
     assert block["should_poll"] is False
     assert block["is_complete"] is True
-    assert payload["started_at"] == "2026-07-30T09:00:00Z"
+    assert payload["started_at"] == 1785136969.95
     assert payload["elapsed"] == 12.34
 
 

--- a/webextrator/tests/test_task_throttle.py
+++ b/webextrator/tests/test_task_throttle.py
@@ -32,7 +32,7 @@ async def test_get_task_returns_immediately_when_finished(monkeypatch):
     slept: list[float] = []
 
     async def mock_query(**_kwargs):
-        return {"id": "t-1", "finished_at": "2026-07-27T00:00:00Z", "response": {}}
+        return {"id": "t-1", "finished_at": 1785110400.0, "response": {}}
 
     async def fake_sleep(seconds):
         slept.append(seconds)
@@ -43,7 +43,7 @@ async def test_get_task_returns_immediately_when_finished(monkeypatch):
     result = await task_tools.webextrator_get_task(task_id="t-1")
 
     assert slept == []
-    assert json.loads(result)["finished_at"] == "2026-07-27T00:00:00Z"
+    assert json.loads(result)["finished_at"] == 1785110400.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
平台已把这两个字段统一成 Unix 浮点秒（[PlatformService#1778](https://github.com/AceDataCloud/PlatformService/pull/1778)），fixture 还在用 ISO 字符串模拟响应。

**功能上不会挂** —— `core/utils.py` 判终态用的是 `payload.get("finished_at") is None`，与类型无关。改的是「照着 fixture 写代码的人会以为服务端仍发 ISO」这件事。

顺带修好一处不自洽：fish/openai/webextrator 的 guidance fixture 转换后 `started_at` 落在了 `finished_at` **之后**，现在改成早 12.34 秒（与 `elapsed` 对齐）。

fish 12 / midjourney 27 / openai 49 / webextrator 12 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)