### PR TITLE
fix(suno): repair advanced tool contracts

### DIFF
--- a/suno/README.md
+++ b/suno/README.md
@@ -32,16 +32,17 @@ Generate AI music, lyrics, and manage audio projects directly from Claude, VS Co
 | `suno_cover_music` | Create a cover or remix version of an existing song in a different style. |
 | `suno_concat_music` | Concatenate extended song segments into a single complete audio file. |
 | `suno_generate_with_persona` | Generate music using a saved artist persona for consistent vocal style. |
-| `suno_remaster_music` | Remaster an existing song to improve audio quality. |
+| `suno_remaster_music` | Remaster an existing song; v5/v5.5 require a variation category. |
 | `suno_stems_music` | Separate a song into individual stems (vocals and instruments). |
 | `suno_replace_section` | Replace a specific time range in a song with new generated content. |
 | `suno_upload_extend` | Extend an uploaded audio (your own music) with new AI-generated content. |
 | `suno_upload_cover` | Create an AI cover of an uploaded audio (your own music). |
-| `suno_mashup_music` | Create a musical mashup by blending multiple songs together. |
+| `suno_mashup_music` | Blend exactly two songs using a required creative-direction prompt. |
+| `suno_all_stems_music` | Return full stem separation; two same-named 12-stem sets may be returned. |
 | `suno_generate_lyrics` | Generate song lyrics from a text prompt. |
 | `suno_get_mp4` | Get an MP4 video version of a generated song. |
 | `suno_get_timing` | Get timing and subtitle data for a generated song. |
-| `suno_extract_vocals` | Extract the vocal track from a generated song (stem separation). |
+| `suno_extract_vocals` | Extract a required vocal interval shorter than 30 seconds. |
 | `suno_get_wav` | Get the lossless WAV format of a generated song. |
 | `suno_get_midi` | Get MIDI data extracted from a generated song. |
 | `suno_create_persona` | Create a new artist persona from an existing audio's vocal style. |

--- a/suno/core/utils.py
+++ b/suno/core/utils.py
@@ -47,6 +47,7 @@ def _with_task_guidance(
     state = payload.get("state", "")
     response = payload.get("response", {})
     success = response.get("success", False) if isinstance(response, dict) else False
+    response_failed = isinstance(response, dict) and response.get("success") is False
 
     if state == "complete" and success:
         payload["mcp_task_polling"] = {
@@ -60,12 +61,18 @@ def _with_task_guidance(
             "note": "Task is complete. The audio URLs are final and ready to present to the user.",
         }
     else:
-        is_failed = str(state).lower() in {"failed", "error", "cancelled", "canceled"}
+        is_failed = response_failed or str(state).lower() in {
+            "failed",
+            "error",
+            "cancelled",
+            "canceled",
+        }
+        effective_state = state or ("failed" if is_failed else "pending")
         payload["mcp_task_polling"] = {
             "task_id": task_id,
             "poll_tool": poll_tool,
             "batch_poll_tool": batch_poll_tool,
-            "state": state,
+            "state": effective_state,
             "is_complete": False,
             "is_failed": is_failed,
             "should_poll": not is_failed,
@@ -74,13 +81,15 @@ def _with_task_guidance(
             "polling_interval_seconds": 15,
             "max_poll_attempts": 100,
             "next_step": (
-                f'Task is NOT complete yet (state: "{state}"). '
-                f'IMPORTANT: Only state="complete" with success=true means the task is finished. '
-                f"Ignore any intermediate audio_url values — "
-                f"these are streaming previews, NOT final results. "
-                f'Wait 15 seconds, then call {poll_tool}(task_id="{task_id}") again. '
-                f"Media generation typically takes 1-5 minutes. "
-                f"Keep polling for up to 100 attempts. Do NOT stop early."
+                "Task failed. Inspect response.error for details and do not poll again."
+                if is_failed
+                else (
+                    f'Task is NOT complete yet (state: "{effective_state}"). '
+                    f'IMPORTANT: Only state="complete" with success=true means the task is finished. '
+                    f"Ignore any intermediate audio_url values — these are streaming previews, NOT final results. "
+                    f'Wait 15 seconds, then call {poll_tool}(task_id="{task_id}") again. '
+                    f"Media generation typically takes 1-5 minutes. Keep polling for up to 100 attempts."
+                )
             ),
         }
     return payload

--- a/suno/tests/test_audio_tools.py
+++ b/suno/tests/test_audio_tools.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from tools.audio_tools import suno_generate_custom_music, suno_generate_inspo
+from tools.audio_tools import (
+    suno_generate_custom_music,
+    suno_generate_inspo,
+    suno_mashup_music,
+    suno_remaster_music,
+)
 
 
 class TestInspoTool:
@@ -49,6 +54,52 @@ class TestInspoTool:
         assert "audio_weight" not in payload
         assert "style" not in payload
         assert "prompt" not in payload
+
+
+class TestRemasterTool:
+    @pytest.mark.asyncio
+    async def test_remaster_forwards_variation_category(self, mock_audio_response):
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            await suno_remaster_music(
+                audio_id="audio-1",
+                variation_category="subtle",
+                model="chirp-v5-5",
+            )
+
+        assert mock_generate.await_args.kwargs == {
+            "action": "remaster",
+            "audio_id": "audio-1",
+            "variation_category": "subtle",
+            "model": "chirp-v5-5",
+            "callback_url": None,
+        }
+
+
+class TestMashupTool:
+    @pytest.mark.asyncio
+    async def test_mashup_forwards_creative_direction(self, mock_audio_response):
+        with patch(
+            "tools.audio_tools.client.generate_audio",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_generate:
+            await suno_mashup_music(
+                mashup_audio_ids=["audio-1", "audio-2"],
+                prompt="Blend both melodies into one arrangement",
+                style="warm acoustic pop",
+                title="Merged Currents",
+                instrumental=True,
+            )
+
+        payload = mock_generate.await_args.kwargs
+        assert payload["action"] == "mashup"
+        assert payload["mashup_audio_ids"] == ["audio-1", "audio-2"]
+        assert payload["prompt"] == "Blend both melodies into one arrangement"
+        assert payload["style"] == "warm acoustic pop"
+        assert payload["title"] == "Merged Currents"
+        assert payload["instrumental"] is True
 
 
 class TestCustomNegativeTags:

--- a/suno/tests/test_media_tools.py
+++ b/suno/tests/test_media_tools.py
@@ -1,0 +1,37 @@
+"""Unit tests for media tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.media_tools import suno_extract_vocals
+
+
+class TestExtractVocalsTool:
+    @pytest.mark.asyncio
+    async def test_forwards_short_interval(self, mock_audio_response):
+        with patch(
+            "tools.media_tools.client.get_vox",
+            new=AsyncMock(return_value=mock_audio_response),
+        ) as mock_vox:
+            await suno_extract_vocals(
+                audio_id="audio-1",
+                vocal_start=1,
+                vocal_end=20,
+            )
+
+        assert mock_vox.await_args.kwargs == {
+            "audio_id": "audio-1",
+            "vocal_start": 1,
+            "vocal_end": 20,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("start,end", [(20, 20), (20, 10), (0, 30), (1, 31)])
+    async def test_rejects_invalid_or_long_interval(self, start, end):
+        with pytest.raises(ValueError, match="shorter than 30 seconds"):
+            await suno_extract_vocals(
+                audio_id="audio-1",
+                vocal_start=start,
+                vocal_end=end,
+            )

--- a/suno/tests/test_task_tools.py
+++ b/suno/tests/test_task_tools.py
@@ -1,0 +1,54 @@
+"""Unit tests for task tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import suno_get_task, suno_get_tasks_batch
+
+
+class TestGetTaskTool:
+    @pytest.mark.asyncio
+    async def test_failed_response_does_not_sleep(self):
+        task = {
+            "id": "failed-task",
+            "state": "",
+            "response": {
+                "success": False,
+                "error": {"code": "bad_request", "message": "prompt is required"},
+            },
+        }
+        with (
+            patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+            patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            result = await suno_get_task(task_id="failed-task")
+
+        mock_sleep.assert_not_awaited()
+        assert '"state": "failed"' in result
+        assert '"should_poll": false' in result
+
+    @pytest.mark.asyncio
+    async def test_batch_marks_response_error_as_failed(self):
+        response = {
+            "count": 1,
+            "items": [
+                {
+                    "id": "failed-task",
+                    "state": "",
+                    "response": {
+                        "success": False,
+                        "error": {"code": "bad_request", "message": "prompt is required"},
+                    },
+                }
+            ],
+        }
+        with patch(
+            "tools.task_tools.client.query_task",
+            new=AsyncMock(return_value=response),
+        ):
+            result = await suno_get_tasks_batch(task_ids=["failed-task"])
+
+        assert "State: failed" in result
+        assert "bad_request" in result
+        assert "keep polling" not in result

--- a/suno/tests/test_utils.py
+++ b/suno/tests/test_utils.py
@@ -83,6 +83,25 @@ class TestFormatTaskResult:
         data = json.loads(result)
         assert data["error"]["code"] == "not_found"
 
+    def test_response_error_without_state_is_terminal(self):
+        result = format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "prompt is required"},
+                },
+            }
+        )
+        data = json.loads(result)
+        guidance = data["mcp_task_polling"]
+        assert guidance["state"] == "failed"
+        assert guidance["is_failed"] is True
+        assert guidance["should_poll"] is False
+        assert guidance["terminal_state_reached"] is True
+        assert guidance["recommended_action"] == "stop"
+
 
 class TestFormatPersonaResult:
     """Tests for format_persona_result function."""

--- a/suno/tools/audio_tools.py
+++ b/suno/tools/audio_tools.py
@@ -437,10 +437,16 @@ async def suno_remaster_music(
             description="ID of the audio to remaster. This is the 'id' field from a previous generation."
         ),
     ],
+    variation_category: Annotated[
+        VariationCategory,
+        Field(
+            description="Required remaster variation intensity. Use 'high' for maximum variation, 'normal' for balanced, or 'subtle' for minimal changes."
+        ),
+    ],
     model: Annotated[
         SunoModel,
         Field(
-            description="Model version to use for remastering. Newer models produce better results."
+            description="Model version to use for remastering. Supported choices are chirp-v4-5-plus, chirp-v5, and chirp-v5-5."
         ),
     ] = DEFAULT_MODEL,
     callback_url: Annotated[
@@ -464,6 +470,7 @@ async def suno_remaster_music(
     result = await client.generate_audio(
         action="remaster",
         audio_id=audio_id,
+        variation_category=variation_category,
         model=model,
         callback_url=callback_url,
     )
@@ -684,8 +691,30 @@ async def suno_upload_cover(
 async def suno_mashup_music(
     mashup_audio_ids: Annotated[
         list[str],
-        Field(description="List of audio IDs to mashup together. Provide 2 or more song IDs."),
+        Field(
+            min_length=2,
+            max_length=2,
+            description="Exactly two audio IDs to mash up together.",
+        ),
     ],
+    prompt: Annotated[
+        str,
+        Field(
+            description="Required creative direction for blending the tracks, such as the desired arrangement, mood, and balance between sources."
+        ),
+    ],
+    style: Annotated[
+        str,
+        Field(description="Optional target music style for the mashup."),
+    ] = "",
+    title: Annotated[
+        str,
+        Field(description="Optional title for the mashup."),
+    ] = "",
+    instrumental: Annotated[
+        bool,
+        Field(description="If true, generate an instrumental mashup without vocals."),
+    ] = False,
     model: Annotated[
         SunoModel,
         Field(description="Model version to use."),
@@ -708,12 +737,20 @@ async def suno_mashup_music(
     Returns:
         Task ID and the mashup audio information.
     """
-    result = await client.generate_audio(
-        action="mashup",
-        mashup_audio_ids=mashup_audio_ids,
-        model=model,
-        callback_url=callback_url,
-    )
+    payload: dict[str, Any] = {
+        "action": "mashup",
+        "mashup_audio_ids": mashup_audio_ids,
+        "prompt": prompt,
+        "instrumental": instrumental,
+        "model": model,
+        "callback_url": callback_url,
+    }
+    if style:
+        payload["style"] = style
+    if title:
+        payload["title"] = title
+
+    result = await client.generate_audio(**payload)
     return format_audio_result(result)
 
 
@@ -731,7 +768,9 @@ async def suno_all_stems_music(
     """Separate a song into all individual stems (vocals, bass, drums, other instruments).
 
     Splits the audio into multiple separate tracks for all components,
-    providing more granular stem separation than suno_stems_music.
+    providing more granular stem separation than suno_stems_music. The service may
+    return two same-named sets of 12 stems without metadata that distinguishes the sets;
+    both sets are preserved so no audio is silently discarded.
 
     Use this when:
     - You need full multi-track stem separation

--- a/suno/tools/media_tools.py
+++ b/suno/tools/media_tools.py
@@ -67,13 +67,19 @@ async def suno_extract_vocals(
         Field(description="The song ID to extract vocals from."),
     ],
     vocal_start: Annotated[
-        float | None,
-        Field(description="Start time in seconds for the vocal extraction range."),
-    ] = None,
+        float,
+        Field(
+            ge=0,
+            description="Required extraction start time in seconds. The selected range must be shorter than 30 seconds.",
+        ),
+    ],
     vocal_end: Annotated[
-        float | None,
-        Field(description="End time in seconds for the vocal extraction range."),
-    ] = None,
+        float,
+        Field(
+            gt=0,
+            description="Required extraction end time in seconds. It must be greater than vocal_start, with a range shorter than 30 seconds.",
+        ),
+    ],
     callback_url: Annotated[
         str | None,
         Field(description="Webhook callback URL for asynchronous notifications."),
@@ -92,11 +98,16 @@ async def suno_extract_vocals(
     Returns:
         Task ID and extracted vocal audio information.
     """
-    payload: dict = {"audio_id": audio_id}
-    if vocal_start is not None:
-        payload["vocal_start"] = vocal_start
-    if vocal_end is not None:
-        payload["vocal_end"] = vocal_end
+    if vocal_start >= vocal_end or vocal_end - vocal_start >= 30:
+        raise ValueError(
+            "vocal_end must be greater than vocal_start and the range must be shorter than 30 seconds"
+        )
+
+    payload: dict = {
+        "audio_id": audio_id,
+        "vocal_start": vocal_start,
+        "vocal_end": vocal_end,
+    }
     if callback_url:
         payload["callback_url"] = callback_url
 

--- a/suno/tools/task_tools.py
+++ b/suno/tools/task_tools.py
@@ -52,7 +52,13 @@ async def suno_get_task(
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
     is_complete = response.get("success", False)
-    if not is_complete:
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 
@@ -94,12 +100,19 @@ async def suno_get_tasks_batch(
 
     for item in result.get("items", []):
         response_info = item.get("response", {})
-        state = item.get("state", "unknown")
+        state = item.get("state", "")
         success = response_info.get("success", False)
+        is_failed = response_info.get("success") is False or str(state).lower() in {
+            "failed",
+            "error",
+            "cancelled",
+            "canceled",
+        }
+        effective_state = state or ("failed" if is_failed else "pending")
         lines.extend(
             [
                 f"=== Task: {item.get('id', 'N/A')} ===",
-                f"State: {state}",
+                f"State: {effective_state}",
                 f"Created At: {item.get('created_at', 'N/A')}",
                 f"Success: {success}",
             ]
@@ -110,11 +123,11 @@ async def suno_get_tasks_batch(
                 lines.append(
                     f"  - {audio.get('title', 'Untitled')}: {audio.get('audio_url', 'N/A')}"
                 )
-        elif state == "failed":
+        elif is_failed:
             lines.append(f"  Error: {response_info.get('error', 'Unknown error')}")
         else:
             lines.append(
-                f"  ⏳ Still {state} — keep polling. Any audio_url values are intermediate previews."
+                f"  ⏳ Still {effective_state} — keep polling. Any audio_url values are intermediate previews."
             )
 
         lines.append("")


### PR DESCRIPTION
## Summary

- require and forward creative direction for `suno_mashup_music`
- expose required remaster variation category and correct vocal extraction interval contract
- stop polling terminal failures when the API omits top-level task state
- document duplicate all-stems sets without discarding results

## Live verification

- Reproduced issue #83 from its stored task: missing prompt fails with `gpt_description_prompt is required`
- Verified a prompted mashup succeeds in production: trace `62e260ca-caf1-42c3-8851-32ca5b0ff935`, task `fd2679d9-40b6-46ea-9861-e0eab624433a`
- Verified short vocal and remaster-with-variation payloads pass action validation; the reporter's old audio ID is no longer visible to the selected route, so those requests then fail with asset-not-found errors
- Confirmed issue #84 all-stems task returns two same-named 12-stem sets and charges 2.2 Credits; the API exposes no discriminator, so the MCP preserves all 24 results

## Tests

- `python -m pytest --cov=core --cov=tools --cov-report=term-missing` (46 passed, 7 skipped)
- `ruff check .`
- generated MCP schemas inspected for required fields and list bounds

Closes https://github.com/AceDataCloud/SunoMCP/issues/83
Closes https://github.com/AceDataCloud/SunoMCP/issues/84

🤖 Generated with [Claude Code](https://claude.com/claude-code)