### PR TITLE
test(suno): fix lyrics request contract

### DIFF
--- a/suno/tests/test_client.py
+++ b/suno/tests/test_client.py
@@ -65,6 +65,29 @@ class TestSunoClient:
             assert result == mock_audio_response
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["default", "remi-v1"])
+    async def test_generate_lyrics_payload_contract(self, client, mock_lyrics_response, model):
+        """Lyrics requests should use the dedicated endpoint contract."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_lyrics_response
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post.return_value = mock_response
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            await client.generate_lyrics(prompt="A song about code", model=model)
+
+        mock_instance.post.assert_awaited_once()
+        request = mock_instance.post.await_args
+        assert request.args[0] == "https://api.test.com/suno/lyrics"
+        payload = request.kwargs["json"]
+        assert isinstance(payload["prompt"], str)
+        assert payload["model"] in {"default", "remi-v1"}
+        assert "action" not in payload
+
+    @pytest.mark.asyncio
     async def test_request_auth_error_401(self, client):
         """Test 401 response raises auth error."""
         mock_response = MagicMock()

--- a/suno/tests/test_integration.py
+++ b/suno/tests/test_integration.py
@@ -89,7 +89,7 @@ class TestLyricsTools:
 
         result = await suno_generate_lyrics(
             prompt="A short song about testing software",
-            model="chirp-v3",
+            model="default",
         )
 
         print("\n=== Generate Lyrics Result ===")
@@ -218,7 +218,7 @@ class TestClientDirectly:
 
         result = await client.generate_lyrics(
             prompt="A song about code",
-            model="chirp-v3",
+            model="remi-v1",
         )
 
         print("\n=== Client Lyrics Result ===")


### PR DESCRIPTION
## Summary

- replace the two invalid Suno lyrics integration models with `default` and `remi-v1`
- add a mocked `/suno/lyrics` request contract test covering both legal models
- assert the payload sends a string `prompt`, a legal lyrics `model`, and no audio-only `action`

## Dependency

- PlatformBackend Suno PR: https://github.com/AceDataCloud/PlatformBackend/pull/1414; link to be added

## Tests

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy core tools main.py`
- `uv run pytest --cov=core --cov=tools --cov-report=term-missing` — 36 passed, 7 skipped
- `git diff --check`
- diff scope check: only `suno/tests/test_client.py` and `suno/tests/test_integration.py`

## Rollback

Revert this test-only commit. No production behavior, schema, or runtime configuration changes are included.

## Out of scope

- production lyrics types, which already define `Literal["default", "remi-v1"]`
- production client/tool behavior
- every MCP family other than Suno

## Review

Adversarial review not requested.

