### PR TITLE
Remove unavailable Seedream 3.0 tool options

### DIFF
--- a/seedream/README.md
+++ b/seedream/README.md
@@ -16,9 +16,8 @@ Generate and edit AI images directly from Claude, VS Code, or any MCP-compatible
 
 - **Text-to-Image Generation** — Create high-quality images from text prompts (Chinese & English)
 - **Image Editing** — Modify existing images with AI (style transfer, background change, virtual try-on)
-- **Multiple Models** — Seedream v5.0 (flagship), v4.5, v4.0, v3.0 T2I, SeedEdit v3.0 I2I
+- **Multiple Models** — Seedream v5.0 (flagship), v4.5, and v4.0
 - **Multi-Resolution** — 1K, 2K, 3K, 4K, adaptive, and custom dimensions
-- **Seed Control** — Reproducible results with seed parameter (v3 models)
 - **Sequential Generation** — Generate related images in sequence (v4.5/v4.0)
 - **Streaming** — Progressive image delivery (v4.5/v4.0)
 - **Task Tracking** — Monitor generation progress and retrieve results
@@ -337,8 +336,6 @@ Clients connect with their own Bearer token — the server extracts the token fr
 | `doubao-seedream-5-0-260128` | v5.0 Lite | Text-to-Image | Best quality, latest flagship, web search | ~$0.040/image |
 | `doubao-seedream-4-5-251128` | v4.5 | Text-to-Image | Previous flagship, great quality | ~$0.037/image |
 | `doubao-seedream-4-0-250828` | v4.0 | Text-to-Image | Best value, most tasks | ~$0.030/image |
-| `doubao-seedream-3-0-t2i-250415` | v3.0 | Text-to-Image | Reproducible results | ~$0.038/image |
-| `doubao-seededit-3-0-i2i-250628` | v3.0 | Image-to-Image | Image editing | ~$0.046/image |
 
 ## Usage Examples
 
@@ -369,15 +366,6 @@ User: 生成一幅中国山水画，有远山、流水和古松
 
 Claude: 好的，我来为您生成这幅山水画。
 [Calls seedream_generate_image with Chinese prompt]
-```
-
-### Reproducible Generation
-
-```
-User: Generate a landscape and make sure I can recreate the exact same image later
-
-Claude: I'll use the v3 model with a fixed seed.
-[Calls seedream_generate_image with model=doubao-seedream-3-0-t2i-250415, seed=42]
 ```
 
 ## Configuration

--- a/seedream/core/types.py
+++ b/seedream/core/types.py
@@ -8,8 +8,6 @@ SeedreamModel = Literal[
     "doubao-seedream-5-0-260128",
     "doubao-seedream-4-5-251128",
     "doubao-seedream-4-0-250828",
-    "doubao-seedream-3-0-t2i-250415",
-    "doubao-seededit-3-0-i2i-250628",
 ]
 
 # Image size presets

--- a/seedream/prompts/__init__.py
+++ b/seedream/prompts/__init__.py
@@ -22,9 +22,10 @@ When the user wants to generate or edit images, choose the appropriate tool base
 - User describes a scene, object, person, concept, or artwork
 
 **Model selection:**
+- v5.0 Pro (`doubao-seedream-5-0-pro-260628`): Best single-image quality
+- v5.0 Lite (`doubao-seedream-5-0-260128`): Best for image sets, streaming, or web search
 - v4.5 (`doubao-seedream-4-5-251128`): Best quality, latest flagship
 - v4.0 (`doubao-seedream-4-0-250828`): Best value, stable and reliable (recommended default)
-- v3.0 T2I (`doubao-seedream-3-0-t2i-250415`): When seed/reproducibility is needed
 
 **Example:** "Create an image of a futuristic cityscape at sunset"
 → Call `seedream_generate_image` with a detailed prompt
@@ -38,8 +39,8 @@ When the user wants to generate or edit images, choose the appropriate tool base
 - User wants to combine or transform images
 
 **Model selection:**
-- `doubao-seededit-3-0-i2i-250628`: Dedicated editing model (recommended)
-- Other models can also accept image input
+- `doubao-seedream-5-0-260128`: Recommended for most edits
+- 5.0 Pro, 4.5, and 4.0 also accept image input
 
 **Example:** "Change the background of this photo to a beach"
 → Call `seedream_edit_image` with image URL and edit description
@@ -74,8 +75,7 @@ When the user wants to generate or edit images, choose the appropriate tool base
 2. Detailed prompts produce significantly better results
 3. Supports both Chinese and English prompts
 4. The v4.5 model produces the highest quality but costs slightly more
-5. Use seed parameter (v3 models only) when reproducibility is important
-6. For editing, ensure image URLs are publicly accessible or use base64
+5. For editing, ensure image URLs are publicly accessible or use base64
 """
 
 
@@ -179,19 +179,10 @@ def seedream_workflow_examples() -> str:
      prompt="Change the background to outer space with stars and nebulae,
      keep the subject unchanged",
      image=["https://example.com/photo.jpg"],
-     model="doubao-seededit-3-0-i2i-250628"
+    model="doubao-seedream-5-0-260128"
    )`
 
-## Workflow 4: Reproducible Generation with Seed
-1. User: "Generate a cat, and I want to be able to recreate the exact same image"
-2. Call `seedream_generate_image(
-     prompt="A fluffy orange tabby cat sitting on a windowsill, soft natural light",
-     model="doubao-seedream-3-0-t2i-250415",
-     seed=42
-   )`
-3. Note: Same prompt + same seed = same image (v3 models only)
-
-## Workflow 5: Sequential Image Generation
+  ## Workflow 4: Sequential Image Generation
 1. User: "Generate a series of related images about space exploration"
 2. Call `seedream_generate_image(
      prompt="Space exploration series: astronaut on Mars surface, red landscape,
@@ -200,12 +191,12 @@ def seedream_workflow_examples() -> str:
      sequential_image_generation="auto"
    )`
 
-## Workflow 6: Batch Status Check
+## Workflow 5: Batch Status Check
 1. After generating multiple images, collect all task_ids
 2. Call `seedream_get_tasks_batch(task_ids=["task-1", "task-2", "task-3"])`
 3. Get status of all images at once
 
-## Workflow 7: Async with Callback
+## Workflow 6: Async with Callback
 1. User has a webhook endpoint
 2. Call `seedream_generate_image(
      prompt="...",
@@ -218,7 +209,6 @@ def seedream_workflow_examples() -> str:
 - Always use detailed, descriptive prompts
 - Start with v4.0 for best value, upgrade to v4.5 for premium quality
 - For editing, image URLs must be publicly accessible
-- Use seed parameter with v3 models for reproducibility
 - Store task_ids for later status checking
 - Seedream excels at both Chinese and English prompts
 """

--- a/seedream/tools/image_tools.py
+++ b/seedream/tools/image_tools.py
@@ -36,10 +36,7 @@ async def seedream_generate_image(
             "no sequential generation, streaming, or web search). "
             "'doubao-seedream-5-0-260128' (v5.0 Lite, latest flagship, sequential generation, streaming, web search). "
             "'doubao-seedream-4-5-251128' (v4.5, previous flagship, great quality). "
-            "'doubao-seedream-4-0-250828' (v4.0, stable, best value). "
-            "'doubao-seedream-3-0-t2i-250415' (v3 text-to-image, supports seed and guidance_scale). "
-            "'doubao-seededit-3-0-i2i-250628' is for image editing only — use seedream_edit_image "
-            "instead."
+            "'doubao-seedream-4-0-250828' (v4.0, stable, best value)."
         ),
     ] = "doubao-seedream-5-0-260128",
     size: Annotated[
@@ -47,14 +44,6 @@ async def seedream_generate_image(
         Field(
             description="Output image resolution. '1K' (default), '2K', '3K', '4K', or 'adaptive'. "
             "You can also specify custom dimensions like '1024x1024', '1280x720', etc."
-        ),
-    ] = None,
-    seed: Annotated[
-        int | None,
-        Field(
-            description="Random seed for reproducible results. Range: [-1, 2147483647]. "
-            "Default is -1 (random). Only works with v3 models "
-            "(doubao-seedream-3-0-t2i and doubao-seededit-3-0-i2i)."
         ),
     ] = None,
     sequential_image_generation: Annotated[
@@ -77,14 +66,6 @@ async def seedream_generate_image(
         Field(
             description="Stream all pictures progressively. Default is false. "
             "Only supports v4.5 and v4.0 models."
-        ),
-    ] = None,
-    guidance_scale: Annotated[
-        float | None,
-        Field(
-            description="Prompt weight — higher values make the result more closely follow the "
-            "prompt. Range: [1, 10]. Default is 2.5 for doubao-seedream-3-0-t2i. "
-            "Only works with v3 models."
         ),
     ] = None,
     response_format: Annotated[
@@ -146,8 +127,6 @@ async def seedream_generate_image(
     - v5.0 (doubao-seedream-5-0-260128): Latest flagship, highest quality
     - v4.5 (doubao-seedream-4-5-251128): Previous flagship, great quality and detail
     - v4.0 (doubao-seedream-4-0-250828): Stable and cost-effective, great for most tasks
-    - v3 T2I (doubao-seedream-3-0-t2i-250415): Supports seed for reproducibility
-
     Returns:
         JSON with task_id, trace_id, success status, and generated image data
         including image URLs.
@@ -159,16 +138,12 @@ async def seedream_generate_image(
 
     if size is not None:
         payload["size"] = size
-    if seed is not None:
-        payload["seed"] = seed
     if sequential_image_generation is not None:
         payload["sequential_image_generation"] = sequential_image_generation
     if sequential_image_generation_options is not None:
         payload["sequential_image_generation_options"] = sequential_image_generation_options
     if stream is not None:
         payload["stream"] = stream
-    if guidance_scale is not None:
-        payload["guidance_scale"] = guidance_scale
     if response_format is not None:
         payload["response_format"] = response_format
     if watermark is not None:
@@ -207,30 +182,14 @@ async def seedream_edit_image(
     model: Annotated[
         SeedreamModel,
         Field(
-            description="Model to use for editing. "
-            "'doubao-seededit-3-0-i2i-250628' (dedicated editing model, best for image "
-            "modification). Other models can also be used for editing when images are provided."
+            description="Model to use for editing. Seedream 5.0 Pro, 5.0 Lite, 4.5, and 4.0 "
+            "all support image editing when images are provided."
         ),
-    ] = "doubao-seededit-3-0-i2i-250628",
+    ] = "doubao-seedream-5-0-260128",
     size: Annotated[
         SeedreamSize | None,
         Field(
             description="Output image resolution. '1K' (default), '2K', '3K', '4K', or 'adaptive'."
-        ),
-    ] = None,
-    seed: Annotated[
-        int | None,
-        Field(
-            description="Random seed for reproducible edits. Range: [-1, 2147483647]. "
-            "Default is -1 (random). Only works with v3 models."
-        ),
-    ] = None,
-    guidance_scale: Annotated[
-        float | None,
-        Field(
-            description="Prompt weight — higher values make edits follow the prompt more closely. "
-            "Range: [1, 10]. Default is 5.5 for doubao-seededit-3-0-i2i. "
-            "Only works with v3 models."
         ),
     ] = None,
     response_format: Annotated[
@@ -282,10 +241,6 @@ async def seedream_edit_image(
 
     if size is not None:
         payload["size"] = size
-    if seed is not None:
-        payload["seed"] = seed
-    if guidance_scale is not None:
-        payload["guidance_scale"] = guidance_scale
     if response_format is not None:
         payload["response_format"] = response_format
     if watermark is not None:

--- a/seedream/tools/info_tools.py
+++ b/seedream/tools/info_tools.py
@@ -24,8 +24,6 @@ async def seedream_list_models() -> str:
 | `doubao-seedream-5-0-260128` | v5.0 Lite | Text-to-Image | Latest flagship, highest quality, sequential generation, streaming, web search | ~$0.040/image |
 | `doubao-seedream-4-5-251128` | v4.5 | Text-to-Image | Previous flagship, great quality, sequential generation, streaming | ~$0.037/image |
 | `doubao-seedream-4-0-250828` | v4.0 | Text-to-Image | Stable, cost-effective, sequential generation, streaming | ~$0.030/image |
-| `doubao-seedream-3-0-t2i-250415` | v3.0 | Text-to-Image | Seed control, guidance scale, reproducible results | ~$0.038/image |
-| `doubao-seededit-3-0-i2i-250628` | v3.0 | Image-to-Image | Image editing, style transfer, seed control, guidance scale | ~$0.046/image |
 
 ## Model Selection Guide
 
@@ -50,30 +48,22 @@ async def seedream_list_models() -> str:
 - Great balance of quality and cost
 - Recommended for most use cases
 
-### For Reproducible Results
-→ **doubao-seedream-3-0-t2i-250415** (v3.0 T2I)
-- Supports seed parameter for exact reproducibility
-- Supports guidance_scale for fine-tuning prompt adherence
-
 ### For Image Editing
-→ **doubao-seededit-3-0-i2i-250628** (v3.0 I2I)
-- Dedicated editing model
-- Requires input image(s)
-- Best for style transfer, background changes, virtual try-on
+→ **doubao-seedream-5-0-260128** (v5.0 Lite)
+- Accepts one or more input images
+- Best for style transfer, background changes, and multi-image composition
 
 ## Feature Comparison
 
-| Feature | v5.0 Pro | v5.0 Lite | v4.5 | v4.0 | v3.0 T2I | v3.0 I2I (Edit) |
-|---------|----------|-----------|------|------|----------|-----------------|
-| Text-to-Image | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Image Editing | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Seed Control | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Guidance Scale | ❌ | ❌ | ❌ | ❌ | ✅ (default 2.5) | ✅ (default 5.5) |
-| Sequential Gen | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Streaming | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Web Search | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Output Format | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Resolution | 1K/2K | 1K/2K/3K/4K/Adaptive | 1K/2K/3K/4K/Adaptive | 1K/2K/3K/4K/Adaptive | 1K/2K/3K/4K/Adaptive | 1K/2K/3K/4K/Adaptive |
+| Feature | v5.0 Pro | v5.0 Lite | v4.5 | v4.0 |
+|---------|----------|-----------|------|------|
+| Text-to-Image | ✅ | ✅ | ✅ | ✅ |
+| Image Editing | ✅ | ✅ | ✅ | ✅ |
+| Sequential Gen | ❌ | ✅ | ✅ | ✅ |
+| Streaming | ❌ | ✅ | ✅ | ✅ |
+| Web Search | ❌ | ✅ | ❌ | ❌ |
+| Output Format | ✅ | ✅ | ❌ | ❌ |
+| Resolution | 1K/2K | 2K/3K/4K/Adaptive | 2K/4K/Adaptive | 1K/2K/4K/Adaptive |
 """
 
 
@@ -116,5 +106,5 @@ You can also specify exact dimensions in `WIDTHxHEIGHT` format:
 - **4K** provides stunning detail but takes longer
 - **adaptive** is great when you're unsure about the best size
 - Custom dimensions give full control over aspect ratio
-- All models support all size options
+- Supported presets vary by model; use the model table above before choosing a size
 """

--- a/seedream/vscode/README.md
+++ b/seedream/vscode/README.md
@@ -4,7 +4,7 @@ Seedream by ByteDance — text-to-image and SeedEdit instruction-based editing.
 
 [![VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=acedatacloud.mcp-seedream) [![PyPI](https://img.shields.io/pypi/v/mcp-seedream-pro.svg?label=PyPI)](https://pypi.org/project/mcp-seedream-pro/) [![Hosted MCP](https://img.shields.io/badge/hosted-mcp-blue)](https://seedream.mcp.acedata.cloud/mcp)
 
-High-resolution image generation and edit-by-instruction with ByteDance Seedream (3.0 / 4.0 / 4.5 / 5.0) and SeedEdit 3.0.
+High-resolution image generation and edit-by-instruction with Seedream 4.0, 4.5, and 5.0.
 
 This extension registers the **seedream** MCP server with VS Code so GitHub
 Copilot and any other agent that speaks the [Model Context Protocol](https://modelcontextprotocol.io/)


### PR DESCRIPTION
## Summary
- remove unavailable Seedream 3.0 T2I / SeedEdit 3.0 from public model literals
- remove unsupported `seed` and `guidance_scale` tool arguments
- default image editing to Seedream 5.0 Lite
- correct model editing and resolution capability guidance across tools, prompts, README, and VS Code copy

## Production evidence
The advertised v3 model IDs now fail immediately in production. Active Seedream 5.0/4.x models remain available and support image editing.

## Validation
- `ruff check seedream/core seedream/tools seedream/prompts seedream/tests`
- `python3 -m compileall -q seedream/core seedream/tools seedream/prompts`
- retired-model reference scan excluding immutable historical changelog
- `git diff --check`

Local full pytest/mypy were unavailable because this machine lacks the project MCP test dependency and mypy; CI owns those gates.

## Dependency / rollout
Downstream contract sync for the PlatformService / PlatformBackend withdrawal.

Rollback: revert this commit to restore the old schemas.