### PR TITLE
style(maestro): satisfy ruff format gate

### DIFF
--- a/maestro/tools/video_tools.py
+++ b/maestro/tools/video_tools.py
@@ -107,11 +107,7 @@ async def maestro_create_video(
     ] = None,
     voice: Annotated[
         MaestroVoice | None,
-        Field(
-            description=(
-                "Narration voice preset. Use 'auto' or omit to let the server decide."
-            )
-        ),
+        Field(description=("Narration voice preset. Use 'auto' or omit to let the server decide.")),
     ] = None,
     callback_url: Annotated[
         str | None,


### PR DESCRIPTION
## Summary

- apply the repository Ruff formatter to the pre-existing Maestro voice field wrapping
- restore the monorepo lint gate after https://github.com/AceDataCloud/MCPs/pull/637 merged

## Validation

- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m pytest -q` → 33 passed

No runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)