### PR TITLE
fix(maestro): support optional client task IDs

### DIFF
--- a/maestro/tests/test_client.py
+++ b/maestro/tests/test_client.py
@@ -15,12 +15,21 @@ async def test_create_video_uses_public_endpoint(api_token: str) -> None:
     )
     client = MaestroClient(api_token=api_token)
 
-    result = await client.create_video({"prompt": "Make a product video", "duration": 30})
+    result = await client.create_video(
+        {
+            "task_id": "0194c0be-8f6c-7e31-a7d2-0123456789ab",
+            "prompt": "Make a product video",
+            "duration": 30,
+        }
+    )
 
     assert result["task_id"] == "task-1"
     request = route.calls.last.request
     assert request.headers["authorization"] == "Bearer test-token"
-    assert request.read() == b'{"prompt":"Make a product video","duration":30}'
+    assert request.read() == (
+        b'{"task_id":"0194c0be-8f6c-7e31-a7d2-0123456789ab",'
+        b'"prompt":"Make a product video","duration":30}'
+    )
 
 
 @respx.mock

--- a/maestro/tests/test_tool_schema.py
+++ b/maestro/tests/test_tool_schema.py
@@ -1,0 +1,14 @@
+"""Public MCP tool schema contracts."""
+
+import tools  # noqa: F401
+from core.server import mcp
+
+
+async def test_create_video_accepts_optional_uuid_task_id() -> None:
+    tool = next(tool for tool in await mcp.list_tools() if tool.name == "maestro_create_video")
+    schema = tool.inputSchema
+
+    assert "task_id" not in schema["required"]
+    task_id = schema["properties"]["task_id"]
+    assert {item.get("format") for item in task_id["anyOf"]} == {"uuid", None}
+    assert task_id["default"] is None

--- a/maestro/tests/test_tools.py
+++ b/maestro/tests/test_tools.py
@@ -2,15 +2,19 @@
 
 import json
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
 
 from tools.task_tools import maestro_get_task, maestro_list_tasks
 from tools.video_tools import maestro_create_video
+
+TASK_ID = UUID("0194c0be-8f6c-7e31-a7d2-0123456789ab")
 
 
 async def test_create_video_builds_complete_payload() -> None:
     with patch("tools.video_tools.client.create_video", new_callable=AsyncMock) as create:
         create.return_value = {"success": True, "task_id": "task-1"}
         result = await maestro_create_video(
+            task_id=TASK_ID,
             prompt="Launch video for a new camera",
             action="generate",
             file_urls=["https://example.com/camera.jpg"],
@@ -25,6 +29,7 @@ async def test_create_video_builds_complete_payload() -> None:
 
     create.assert_awaited_once_with(
         {
+            "task_id": str(TASK_ID),
             "prompt": "Launch video for a new camera",
             "action": "generate",
             "file_urls": ["https://example.com/camera.jpg"],
@@ -41,7 +46,7 @@ async def test_create_video_builds_complete_payload() -> None:
 
 
 async def test_iteration_requires_reference_task() -> None:
-    result = await maestro_create_video(prompt="Make it faster", action="remix")
+    result = await maestro_create_video(task_id=TASK_ID, prompt="Make it faster", action="remix")
 
     assert result == "Error: action=remix requires ref_task_id."
 
@@ -58,13 +63,19 @@ async def test_iteration_does_not_clobber_source_format() -> None:
     with patch("tools.video_tools.client.create_video", new_callable=AsyncMock) as create:
         create.return_value = {"success": True, "task_id": "task-2"}
         await maestro_create_video(
+            task_id=TASK_ID,
             prompt="Tighten the intro",
             action="edit",
             ref_task_id="task-1",
         )
 
     create.assert_awaited_once_with(
-        {"prompt": "Tighten the intro", "action": "edit", "ref_task_id": "task-1"}
+        {
+            "task_id": str(TASK_ID),
+            "prompt": "Tighten the intro",
+            "action": "edit",
+            "ref_task_id": "task-1",
+        }
     )
 
 

--- a/maestro/tools/video_tools.py
+++ b/maestro/tools/video_tools.py
@@ -1,6 +1,7 @@
 """Maestro video creation tools."""
 
 from typing import Annotated, Any, TypedDict
+from uuid import UUID
 
 from pydantic import Field
 
@@ -58,6 +59,15 @@ async def maestro_create_video(
             min_length=1,
         ),
     ],
+    task_id: Annotated[
+        UUID | None,
+        Field(
+            description=(
+                "Optional client-generated UUID. Reusing it is rejected; omit it to let the "
+                "server generate a task ID."
+            )
+        ),
+    ] = None,
     action: Annotated[
         MaestroAction,
         Field(
@@ -167,6 +177,8 @@ async def maestro_create_video(
     # format (ratio/duration/quality) when iterating, avoiding wrong output and
     # mis-billing on remix/edit/extend.
     payload: dict[str, Any] = {"prompt": prompt, "action": action}
+    if task_id is not None:
+        payload["task_id"] = str(task_id)
     if ref_task_id:
         payload["ref_task_id"] = ref_task_id
     if aspect is not None:


### PR DESCRIPTION
## Summary

- add an optional caller-generated UUID `task_id` to `maestro_create_video`
- send it only when supplied; callers that omit it keep server-generated task IDs
- expose the optional field as nullable `format: uuid` in the MCP schema
- the Ace Data Cloud producer schedule explicitly generates and supplies one UUID per run to protect that workflow from transport replay

## Root cause

A single scheduled MCP tool call was replayed into two independent HTTP POSTs. Prompt-level “exactly once” cannot stop transport replay; an optional stable resource ID lets this workflow target the same task while preserving backward compatibility for every other caller.

## Validation

- `python3 -m pytest -q` → **34 passed**
- schema test asserts `task_id` is optional, nullable, and UUID-formatted
- omission test proves the payload remains unchanged for ordinary callers
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy core tools`

## Dependency

Merge/deploy https://github.com/AceDataCloud/PlatformService/pull/1958 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)