### PR TITLE
fix(minimax): remove watermark tool option

### DIFF
--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -41,8 +41,16 @@ async def test_image_tool_payload(monkeypatch, generated_response):
         model="MiniMax-H3",
         content=[
             {"type": "text", "text": "move"},
-            {"type": "image_url", "image_url": {"url": "https://cdn.test/one.png"}, "role": "first_frame"},
-            {"type": "image_url", "image_url": {"url": "https://cdn.test/two.png"}, "role": "reference_image"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cdn.test/one.png"},
+                "role": "first_frame",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cdn.test/two.png"},
+                "role": "reference_image",
+            },
         ],
         resolution="2K",
         ratio="16:9",
@@ -63,8 +71,16 @@ async def test_audio_tool_payload(monkeypatch, generated_response):
         model="MiniMax-H3",
         content=[
             {"type": "text", "text": "dance"},
-            {"type": "image_url", "image_url": {"url": "https://cdn.test/one.png"}, "role": "first_frame"},
-            {"type": "audio_url", "audio_url": {"url": "https://cdn.test/beat.mp3"}, "role": "reference_audio"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cdn.test/one.png"},
+                "role": "first_frame",
+            },
+            {
+                "type": "audio_url",
+                "audio_url": {"url": "https://cdn.test/beat.mp3"},
+                "role": "reference_audio",
+            },
         ],
         resolution="2K",
         ratio="16:9",

--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -25,7 +25,6 @@ async def test_text_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="16:9",
         duration=6,
-        aigc_watermark=False,
     )
 
 
@@ -48,7 +47,6 @@ async def test_image_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="16:9",
         duration=4,
-        aigc_watermark=False,
     )
 
 
@@ -71,7 +69,6 @@ async def test_audio_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="16:9",
         duration=4,
-        aigc_watermark=False,
     )
 
 
@@ -105,5 +102,4 @@ async def test_full_schema_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="adaptive",
         duration=4,
-        aigc_watermark=False,
     )

--- a/minimax/tools/task_tools.py
+++ b/minimax/tools/task_tools.py
@@ -12,9 +12,7 @@ from core.utils import format_batch_task_result, format_task_result
 
 @mcp.tool()
 async def minimax_list_tasks(
-    limit: Annotated[
-        int | None, Field(description="Maximum number of tasks to return.")
-    ] = None,
+    limit: Annotated[int | None, Field(description="Maximum number of tasks to return.")] = None,
     offset: Annotated[
         int | None, Field(description="Number of tasks to skip before returning results.")
     ] = None,
@@ -33,7 +31,9 @@ async def minimax_list_tasks(
         "created_at_min": created_at_min,
         "created_at_max": created_at_max,
     }
-    result = await client.query_task(**{key: value for key, value in payload.items() if value is not None})
+    result = await client.query_task(
+        **{key: value for key, value in payload.items() if value is not None}
+    )
     return format_batch_task_result(result)
 
 

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -26,7 +26,6 @@ def _common_payload(
     ratio: MinimaxRatio,
     duration: int,
     content: list[dict[str, str | dict[str, str]]],
-    aigc_watermark: bool,
     callback_url: str | None,
 ) -> dict:
     payload: dict = {
@@ -35,7 +34,6 @@ def _common_payload(
         "resolution": resolution,
         "ratio": ratio,
         "duration": duration,
-        "aigc_watermark": aigc_watermark,
     }
     if callback_url:
         payload["callback_url"] = callback_url
@@ -61,7 +59,6 @@ async def minimax_generate_video_from_text(
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,
-    aigc_watermark: Annotated[bool, Field(description="Add an AIGC watermark.")] = False,
     model: Annotated[MinimaxModel, Field(description="MiniMax H3 model name.")] = DEFAULT_MODEL,
     callback_url: Annotated[
         str | None, Field(description="Optional public webhook URL for the final result.")
@@ -74,7 +71,6 @@ async def minimax_generate_video_from_text(
         ratio=ratio,
         duration=duration,
         content=[{"type": "text", "text": prompt}],
-        aigc_watermark=aigc_watermark,
         callback_url=callback_url,
     )
     return format_video_result(await client.generate_video(**payload))
@@ -84,8 +80,7 @@ async def minimax_generate_video_from_text(
 async def minimax_generate_video_from_images(
     image_urls: Annotated[
         list[str], Field(min_length=1, description="Public image URLs.")
-    ],
-    prompt: Annotated[
+    ],    prompt: Annotated[
         str, Field(min_length=1, max_length=7000, description="Required motion and style guidance.")
     ],
     resolution: Annotated[
@@ -97,7 +92,6 @@ async def minimax_generate_video_from_images(
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,
-    aigc_watermark: Annotated[bool, Field(description="Add an AIGC watermark.")] = False,
     model: Annotated[MinimaxModel, Field(description="MiniMax H3 model name.")] = DEFAULT_MODEL,
     callback_url: Annotated[
         str | None, Field(description="Optional public webhook URL for the final result.")
@@ -120,7 +114,6 @@ async def minimax_generate_video_from_images(
                 for index, image_url in enumerate(image_urls)
             ],
         ],
-        aigc_watermark=aigc_watermark,
         callback_url=callback_url,
     )
     return format_video_result(await client.generate_video(**payload))
@@ -130,8 +123,7 @@ async def minimax_generate_video_from_images(
 async def minimax_generate_video_from_audio(
     audio_urls: Annotated[
         list[str], Field(min_length=1, description="Public audio URLs.")
-    ],
-    image_urls: Annotated[
+    ],    image_urls: Annotated[
         list[str],
         Field(min_length=1, description="Required reference images."),
     ],
@@ -147,7 +139,6 @@ async def minimax_generate_video_from_audio(
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,
-    aigc_watermark: Annotated[bool, Field(description="Add an AIGC watermark.")] = False,
     model: Annotated[MinimaxModel, Field(description="MiniMax H3 model name.")] = DEFAULT_MODEL,
     callback_url: Annotated[
         str | None, Field(description="Optional public webhook URL for the final result.")
@@ -178,7 +169,6 @@ async def minimax_generate_video_from_audio(
                 for audio_url in audio_urls
             ],
         ],
-        aigc_watermark=aigc_watermark,
         callback_url=callback_url,
     )
     return format_video_result(await client.generate_video(**payload))
@@ -200,7 +190,6 @@ async def minimax_generate_video(
         MinimaxRatio,
         Field(description="Output aspect ratio: adaptive, 21:9, 16:9, 4:3, 1:1, 3:4, or 9:16."),
     ] = DEFAULT_RATIO,
-    aigc_watermark: Annotated[bool, Field(description="Add an AIGC watermark.")] = False,
     model: Annotated[MinimaxModel, Field(description="MiniMax H3 model name.")] = DEFAULT_MODEL,
     callback_url: Annotated[
         str | None, Field(description="Optional public webhook URL for the final result.")
@@ -213,7 +202,6 @@ async def minimax_generate_video(
         ratio=ratio,
         duration=duration,
         content=[item.model_dump(exclude_none=True) for item in content],
-        aigc_watermark=aigc_watermark,
         callback_url=callback_url,
     )
     return format_video_result(await client.generate_video(**payload))

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -25,7 +25,7 @@ def _common_payload(
     resolution: MinimaxResolution,
     ratio: MinimaxRatio,
     duration: int,
-    content: list[dict[str, str | dict[str, str]]],
+    content: list[dict],
     callback_url: str | None,
 ) -> dict:
     payload: dict = {

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -53,9 +53,7 @@ async def minimax_generate_video_from_text(
     resolution: Annotated[
         MinimaxResolution, Field(description="Output resolution: 768P or 2K.")
     ] = DEFAULT_RESOLUTION,
-    ratio: Annotated[
-        MinimaxRatio, Field(description="Output aspect ratio.")
-    ] = DEFAULT_RATIO,
+    ratio: Annotated[MinimaxRatio, Field(description="Output aspect ratio.")] = DEFAULT_RATIO,
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,
@@ -78,17 +76,14 @@ async def minimax_generate_video_from_text(
 
 @mcp.tool()
 async def minimax_generate_video_from_images(
-    image_urls: Annotated[
-        list[str], Field(min_length=1, description="Public image URLs.")
-    ],    prompt: Annotated[
+    image_urls: Annotated[list[str], Field(min_length=1, description="Public image URLs.")],
+    prompt: Annotated[
         str, Field(min_length=1, max_length=7000, description="Required motion and style guidance.")
     ],
     resolution: Annotated[
         MinimaxResolution, Field(description="Output resolution: 768P or 2K.")
     ] = DEFAULT_RESOLUTION,
-    ratio: Annotated[
-        MinimaxRatio, Field(description="Output aspect ratio.")
-    ] = DEFAULT_RATIO,
+    ratio: Annotated[MinimaxRatio, Field(description="Output aspect ratio.")] = DEFAULT_RATIO,
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,
@@ -121,9 +116,8 @@ async def minimax_generate_video_from_images(
 
 @mcp.tool()
 async def minimax_generate_video_from_audio(
-    audio_urls: Annotated[
-        list[str], Field(min_length=1, description="Public audio URLs.")
-    ],    image_urls: Annotated[
+    audio_urls: Annotated[list[str], Field(min_length=1, description="Public audio URLs.")],
+    image_urls: Annotated[
         list[str],
         Field(min_length=1, description="Required reference images."),
     ],
@@ -133,9 +127,7 @@ async def minimax_generate_video_from_audio(
     resolution: Annotated[
         MinimaxResolution, Field(description="Output resolution: 768P or 2K.")
     ] = DEFAULT_RESOLUTION,
-    ratio: Annotated[
-        MinimaxRatio, Field(description="Output aspect ratio.")
-    ] = DEFAULT_RATIO,
+    ratio: Annotated[MinimaxRatio, Field(description="Output aspect ratio.")] = DEFAULT_RATIO,
     duration: Annotated[
         int, Field(ge=4, le=15, description="Integer output duration from 4 to 15 seconds.")
     ] = DEFAULT_DURATION,


### PR DESCRIPTION
## Contract

`POST /minimax/videos` (API `64f22fd9-0efd-445e-b0b1-135682fd66d7`) no longer exposes `aigc_watermark`. After the coordinated runtime change, explicitly sending either boolean value is rejected as an unsupported field (HTTP 400), rather than silently ignored.

## Changes and validation

Removes the option from all four MiniMax MCP tool schemas and from the shared API payload helper. Updates the payload tests and widens the dynamic multimodal helper type to match its JSON contract.

Validation:
- local ruff and full-package format check passed
- local mypy passed for all 13 source files
- direct tool-signature and payload smoke passed
- CI lint, build, and tests on Python 3.10/3.11/3.12 are all green

## Dependency graph

consumer surfaces → PlatformService runtime enforcement + PlatformBackend OpenAPI/docs → generated Docs/downstream reconciliation

This consumer removal is safe to merge before the runtime/contract switch because it only stops emitting an optional field whose existing default is already `false`.

## Rollout / rollback

Release before or with the PlatformService and PlatformBackend PRs. Roll back together with the coordinated set; do not restore the parameter in only one surface.

## Out of scope

Legacy `/hailuo/videos`, billing rules, generated Docs files, and historical validation reports.

Adversarial review: not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
