### PR TITLE
feat(acedatacloud): add current user info tool

### DIFF
--- a/acedatacloud/README.md
+++ b/acedatacloud/README.md
@@ -26,6 +26,7 @@ MCP-compatible client.
 
 | Tool | Description |
 |------|-------------|
+| `acedatacloud_get_user_info` | Current authenticated account user ID. |
 | `acedatacloud_get_balance` | Remaining credits per subscription, plus a total. |
 | `acedatacloud_list_applications` | Your subscriptions with balance/spend. |
 | `acedatacloud_list_services` | List or search available services. |

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -18,8 +18,17 @@ API = "https://platform.acedata.cloud/api/v1"
 @respx.mock
 @pytest.mark.asyncio
 async def test_get_user_info_uses_current_request_token():
-    route = respx.get(f"{API}/users/me/").mock(
-        return_value=httpx.Response(200, json={"user_id": "user-1"})
+    route = respx.get(f"{API}/platform-tokens/me/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "user-1",
+                "username": "testuser",
+                "email": "test@example.com",
+                "nickname": "Test",
+                "avatar": None,
+            },
+        )
     )
     set_request_api_token("platform-request-token")
     try:
@@ -27,14 +36,15 @@ async def test_get_user_info_uses_current_request_token():
     finally:
         set_request_api_token(None)
 
-    assert out == {"user_id": "user-1"}
+    assert out["id"] == "user-1"
+    assert out["username"] == "testuser"
     assert route.calls[0].request.headers["authorization"] == "Bearer platform-request-token"
 
 
 @respx.mock
 @pytest.mark.asyncio
 async def test_get_user_info_maps_authentication_errors():
-    respx.get(f"{API}/users/me/").mock(
+    respx.get(f"{API}/platform-tokens/me/").mock(
         return_value=httpx.Response(401, json={"detail": "Invalid platform token"})
     )
 
@@ -46,7 +56,7 @@ async def test_get_user_info_maps_authentication_errors():
 @respx.mock
 @pytest.mark.asyncio
 async def test_get_user_info_maps_empty_response():
-    respx.get(f"{API}/users/me/").mock(return_value=httpx.Response(204))
+    respx.get(f"{API}/platform-tokens/me/").mock(return_value=httpx.Response(204))
 
     out = json.loads(await acedatacloud_get_user_info())
 

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -6,11 +6,51 @@ import httpx
 import pytest
 import respx
 
+from core.client import set_request_api_token
 from tools.admin_tools import acedatacloud_create_announcement
+from tools.info_tools import acedatacloud_get_user_info
 from tools.read_tools import acedatacloud_get_balance, acedatacloud_list_services
 from tools.write_tools import acedatacloud_create_credential, acedatacloud_delete_credential
 
 API = "https://platform.acedata.cloud/api/v1"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_user_info_uses_current_request_token():
+    route = respx.get(f"{API}/users/me/").mock(
+        return_value=httpx.Response(200, json={"user_id": "user-1"})
+    )
+    set_request_api_token("platform-request-token")
+    try:
+        out = json.loads(await acedatacloud_get_user_info())
+    finally:
+        set_request_api_token(None)
+
+    assert out == {"user_id": "user-1"}
+    assert route.calls[0].request.headers["authorization"] == "Bearer platform-request-token"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_user_info_maps_authentication_errors():
+    respx.get(f"{API}/users/me/").mock(
+        return_value=httpx.Response(401, json={"detail": "Invalid platform token"})
+    )
+
+    out = json.loads(await acedatacloud_get_user_info())
+
+    assert out == {"error": "Authentication Error", "message": "Invalid platform token"}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_user_info_maps_empty_response():
+    respx.get(f"{API}/users/me/").mock(return_value=httpx.Response(204))
+
+    out = json.loads(await acedatacloud_get_user_info())
+
+    assert out == {"error": "No Response", "message": "The API returned an empty response."}
 
 
 @respx.mock

--- a/acedatacloud/tools/info_tools.py
+++ b/acedatacloud/tools/info_tools.py
@@ -1,6 +1,27 @@
 """Informational tools for the Platform MCP server."""
 
+from core.client import client
+from core.exceptions import PlatformAPIError, PlatformAuthError
 from core.server import mcp
+from core.utils import dumps, error_json
+
+
+@mcp.tool()
+async def acedatacloud_get_user_info() -> str:
+    """Get the current authenticated AceDataCloud account's user ID.
+
+    Call this when a task needs to identify the account represented by the
+    current platform credential, including when constructing an inviter_id URL.
+    """
+    try:
+        result = await client.get("/users/me/")
+        if result is None:
+            return error_json("No Response", "The API returned an empty response.")
+        return dumps(result)
+    except PlatformAuthError as e:
+        return error_json("Authentication Error", e.message)
+    except PlatformAPIError as e:
+        return error_json("API Error", e.message)
 
 
 @mcp.tool()
@@ -10,7 +31,7 @@ async def acedatacloud_get_usage_guide() -> str:
     Explains the available tools, the write-confirmation model, and the
     authentication requirements.
     """
-    # Last updated: 2026-06-28
+    # Last updated: 2026-08-10
     return """# AceDataCloud Platform Management — Tool Guide
 
 These tools manage your AceDataCloud account via the console API
@@ -19,6 +40,7 @@ ACEDATACLOUD_PLATFORM_TOKEN — NOT the api.acedata.cloud service token.
 Create one at https://platform.acedata.cloud/console/platform-tokens
 
 ## Read tools (safe)
+- acedatacloud_get_user_info — current authenticated account user ID
 - acedatacloud_get_balance — remaining credits per subscription (+ total)
 - acedatacloud_list_applications — your subscriptions and balances
 - acedatacloud_list_services — list/search available services

--- a/acedatacloud/tools/info_tools.py
+++ b/acedatacloud/tools/info_tools.py
@@ -8,13 +8,14 @@ from core.utils import dumps, error_json
 
 @mcp.tool()
 async def acedatacloud_get_user_info() -> str:
-    """Get the current authenticated AceDataCloud account's user ID.
+    """Get the current authenticated AceDataCloud account's user profile.
 
-    Call this when a task needs to identify the account represented by the
-    current platform credential, including when constructing an inviter_id URL.
+    Returns id, username, email, nickname, and avatar for the account
+    represented by the current platform credential. Useful for constructing
+    personalized content (e.g. inviter_id referral links).
     """
     try:
-        result = await client.get("/users/me/")
+        result = await client.get("/platform-tokens/me/")
         if result is None:
             return error_json("No Response", "The API returned an empty response.")
         return dumps(result)


### PR DESCRIPTION
## Summary
- add safe read-only `acedatacloud_get_user_info`
- resolve opaque platform tokens through `/api/v1/users/me/` instead of local JWT decoding
- document the tool and cover request-token, auth-error, and empty-response behavior

## Tests
- focused Ruff checks passed
- `mypy core tools` passed
- local pytest was blocked by an incompatible global pytest/pytest-asyncio environment; CI remains the test gate

## Runtime dependency
Requires the PlatformBackend `/api/v1/users/me/` endpoint to be deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)