### PR TITLE
feat(maestro): expose production SKU contract

### DIFF
--- a/maestro/README.md
+++ b/maestro/README.md
@@ -31,6 +31,16 @@ Ask an MCP client:
 
 The tool returns a `task_id` immediately. Query that ID until `status` is `succeeded` or `failed`. Successful tasks expose videos in `response.data.variants`.
 
+## Production SKUs
+
+| SKU | Price | Duration | Output | Languages | Capabilities |
+|---|---:|---:|---|---:|---|
+| `lite` | 0.20 Credits/second | 5–30s | 720p/24fps | 1 | auto/narrated/captions; generate/edit |
+| `standard` | 0.60 Credits/second | 5–120s | 1080p/30fps | 2 | adds avatar and remix |
+| `pro` | 1.20 Credits/second | 5–300s | 1080p/30fps | 4 | adds drama and extend |
+
+Successful tasks are billed from the delivered integer-second duration; there is no 30-second minimum. Avatar uses a 1.15× scenario multiplier, drama uses 1.35×, and each additional delivered language adds 6 Credits. Failed tasks and task polling are free.
+
 To revise an existing result, call `maestro_create_video` with an iteration action and the prior task ID:
 
 ```json

--- a/maestro/tests/test_tools.py
+++ b/maestro/tests/test_tools.py
@@ -68,6 +68,25 @@ async def test_iteration_does_not_clobber_source_format() -> None:
     )
 
 
+async def test_sku_limits_fail_before_api_call() -> None:
+    with patch("tools.video_tools.client.create_video", new_callable=AsyncMock) as create:
+        create.return_value = {"success": True, "task_id": "task-pro"}
+        assert "at most 30 seconds" in await maestro_create_video(
+            prompt="x", quality="lite", duration=31
+        )
+        assert "higher Maestro SKU" in await maestro_create_video(
+            prompt="x", quality="standard", scenario="drama"
+        )
+        assert "higher Maestro SKU" in await maestro_create_video(
+            prompt="x", quality="standard", action="extend", ref_task_id="task-1"
+        )
+        await maestro_create_video(
+            prompt="x", quality="pro", action="extend", ref_task_id="task-1", duration=300
+        )
+
+    create.assert_awaited_once()
+
+
 async def test_task_tools_delegate_to_client() -> None:
     with patch("tools.task_tools.client.get_task", new_callable=AsyncMock) as get_task:
         get_task.return_value = {"id": "task-1", "status": "succeeded"}

--- a/maestro/tools/video_tools.py
+++ b/maestro/tools/video_tools.py
@@ -1,6 +1,6 @@
 """Maestro video creation tools."""
 
-from typing import Annotated, Any
+from typing import Annotated, Any, TypedDict
 
 from pydantic import Field
 
@@ -15,6 +15,35 @@ from core.types import (
     MaestroVoice,
 )
 from core.utils import format_submission_result
+
+
+class SkuLimits(TypedDict):
+    duration: int
+    languages: int
+    actions: set[str]
+    scenarios: set[str]
+
+
+SKU_LIMITS: dict[str, SkuLimits] = {
+    "lite": {
+        "duration": 30,
+        "languages": 1,
+        "actions": {"generate", "edit"},
+        "scenarios": {"auto", "narrated", "captions"},
+    },
+    "standard": {
+        "duration": 120,
+        "languages": 2,
+        "actions": {"generate", "remix", "edit"},
+        "scenarios": {"auto", "narrated", "captions", "avatar"},
+    },
+    "pro": {
+        "duration": 300,
+        "languages": 4,
+        "actions": {"generate", "remix", "edit", "extend"},
+        "scenarios": {"auto", "narrated", "captions", "avatar", "drama"},
+    },
+}
 
 
 @mcp.tool()
@@ -121,6 +150,17 @@ async def maestro_create_video(
     """
     if action != "generate" and not ref_task_id:
         return f"Error: action={action} requires ref_task_id."
+
+    sku = quality or "standard"
+    limits = SKU_LIMITS[sku]
+    if duration is not None and duration > limits["duration"]:
+        return f"Error: {sku} supports at most {limits['duration']} seconds."
+    if langs and len(langs) > limits["languages"]:
+        return f"Error: {sku} supports at most {limits['languages']} language(s)."
+    if action not in limits["actions"]:
+        return f"Error: action={action} requires a higher Maestro SKU."
+    if scenario is not None and scenario not in limits["scenarios"]:
+        return f"Error: scenario={scenario} requires a higher Maestro SKU."
 
     # Only send fields the caller set. Omitting them lets the server apply its
     # documented default on a fresh generate and inherit the source task's


### PR DESCRIPTION
## Contract
Align Maestro MCP with the live Lite / Standard / Pro API contract, including conditional duration, language, scenario, and action limits.

- actual delivered integer-second billing; no 30-second minimum
- Lite 0.20 Cr/s, Standard 0.60 Cr/s, Pro 1.20 Cr/s
- no runtime/provider changes

## Validation
- ruff passed
- mypy passed
- pytest: 34 passed

Depends only on the already-live core Maestro contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)