### PR TITLE
fix(sync): publish MiniMax MCP mirror

### DIFF
--- a/sync.yaml
+++ b/sync.yaml
@@ -59,6 +59,10 @@ mappings:
     repo: AceDataCloud/HailuoMCP
     exclude:
       - .gitbooks
+  minimax:
+    repo: AceDataCloud/MinimaxMCP
+    exclude:
+      - .gitbooks
   happyhorse:
     repo: AceDataCloud/HappyHorseMCP
     exclude:


### PR DESCRIPTION
## Summary
- register `minimax/` in the MCP monorepo mirror map
- publish it to `AceDataCloud/MinimaxMCP` so standalone CI/deploy can run

## Verification
- parsed `sync.yaml` and asserted the MiniMax mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)