### PR TITLE
fix(openai): restore audio transcription multipart requests

### DIFF
--- a/openai/core/client.py
+++ b/openai/core/client.py
@@ -326,18 +326,16 @@ class OpenAIClient:
         logger.info(f"POST {url} (multipart/form-data)")
         logger.debug(f"Timeout: {request_timeout}s")
 
-        # Build httpx multipart files / data dicts
         files: list[tuple[str, Any]] = []
-        data: list[tuple[str, str]] = []
+        data: dict[str, str] = {}
         for key, value in fields.items():
             if isinstance(value, bytes):
                 files.append((key, ("audio", value, "application/octet-stream")))
             elif isinstance(value, list):
-                # Array fields use bracket notation (e.g. timestamp_granularities[])
                 for item in value:
-                    data.append((f"{key}[]", str(item)))
+                    files.append((f"{key}[]", (None, str(item))))
             else:
-                data.append((key, str(value)))
+                data[key] = str(value)
 
         # The auth header must NOT include content-type — httpx sets it for multipart
         token = get_request_api_token() or self.api_token
@@ -350,11 +348,10 @@ class OpenAIClient:
 
         async with httpx.AsyncClient() as http_client:
             try:
-                # A tuple list preserves repeated multipart field names; httpx accepts it at runtime.
                 response = await http_client.post(
                     url,
                     files=files if files else None,
-                    data=data,  # type: ignore[arg-type]
+                    data=data,
                     headers=headers,
                     timeout=request_timeout,
                 )

--- a/openai/tests/test_client.py
+++ b/openai/tests/test_client.py
@@ -168,34 +168,39 @@ class TestOpenAIClient:
             assert "/openai/images/generations" in call_args[0][0]
 
     @pytest.mark.asyncio
-    async def test_request_multipart_preserves_all_list_items(self, client):
-        """Multipart list fields must be sent as repeated bracketed form entries."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.headers = {"content-type": "application/json"}
-        mock_response.json.return_value = {"text": "ok"}
+    async def test_request_multipart_sends_async_stream_with_repeated_fields(
+        self, client, monkeypatch
+    ):
+        """Multipart fields must use an async-compatible httpx request body."""
+        captured_body = b""
 
-        with patch("httpx.AsyncClient") as mock_http:
-            mock_instance = AsyncMock()
-            mock_instance.post.return_value = mock_response
-            mock_http.return_value.__aenter__.return_value = mock_instance
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_body
+            captured_body = await request.aread()
+            return httpx.Response(200, json={"text": "ok"})
 
-            await client.request_multipart(
-                "/v1/audio/transcriptions",
-                {
-                    "file": b"audio-bytes",
-                    "timestamp_granularities": ["word", "segment"],
-                    "languages": ["en", "fr"],
-                    "keywords": ["AceDataCloud", "MCP"],
-                },
-            )
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
 
-            call_kwargs = mock_instance.post.call_args.kwargs
-            assert call_kwargs["data"] == [
-                ("timestamp_granularities[]", "word"),
-                ("timestamp_granularities[]", "segment"),
-                ("languages[]", "en"),
-                ("languages[]", "fr"),
-                ("keywords[]", "AceDataCloud"),
-                ("keywords[]", "MCP"),
-            ]
+        def make_client(*_args, **_kwargs):
+            return real_async_client(transport=transport)
+
+        monkeypatch.setattr(httpx, "AsyncClient", make_client)
+
+        result = await client.request_multipart(
+            "/v1/audio/transcriptions",
+            {
+                "file": b"audio-bytes",
+                "model": "whisper-1",
+                "timestamp_granularities": ["word", "segment"],
+                "languages": ["en", "fr"],
+            },
+        )
+
+        assert result == {"text": "ok"}
+        assert b'name="file"' in captured_body
+        assert b"audio-bytes" in captured_body
+        assert b'name="model"' in captured_body
+        assert b"whisper-1" in captured_body
+        assert captured_body.count(b'name="timestamp_granularities[]"') == 2
+        assert captured_body.count(b'name="languages[]"') == 2


### PR DESCRIPTION
## Summary
- encode scalar multipart fields as an async-compatible mapping
- encode repeated array fields as multipart form parts without passing a synchronous tuple stream to `httpx.AsyncClient`
- replace the over-mocked unit test with a real `httpx.MockTransport` regression test

## Production evidence
The Studio OpenAI MCP tool failed before sending the transcription request with:

```text
Attempted to send an sync request with an AsyncClient instance.
```

The issue reproduced locally with the previous `data=list[tuple]` request shape. Both the original 34.9 MB recording and two valid sub-10 MB/sub-6 MB segments failed identically, ruling out file size, format, and URL access.

## Verification
- `python3 -m pytest -q` (56 passed)
- `python3 -m pytest tests/test_client.py tests/test_audio_tools.py -q` (27 passed)
- `python3 -m ruff check core/client.py tests/test_client.py`
- `python3 -m ruff format --check core/client.py tests/test_client.py`
- `python3 -m mypy core/client.py`

## Post-deploy
Re-run `openai_transcribe_audio` against one of the prepared audio segments and confirm the request reaches `/v1/audio/transcriptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)