### PR TITLE
fix(maestro): restore task history listing

### DIFF
--- a/maestro/core/client.py
+++ b/maestro/core/client.py
@@ -89,5 +89,19 @@ class MaestroClient:
         """Retrieve one Maestro task."""
         return await self.request("/maestro/tasks", {"id": task_id, "action": "retrieve"})
 
+    async def list_tasks(
+        self,
+        limit: int,
+        created_at_min: int | None = None,
+        created_at_max: int | None = None,
+    ) -> dict[str, Any]:
+        """List recent Maestro tasks for the authenticated user."""
+        payload: dict[str, Any] = {"action": "retrieve_batch", "limit": limit}
+        if created_at_min is not None:
+            payload["created_at_min"] = created_at_min
+        if created_at_max is not None:
+            payload["created_at_max"] = created_at_max
+        return await self.request("/maestro/tasks", payload)
+
 
 client = MaestroClient()

--- a/maestro/main.py
+++ b/maestro/main.py
@@ -80,6 +80,10 @@ def main() -> None:
                         "name": "maestro_get_task",
                         "description": "Get video progress and outputs",
                     },
+                    {
+                        "name": "maestro_list_tasks",
+                        "description": "List recent Maestro tasks",
+                    },
                 ],
                 "prompts": [
                     {

--- a/maestro/tests/test_client.py
+++ b/maestro/tests/test_client.py
@@ -36,6 +36,20 @@ async def test_task_operations_use_tasks_endpoint(api_token: str) -> None:
 
 
 @respx.mock
+async def test_list_tasks_uses_batch_action_and_time_bounds(api_token: str) -> None:
+    route = respx.post("https://api.acedata.cloud/maestro/tasks").mock(
+        return_value=httpx.Response(200, json={"count": 0, "items": []})
+    )
+    client = MaestroClient(api_token=api_token)
+
+    await client.list_tasks(30, 100, 200)
+
+    assert route.calls.last.request.read() == (
+        b'{"action":"retrieve_batch","limit":30,"created_at_min":100,"created_at_max":200}'
+    )
+
+
+@respx.mock
 async def test_api_error_preserves_status(api_token: str) -> None:
     respx.post("https://api.acedata.cloud/maestro/tasks").mock(
         return_value=httpx.Response(404, json={"detail": "task not found"})

--- a/maestro/tests/test_tools.py
+++ b/maestro/tests/test_tools.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import AsyncMock, patch
 
-from tools.task_tools import maestro_get_task
+from tools.task_tools import maestro_get_task, maestro_list_tasks
 from tools.video_tools import maestro_create_video
 
 
@@ -75,3 +75,13 @@ async def test_task_tools_delegate_to_client() -> None:
         await maestro_get_task("task-1")
 
     get_task.assert_awaited_once_with("task-1")
+
+
+async def test_list_tasks_delegates_filters_to_client() -> None:
+    with patch("tools.task_tools.client.list_tasks", new_callable=AsyncMock) as list_tasks:
+        list_tasks.return_value = {"count": 0, "items": []}
+
+        result = await maestro_list_tasks(30, 100, 200)
+
+    list_tasks.assert_awaited_once_with(30, 100, 200)
+    assert json.loads(result) == {"count": 0, "items": []}

--- a/maestro/tools/task_tools.py
+++ b/maestro/tools/task_tools.py
@@ -7,7 +7,7 @@ from pydantic import Field
 
 from core.client import client
 from core.server import mcp
-from core.utils import IN_FLIGHT_STATES, format_task_result
+from core.utils import IN_FLIGHT_STATES, format_result, format_task_result
 
 
 @mcp.tool()
@@ -24,3 +24,22 @@ async def maestro_get_task(
     if str(data.get("status", "")).lower() in IN_FLIGHT_STATES:
         await asyncio.sleep(5)
     return format_task_result(data)
+
+
+@mcp.tool()
+async def maestro_list_tasks(
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of recent tasks to return.", ge=1, le=100),
+    ] = 20,
+    created_at_min: Annotated[
+        int | None,
+        Field(description="Optional inclusive lower Unix timestamp for task creation time."),
+    ] = None,
+    created_at_max: Annotated[
+        int | None,
+        Field(description="Optional inclusive upper Unix timestamp for task creation time."),
+    ] = None,
+) -> str:
+    """List recent Maestro tasks owned by the authenticated user."""
+    return format_result(await client.list_tasks(limit, created_at_min, created_at_max))


### PR DESCRIPTION
## Summary

- restore `maestro_list_tasks` as a read-only Maestro MCP tool
- forward `limit` and optional creation-time bounds to `/maestro/tasks` with `action=retrieve_batch`
- advertise the tool in the public server card
- add client payload and tool delegation regression tests

## Root cause

The split YouTube publisher schedule must scan completed Maestro history without creating videos. Production `mcp-maestro:9` exposed only create/get even though the connector catalog documents `maestro_list_tasks`, so the publisher correctly stopped rather than creating a replacement task.

## Validation

- `python3 -m pytest -q` → 33 passed
- `python3 -m ruff check .`
- `python3 -m mypy core tools`

## Rollout

After deployment, verify MCP tools/list exposes `maestro_list_tasks`, then resume and re-run the publisher-only scheduled-task validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)