### PR TITLE
docs(minimax): link public API reference

### DIFF
--- a/minimax/README.md
+++ b/minimax/README.md
@@ -37,6 +37,8 @@ https://minimax.mcp.acedata.cloud/mcp
 
 The hosted server supports AceDataCloud OAuth. MCP clients that support remote OAuth can connect directly to this URL.
 
+Public API reference: [MiniMax H3 Videos API](https://platform.acedata.cloud/documents/minimax-videos).
+
 ## Local installation
 
 ```bash


### PR DESCRIPTION
## Summary
- link the MiniMax MCP README to its public API reference
- trigger the now-mapped `minimax/` directory mirror into `AceDataCloud/MinimaxMCP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)