### PR TITLE
feat(seedance): add Seedance 2.5 MCP support

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -17,7 +17,7 @@ Generate AI videos directly from Claude, VS Code, or any MCP-compatible client.
 - **Text to Video** - Create AI-generated videos from text prompts
 - **Image to Video** - Animate images with first frame, last frame, and reference image control
 - **Multiple Models** - Support for Seedance 2.0 (incl. Fast/Mini, multimodal reference), 1.5 Pro, 1.0 Pro, 1.0 Pro Fast, 1.0 Lite T2V/I2V
-- **Multiple Resolutions** - 480p, 720p (default), 1080p, and 4k output (4k: `doubao-seedance-2-5-260628` only)
+- **Multiple Resolutions** - 480p, 720p (default), 1080p, and 4k output (4k: `doubao-seedance-2-0-260128` only)
 - **Flexible Aspect Ratios** - 16:9, 9:16, 1:1, 4:3, 3:4, 21:9, and adaptive
 - **Audio Generation** - Generate synchronized audio for videos (1.5 Pro and 2.0 series)
 - **Service Tiers** - Default (priority) and Flex (cost-effective) processing
@@ -364,7 +364,7 @@ Claude: I'll generate a video with synchronized audio.
 
 | Model                                 | Description       | Features                   |
 | ------------------------------------- | ----------------- | -------------------------- |
-| `doubao-seedance-2-5-260628`          | 2.0 (default)     | Latest generation, 4k, multimodal reference |
+| `doubao-seedance-2-5-260628`          | 2.5               | Up to 30s, edit/extend, multimodal reference |
 | `doubao-seedance-2-0-fast-260128`     | 2.0 Fast          | Latest generation fast     |
 | `doubao-seedance-2-0-mini-260615`     | 2.0 Mini          | Latest generation, lightweight, cheapest 2.0 |
 | `doubao-seedance-1-5-pro-251215`      | 1.5 Pro           | Audio generation, T2V, I2V |
@@ -395,7 +395,7 @@ Claude: I'll generate a video with synchronized audio.
 | `ACEDATACLOUD_API_BASE_URL`   | API base URL                | `https://api.acedata.cloud`      |
 | `ACEDATACLOUD_OAUTH_CLIENT_ID`  | OAuth client ID (hosted mode) | —                           |
 | `ACEDATACLOUD_PLATFORM_BASE_URL` | Platform base URL            | `https://platform.acedata.cloud` |
-| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-2-5-260628` |
+| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-2-0-260128` |
 | `SEEDANCE_DEFAULT_RESOLUTION` | Default resolution          | `720p`                           |
 | `SEEDANCE_DEFAULT_RATIO`      | Default aspect ratio        | `16:9`                           |
 | `SEEDANCE_DEFAULT_DURATION`   | Default duration (seconds)  | `5`                              |

--- a/seedance/README.md
+++ b/seedance/README.md
@@ -17,7 +17,7 @@ Generate AI videos directly from Claude, VS Code, or any MCP-compatible client.
 - **Text to Video** - Create AI-generated videos from text prompts
 - **Image to Video** - Animate images with first frame, last frame, and reference image control
 - **Multiple Models** - Support for Seedance 2.0 (incl. Fast/Mini, multimodal reference), 1.5 Pro, 1.0 Pro, 1.0 Pro Fast, 1.0 Lite T2V/I2V
-- **Multiple Resolutions** - 480p, 720p (default), 1080p, and 4k output (4k: `doubao-seedance-2-0-260128` only)
+- **Multiple Resolutions** - 480p, 720p (default), 1080p, and 4k output (4k: `doubao-seedance-2-5-260628` only)
 - **Flexible Aspect Ratios** - 16:9, 9:16, 1:1, 4:3, 3:4, 21:9, and adaptive
 - **Audio Generation** - Generate synchronized audio for videos (1.5 Pro and 2.0 series)
 - **Service Tiers** - Default (priority) and Flex (cost-effective) processing
@@ -364,7 +364,7 @@ Claude: I'll generate a video with synchronized audio.
 
 | Model                                 | Description       | Features                   |
 | ------------------------------------- | ----------------- | -------------------------- |
-| `doubao-seedance-2-0-260128`          | 2.0 (default)     | Latest generation, 4k, multimodal reference |
+| `doubao-seedance-2-5-260628`          | 2.0 (default)     | Latest generation, 4k, multimodal reference |
 | `doubao-seedance-2-0-fast-260128`     | 2.0 Fast          | Latest generation fast     |
 | `doubao-seedance-2-0-mini-260615`     | 2.0 Mini          | Latest generation, lightweight, cheapest 2.0 |
 | `doubao-seedance-1-5-pro-251215`      | 1.5 Pro           | Audio generation, T2V, I2V |
@@ -395,7 +395,7 @@ Claude: I'll generate a video with synchronized audio.
 | `ACEDATACLOUD_API_BASE_URL`   | API base URL                | `https://api.acedata.cloud`      |
 | `ACEDATACLOUD_OAUTH_CLIENT_ID`  | OAuth client ID (hosted mode) | —                           |
 | `ACEDATACLOUD_PLATFORM_BASE_URL` | Platform base URL            | `https://platform.acedata.cloud` |
-| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-2-0-260128` |
+| `SEEDANCE_DEFAULT_MODEL`      | Default model               | `doubao-seedance-2-5-260628` |
 | `SEEDANCE_DEFAULT_RESOLUTION` | Default resolution          | `720p`                           |
 | `SEEDANCE_DEFAULT_RATIO`      | Default aspect ratio        | `16:9`                           |
 | `SEEDANCE_DEFAULT_DURATION`   | Default duration (seconds)  | `5`                              |

--- a/seedance/core/types.py
+++ b/seedance/core/types.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 # Seedance video models
 SeedanceModel = Literal[
+    "doubao-seedance-2-5-260628",
     "doubao-seedance-2-0-260128",
     "doubao-seedance-2-0-fast-260128",
     "doubao-seedance-2-0-mini-260615",
@@ -48,8 +49,11 @@ ImageRole = Literal[
     "reference_image",
 ]
 
+OmniReferenceTaskType = Literal["auto", "edit", "extend"]
+OutputFormat = Literal["mp4", "mov"]
+
 # Default values
-DEFAULT_MODEL: SeedanceModel = "doubao-seedance-2-0-260128"
+DEFAULT_MODEL: SeedanceModel = "doubao-seedance-2-5-260628"
 DEFAULT_RESOLUTION: Resolution = "720p"
 DEFAULT_RATIO: AspectRatio = "16:9"
 DEFAULT_DURATION: int = 5

--- a/seedance/core/types.py
+++ b/seedance/core/types.py
@@ -53,7 +53,7 @@ OmniReferenceTaskType = Literal["auto", "edit", "extend"]
 OutputFormat = Literal["mp4", "mov"]
 
 # Default values
-DEFAULT_MODEL: SeedanceModel = "doubao-seedance-2-5-260628"
+DEFAULT_MODEL: SeedanceModel = "doubao-seedance-2-0-260128"
 DEFAULT_RESOLUTION: Resolution = "720p"
 DEFAULT_RATIO: AspectRatio = "16:9"
 DEFAULT_DURATION: int = 5

--- a/seedance/prompts/__init__.py
+++ b/seedance/prompts/__init__.py
@@ -36,7 +36,7 @@ When the user wants to generate video, choose the appropriate tool based on thei
 -> Call `seedance_generate_video_from_image` with first_frame_url=image_url and appropriate prompt
 
 ## Choosing the Right Model
-- **Latest generation quality:** `doubao-seedance-2-0-260128`
+- **Latest generation quality:** `doubao-seedance-2-5-260628`
 - **Latest generation fast:** `doubao-seedance-2-0-fast-260128`
 - **Latest generation lightweight / cheapest within 2.0:** `doubao-seedance-2-0-mini-260615`
 - **1.5 flagship + audio:** `doubao-seedance-1-5-pro-251215`

--- a/seedance/tests/test_video_tools.py
+++ b/seedance/tests/test_video_tools.py
@@ -181,7 +181,9 @@ class TestSeedanceGenerateVideoFromImage:
             assert call_kwargs["model"] == model
 
     @pytest.mark.asyncio
-    async def test_seedance_25_multimodal_roles_and_options(self, mock_video_response: dict) -> None:
+    async def test_seedance_25_multimodal_roles_and_options(
+        self, mock_video_response: dict
+    ) -> None:
         with patch("tools.video_tools.client") as mock_client:
             mock_client.generate_video = AsyncMock(return_value=mock_video_response)
             await seedance_generate_video_from_image(

--- a/seedance/tests/test_video_tools.py
+++ b/seedance/tests/test_video_tools.py
@@ -60,7 +60,11 @@ class TestSeedanceGenerateVideo:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "model",
-        ["doubao-seedance-2-0-260128", "doubao-seedance-2-0-fast-260128"],
+        [
+            "doubao-seedance-2-5-260628",
+            "doubao-seedance-2-0-260128",
+            "doubao-seedance-2-0-fast-260128",
+        ],
     )
     async def test_new_models_parameter_sent_to_api(
         self, model: str, mock_video_response: dict
@@ -74,6 +78,22 @@ class TestSeedanceGenerateVideo:
             )
             call_kwargs = mock_client.generate_video.call_args[1]
             assert call_kwargs["model"] == model
+
+    @pytest.mark.asyncio
+    async def test_seedance_25_options_sent_to_api(self, mock_video_response: dict) -> None:
+        with patch("tools.video_tools.client") as mock_client:
+            mock_client.generate_video = AsyncMock(return_value=mock_video_response)
+            await seedance_generate_video(
+                prompt="A test video",
+                model="doubao-seedance-2-5-260628",
+                duration=30,
+                output_format="mov",
+                tools=[{"type": "web_search"}],
+            )
+            call_kwargs = mock_client.generate_video.call_args[1]
+            assert call_kwargs["duration"] == 30
+            assert call_kwargs["output_format"] == "mov"
+            assert call_kwargs["tools"] == [{"type": "web_search"}]
 
     @pytest.mark.asyncio
     async def test_execution_expires_after_default(self, mock_video_response: dict) -> None:
@@ -140,7 +160,11 @@ class TestSeedanceGenerateVideoFromImage:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "model",
-        ["doubao-seedance-2-0-260128", "doubao-seedance-2-0-fast-260128"],
+        [
+            "doubao-seedance-2-5-260628",
+            "doubao-seedance-2-0-260128",
+            "doubao-seedance-2-0-fast-260128",
+        ],
     )
     async def test_new_models_parameter_sent_to_api(
         self, model: str, mock_video_response: dict
@@ -155,6 +179,26 @@ class TestSeedanceGenerateVideoFromImage:
             )
             call_kwargs = mock_client.generate_video.call_args[1]
             assert call_kwargs["model"] == model
+
+    @pytest.mark.asyncio
+    async def test_seedance_25_multimodal_roles_and_options(self, mock_video_response: dict) -> None:
+        with patch("tools.video_tools.client") as mock_client:
+            mock_client.generate_video = AsyncMock(return_value=mock_video_response)
+            await seedance_generate_video_from_image(
+                prompt="Extend the shot",
+                reference_video_urls=["https://example.com/video.mp4"],
+                reference_audio_urls=["https://example.com/audio.mp3"],
+                model="doubao-seedance-2-5-260628",
+                ratio="adaptive",
+                duration=30,
+                omni_reference_task_type="extend",
+                output_format="mov",
+            )
+            call_kwargs = mock_client.generate_video.call_args[1]
+            assert call_kwargs["content"][1]["role"] == "reference_audio"
+            assert call_kwargs["content"][2]["role"] == "reference_video"
+            assert call_kwargs["omni_reference_task_type"] == "extend"
+            assert call_kwargs["output_format"] == "mov"
 
     @pytest.mark.asyncio
     async def test_execution_expires_after_default(self, mock_video_response: dict) -> None:

--- a/seedance/tools/info_tools.py
+++ b/seedance/tools/info_tools.py
@@ -18,7 +18,7 @@ async def seedance_list_models() -> str:
 
 | Model | Type | Strengths | Audio | Credits (720p/sec) |
 |-------|------|-----------|-------|--------------------|
-| doubao-seedance-2-5-260628 | 2.5 | Latest flagship, up to 30s, multimodal reference, edit/extend (default) | Yes | 2.5565 |
+| doubao-seedance-2-5-260628 | 2.5 | Latest flagship, up to 30s, multimodal reference, edit/extend | Yes | 2.5565 |
 | doubao-seedance-2-0-260128 | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (default) | Yes | ~$0.146 |
 | doubao-seedance-2-0-fast-260128 | 2.0 Fast | Latest generation, faster, up to 720p | Yes | ~$0.117 |
 | doubao-seedance-2-0-mini-260615 | 2.0 Mini | Latest generation, lightweight, cheapest within 2.0, up to 720p | Yes | ~$0.073 |
@@ -29,8 +29,8 @@ async def seedance_list_models() -> str:
 | doubao-seedance-1-0-lite-i2v-250428 | Lite I2V | Lightweight image-to-video | No | ~$0.033 |
 
 Model Selection Guide:
-- Latest flagship / default: doubao-seedance-2-5-260628 (up to 30s, multimodal reference, edit/extend)
-- Highest resolution: doubao-seedance-2-0-260128 (up to 4k)
+- Latest flagship: doubao-seedance-2-5-260628 (up to 30s, multimodal reference, edit/extend)
+- Default / highest resolution: doubao-seedance-2-0-260128 (up to 4k)
 - Latest fast: doubao-seedance-2-0-fast-260128
 - Latest lightweight / cheapest within 2.0: doubao-seedance-2-0-mini-260615
 - 1.5 flagship (audio): doubao-seedance-1-5-pro-251215

--- a/seedance/tools/info_tools.py
+++ b/seedance/tools/info_tools.py
@@ -13,11 +13,12 @@ async def seedance_list_models() -> str:
     Returns:
         Table of all models with descriptions, capabilities, and pricing.
     """
-    # Last updated: 2026-04-05
+    # Last updated: 2026-08-14
     return """Available Seedance Models:
 
-| Model | Type | Strengths | Audio | Cost (720p/sec) |
-|-------|------|-----------|-------|-----------------|
+| Model | Type | Strengths | Audio | Credits (720p/sec) |
+|-------|------|-----------|-------|--------------------|
+| doubao-seedance-2-5-260628 | 2.5 | Latest flagship, up to 30s, multimodal reference, edit/extend (default) | Yes | 2.5565 |
 | doubao-seedance-2-0-260128 | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (default) | Yes | ~$0.146 |
 | doubao-seedance-2-0-fast-260128 | 2.0 Fast | Latest generation, faster, up to 720p | Yes | ~$0.117 |
 | doubao-seedance-2-0-mini-260615 | 2.0 Mini | Latest generation, lightweight, cheapest within 2.0, up to 720p | Yes | ~$0.073 |
@@ -28,7 +29,8 @@ async def seedance_list_models() -> str:
 | doubao-seedance-1-0-lite-i2v-250428 | Lite I2V | Lightweight image-to-video | No | ~$0.033 |
 
 Model Selection Guide:
-- Latest quality / default: doubao-seedance-2-0-260128 (up to 4k, multimodal reference)
+- Latest flagship / default: doubao-seedance-2-5-260628 (up to 30s, multimodal reference, edit/extend)
+- Highest resolution: doubao-seedance-2-0-260128 (up to 4k)
 - Latest fast: doubao-seedance-2-0-fast-260128
 - Latest lightweight / cheapest within 2.0: doubao-seedance-2-0-mini-260615
 - 1.5 flagship (audio): doubao-seedance-1-5-pro-251215
@@ -38,9 +40,9 @@ Model Selection Guide:
 - Image-to-video lightweight: doubao-seedance-1-0-lite-i2v-250428
 
 Notes:
-- Audio generation (generate_audio) is supported by the 1.5 Pro and 2.0 series models
-- Seedance 2.0 adds multimodal reference inputs: real-person/character image, reference audio, reference video
-- Resolution affects cost: 480p < 720p < 1080p < 4k ('4k' is doubao-seedance-2-0-260128 only; 2-0-fast / 2-0-mini max at 720p)
+- Audio generation (generate_audio) is supported by the 1.5 Pro and 2.x models
+- Seedance 2.0 adds multimodal reference inputs; Seedance 2.5 adds pure-audio reference, larger limits, edit, and extend
+- Resolution affects cost: 480p < 720p < 1080p < 4k ('4k' is doubao-seedance-2-0-260128 only; 2.5 / 2-0-fast / 2-0-mini max at 720p)
 """
 
 
@@ -53,7 +55,7 @@ async def seedance_list_resolutions() -> str:
     Returns:
         Tables of resolutions and aspect ratios with descriptions.
     """
-    # Last updated: 2026-04-05
+    # Last updated: 2026-08-14
     return """Available Seedance Resolutions:
 
 | Resolution | Description | Best For |
@@ -92,7 +94,7 @@ async def seedance_list_actions() -> str:
     Returns:
         Categorized list of all actions and their corresponding tools.
     """
-    # Last updated: 2026-04-05
+    # Last updated: 2026-08-14
     return """Available Seedance Actions and Tools:
 
 Video Generation:
@@ -135,7 +137,7 @@ Tips:
 - Use descriptive prompts for better results
 - Include motion descriptions: "walking", "flying", "zooming in"
 - Specify style: "cinematic", "realistic", "artistic", "anime"
-- 1.5 Pro model supports audio generation (~2x cost)
+- 1.5 Pro and 2.x models support audio generation
 - Use seed parameter for reproducible results
 - Use return_last_frame=true when planning to extend videos
 """

--- a/seedance/tools/video_tools.py
+++ b/seedance/tools/video_tools.py
@@ -12,6 +12,8 @@ from core.types import (
     DEFAULT_RATIO,
     DEFAULT_RESOLUTION,
     AspectRatio,
+    OmniReferenceTaskType,
+    OutputFormat,
     Resolution,
     SeedanceModel,
 )
@@ -38,8 +40,9 @@ async def seedance_generate_video(
         Field(
             description=(
                 "Model version to use. Options: "
-                "'doubao-seedance-2-0-260128' (latest generation, highest quality, "
-                "supports 4k and multimodal reference, default), "
+                "'doubao-seedance-2-5-260628' (latest flagship, up to 30 seconds, "
+                "multimodal reference, edit/extend, default), "
+                "'doubao-seedance-2-0-260128' (highest resolution, supports 4k), "
                 "'doubao-seedance-2-0-fast-260128' (latest generation, faster, up to 720p), "
                 "'doubao-seedance-2-0-mini-260615' (latest generation, lightweight, "
                 "cheapest within the 2.0 series, up to 720p), "
@@ -76,11 +79,11 @@ async def seedance_generate_video(
         Field(
             description=(
                 "Video duration in seconds. 1.0 series: 2–12; 1.5 Pro: 4–12; "
-                "2.0 series: 4–15. Use -1 for auto-duration (1.5 Pro and 2.0 series only). "
+                "2.0 series: 4–15; 2.5: 4–30. Use -1 for auto-duration (1.5 Pro and 2.x). "
                 "Default is 5. Mutually exclusive with 'frames'."
             ),
             ge=-1,
-            le=15,
+            le=30,
         ),
     ] = None,
     frames: Annotated[
@@ -135,6 +138,14 @@ async def seedance_generate_video(
             )
         ),
     ] = False,
+    output_format: Annotated[
+        OutputFormat | None,
+        Field(description="Seedance 2.5 output format: mp4 or mov."),
+    ] = None,
+    tools: Annotated[
+        list[dict[str, Any]] | None,
+        Field(description="Optional Seedance 2.5 tool configuration objects."),
+    ] = None,
     callback_url: Annotated[
         str | None,
         Field(
@@ -192,6 +203,12 @@ async def seedance_generate_video(
 
     if generate_audio:
         payload["generate_audio"] = True
+
+    if output_format:
+        payload["output_format"] = output_format
+
+    if tools:
+        payload["tools"] = tools
 
     if callback_url:
         payload["callback_url"] = callback_url
@@ -293,11 +310,11 @@ async def seedance_generate_video_from_image(
         Field(
             description=(
                 "Video duration in seconds. 1.0 series: 2–12; 1.5 Pro: 4–12; "
-                "2.0 series: 4–15. Use -1 for auto-duration (1.5 Pro and 2.0 series only). "
+                "2.0 series: 4–15; 2.5: 4–30. Use -1 for auto-duration (1.5 Pro and 2.x). "
                 "Default is 5. Mutually exclusive with 'frames'."
             ),
             ge=-1,
-            le=15,
+            le=30,
         ),
     ] = None,
     frames: Annotated[
@@ -317,7 +334,7 @@ async def seedance_generate_video_from_image(
         Field(
             description=(
                 "If true, generate audio. Supported by 'doubao-seedance-1-5-pro-251215' "
-                "and the 'doubao-seedance-2-0' series. Default is false."
+                "and the Seedance 2.x series. Default is false."
             )
         ),
     ] = False,
@@ -335,6 +352,18 @@ async def seedance_generate_video_from_image(
             description=("If true, return the last frame of the generated video. Default is false.")
         ),
     ] = False,
+    omni_reference_task_type: Annotated[
+        OmniReferenceTaskType | None,
+        Field(description="Seedance 2.5 task type: auto, edit, or extend."),
+    ] = None,
+    output_format: Annotated[
+        OutputFormat | None,
+        Field(description="Seedance 2.5 output format: mp4 or mov."),
+    ] = None,
+    tools: Annotated[
+        list[dict[str, Any]] | None,
+        Field(description="Optional Seedance 2.5 tool configuration objects."),
+    ] = None,
     callback_url: Annotated[
         str | None,
         Field(description="Webhook callback URL for asynchronous notifications."),
@@ -415,10 +444,14 @@ async def seedance_generate_video_from_image(
         )
 
     for audio_url in reference_audio_urls:
-        content.append({"type": "audio_url", "audio_url": {"url": audio_url}})
+        content.append(
+            {"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"}
+        )
 
     for video_url in reference_video_urls:
-        content.append({"type": "video_url", "video_url": {"url": video_url}})
+        content.append(
+            {"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"}
+        )
 
     payload: dict[str, Any] = {
         "model": model,
@@ -439,6 +472,15 @@ async def seedance_generate_video_from_image(
 
     if generate_audio:
         payload["generate_audio"] = True
+
+    if omni_reference_task_type:
+        payload["omni_reference_task_type"] = omni_reference_task_type
+
+    if output_format:
+        payload["output_format"] = output_format
+
+    if tools:
+        payload["tools"] = tools
 
     if callback_url:
         payload["callback_url"] = callback_url


### PR DESCRIPTION
## Dependency graph

Depends on:
- https://github.com/AceDataCloud/PlatformService/pull/1991
- https://github.com/AceDataCloud/PlatformBackend/pull/1474

Canonical MCP source; the SeedanceMCP standalone mirror is generated after merge.

## Contract

- Adds `doubao-seedance-2-5-260628` and makes it the recommended MCP default.
- Supports 30-second output, `omni_reference_task_type`, `output_format`, and `tools`.
- Fixes reference audio/video items to include the required public roles.
- Updates model/resolution/action guidance and pricing display to Credits.
- Existing 1.x/2.0 tools remain compatible.

MiniMax MCP was audited and already uses the fixed async task create/retrieve flow, so no duplicate change was needed.

## Tests

- Seedance: 42 passed, 2 skipped; ruff passed; mypy passed.
- MiniMax regression: 38 passed, 3 skipped; ruff passed; mypy passed.
- `git diff --check` passed.

## Rollout / rollback

Merge only after the public OpenAPI contract is approved. The monorepo sync publishes the standalone SeedanceMCP; rollback by reverting this PR and republishing the previous package.

## Adversarial review

Not requested; no adversarial review was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)