### PR TITLE
feat(suno): use negative_tags in MCP tools

### DIFF
--- a/suno/prompts/__init__.py
+++ b/suno/prompts/__init__.py
@@ -109,7 +109,7 @@ def suno_workflow_examples() -> str:
 
 ## Tips:
 - Always be descriptive in prompts - include genre, mood, instruments, tempo
-- Use style_negative to exclude unwanted elements
+- Use negative_tags to exclude unwanted elements
 - For v4.5+ models, offer vocal_gender option for custom songs
 """
 
@@ -153,7 +153,7 @@ Good prompts include:
 
 ## Style Negative Examples
 
-Use style_negative to exclude:
+Use negative_tags to exclude:
 - "autotune, robotic" - for natural vocals
 - "heavy metal, screaming" - for softer songs
 - "electronic, synth" - for acoustic sound

--- a/suno/tests/test_audio_tools.py
+++ b/suno/tests/test_audio_tools.py
@@ -51,6 +51,35 @@ class TestInspoTool:
         assert "prompt" not in payload
 
 
+class TestCustomNegativeTags:
+    """Tests for excluded styles on custom generation."""
+
+    @pytest.mark.asyncio
+    async def test_negative_tags_are_forwarded(self, mock_audio_response):
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            await suno_generate_custom_music(
+                lyric="[Verse]\nhello",
+                negative_tags="metal, distortion",
+            )
+
+        payload = mock_generate.await_args.kwargs
+        assert payload["negative_tags"] == "metal, distortion"
+        assert "style_negative" not in payload
+
+    @pytest.mark.asyncio
+    async def test_empty_negative_tags_are_omitted(self, mock_audio_response):
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            await suno_generate_custom_music(lyric="[Verse]\nhello")
+
+        assert "negative_tags" not in mock_generate.await_args.kwargs
+
+
 class TestCustomDuration:
     """Tests for the duration parameter on custom generation."""
 

--- a/suno/tools/audio_tools.py
+++ b/suno/tools/audio_tools.py
@@ -109,10 +109,10 @@ async def suno_generate_custom_music(
             description="Prompt for auto-generating lyrics. Only used when custom is true and lyric is empty. Provide a dict with the lyric generation parameters (e.g. {'prompt': 'A song about winter'})."
         ),
     ] = None,
-    style_negative: Annotated[
+    negative_tags: Annotated[
         str,
         Field(
-            description="Styles to explicitly exclude from the generation. Examples: 'heavy metal, screaming', 'autotune, electronic'"
+            description="Styles or genres to explicitly exclude from custom generation. Examples: 'heavy metal, screaming', 'autotune, electronic'"
         ),
     ] = "",
     vocal_gender: Annotated[
@@ -184,8 +184,8 @@ async def suno_generate_custom_music(
         payload["lyric_prompt"] = lyric_prompt
     if style:
         payload["style"] = style
-    if style_negative:
-        payload["style_negative"] = style_negative
+    if negative_tags:
+        payload["negative_tags"] = negative_tags
     if vocal_gender and vocal_gender in ("f", "m"):
         payload["vocal_gender"] = vocal_gender
     if variation_category:


### PR DESCRIPTION
## Contract
Expose `negative_tags` in the Suno MCP tool schema and payload. This follows the canonical API contract.

## Dependency graph
PlatformService runtime -> PlatformBackend contract/docs -> MCP client.

Depends on https://github.com/AceDataCloud/PlatformBackend/pull/1301.

## Validation
- `pytest -q`: 34 passed, 7 skipped.
- Ruff check and format check passed.

## Review
Adversarial review not requested.

## Rollout / rollback
Release through the existing MCP publication workflow. Revert this PR to restore the old tool parameter.
