### PR TITLE
fix(minimax): keep reference roles contract-valid

### DIFF
--- a/minimax/core/client.py
+++ b/minimax/core/client.py
@@ -74,7 +74,9 @@ class MinimaxClient:
             body = {}
 
         error_obj = body.get("error", {})
-        code = body.get("code") or error_obj.get("code") or error_obj.get("type") or f"http_{status}"
+        code = (
+            body.get("code") or error_obj.get("code") or error_obj.get("type") or f"http_{status}"
+        )
         message = (
             error_obj.get("message") or body.get("detail") or response.text or f"HTTP {status}"
         )

--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -30,7 +30,32 @@ async def test_text_tool_payload(monkeypatch, generated_response):
 
 
 @pytest.mark.asyncio
-async def test_image_tool_payload(monkeypatch, generated_response):
+async def test_image_tool_single_image_uses_first_frame(monkeypatch, generated_response):
+    generate = AsyncMock(return_value=generated_response)
+    monkeypatch.setattr(video_tools.client, "generate_video", generate)
+
+    await video_tools.minimax_generate_video_from_images(
+        ["https://cdn.test/one.png"], prompt="move"
+    )
+
+    generate.assert_awaited_once_with(
+        model="MiniMax-H3",
+        content=[
+            {"type": "text", "text": "move"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://cdn.test/one.png"},
+                "role": "first_frame",
+            },
+        ],
+        resolution="2K",
+        ratio="16:9",
+        duration=4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_image_tool_multiple_images_uses_reference(monkeypatch, generated_response):
     generate = AsyncMock(return_value=generated_response)
     monkeypatch.setattr(video_tools.client, "generate_video", generate)
 

--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -45,7 +45,7 @@ async def test_image_tool_payload(monkeypatch, generated_response):
             {
                 "type": "image_url",
                 "image_url": {"url": "https://cdn.test/one.png"},
-                "role": "first_frame",
+                "role": "reference_image",
             },
             {
                 "type": "image_url",
@@ -75,7 +75,7 @@ async def test_audio_tool_payload(monkeypatch, generated_response):
             {
                 "type": "image_url",
                 "image_url": {"url": "https://cdn.test/one.png"},
-                "role": "first_frame",
+                "role": "reference_image",
             },
             {
                 "type": "audio_url",

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -104,7 +104,7 @@ async def minimax_generate_video_from_images(
                 {
                     "type": "image_url",
                     "image_url": {"url": image_url},
-                    "role": "first_frame" if index == 0 else "reference_image",
+                    "role": "reference_image",
                 }
                 for index, image_url in enumerate(image_urls)
             ],
@@ -148,7 +148,7 @@ async def minimax_generate_video_from_audio(
                 {
                     "type": "image_url",
                     "image_url": {"url": image_url},
-                    "role": "first_frame" if index == 0 else "reference_image",
+                    "role": "reference_image",
                 }
                 for index, image_url in enumerate(image_urls)
             ],

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -92,7 +92,13 @@ async def minimax_generate_video_from_images(
         str | None, Field(description="Optional public webhook URL for the final result.")
     ] = None,
 ) -> str:
-    """Generate from one first-frame image or multiple reference images."""
+    """Generate from one first-frame image or multiple reference images.
+
+    Single image uses first_frame mode; multiple images use reference_image mode.
+    The two modes are mutually exclusive per MiniMax H3 v2 API contract.
+    """
+    # Official constraint: first_frame/last_frame and reference_image are mutually exclusive.
+    role = "first_frame" if len(image_urls) == 1 else "reference_image"
     payload = _common_payload(
         model=model,
         resolution=resolution,
@@ -104,9 +110,9 @@ async def minimax_generate_video_from_images(
                 {
                     "type": "image_url",
                     "image_url": {"url": image_url},
-                    "role": "reference_image",
+                    "role": role,
                 }
-                for index, image_url in enumerate(image_urls)
+                for image_url in image_urls
             ],
         ],
         callback_url=callback_url,
@@ -136,7 +142,11 @@ async def minimax_generate_video_from_audio(
         str | None, Field(description="Optional public webhook URL for the final result.")
     ] = None,
 ) -> str:
-    """Generate a MiniMax H3 video guided by audio and reference images."""
+    """Generate a MiniMax H3 video guided by audio and reference images.
+
+    Audio-guided generation uses reference mode exclusively (reference_audio
+    forces the entire content into reference-to-video mode per the H3 v2 contract).
+    """
     payload = _common_payload(
         model=model,
         resolution=resolution,
@@ -150,7 +160,7 @@ async def minimax_generate_video_from_audio(
                     "image_url": {"url": image_url},
                     "role": "reference_image",
                 }
-                for index, image_url in enumerate(image_urls)
+                for image_url in image_urls
             ],
             *[
                 {


### PR DESCRIPTION
## Summary
- keep multi-image generation entirely in the `reference_image` scenario
- prevent audio-guided payloads from mixing `first_frame` with reference media
- update payload assertions for the H3 v2 role contract

## Validation
Local pytest was blocked before collection by incompatible globally installed pytest and pytest-asyncio versions; repository CI uses its isolated dependency matrix.

## Scope
No new tools, media modes, or client behavior beyond correcting generated roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)