### PR TITLE
fix: stop polling failed async MCP tasks

### DIFF
--- a/flux/core/utils.py
+++ b/flux/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/flux/tests/test_terminal_state_contract.py
+++ b/flux/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import flux_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await flux_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/flux/tools/task_tools.py
+++ b/flux/tools/task_tools.py
@@ -42,8 +42,14 @@ async def flux_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/grok/core/utils.py
+++ b/grok/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/grok/tests/test_terminal_state_contract.py
+++ b/grok/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import grok_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await grok_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/grok/tools/task_tools.py
+++ b/grok/tools/task_tools.py
@@ -45,8 +45,14 @@ async def grok_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/hailuo/core/utils.py
+++ b/hailuo/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/hailuo/tests/test_terminal_state_contract.py
+++ b/hailuo/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import hailuo_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await hailuo_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/hailuo/tools/task_tools.py
+++ b/hailuo/tools/task_tools.py
@@ -44,8 +44,14 @@ async def hailuo_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/kling/core/utils.py
+++ b/kling/core/utils.py
@@ -47,17 +47,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/kling/tests/test_terminal_state_contract.py
+++ b/kling/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import kling_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await kling_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/kling/tools/lip_sync_tools.py
+++ b/kling/tools/lip_sync_tools.py
@@ -100,11 +100,15 @@ async def kling_lip_sync(
         Task ID and lip-sync video information.
     """
     if not video_url and not video_id:
-        return '{"error": "Validation Error", "message": "Either video_url or video_id is required."}'
+        return (
+            '{"error": "Validation Error", "message": "Either video_url or video_id is required."}'
+        )
     if mode == "audio2video" and not audio_url and not audio_file:
         return '{"error": "Validation Error", "message": "audio_url or audio_file is required when mode=\'audio2video\'."}'
     if mode == "text2video" and not text:
-        return '{"error": "Validation Error", "message": "text is required when mode=\'text2video\'."}'
+        return (
+            '{"error": "Validation Error", "message": "text is required when mode=\'text2video\'."}'
+        )
 
     payload: dict = {"mode": mode}
 

--- a/kling/tools/task_tools.py
+++ b/kling/tools/task_tools.py
@@ -44,8 +44,14 @@ async def kling_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/luma/core/utils.py
+++ b/luma/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/luma/tests/test_terminal_state_contract.py
+++ b/luma/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import luma_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await luma_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/luma/tools/task_tools.py
+++ b/luma/tools/task_tools.py
@@ -44,8 +44,14 @@ async def luma_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/midjourney/core/utils.py
+++ b/midjourney/core/utils.py
@@ -45,17 +45,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/midjourney/tests/test_terminal_state_contract.py
+++ b/midjourney/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import midjourney_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await midjourney_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/midjourney/tools/task_tools.py
+++ b/midjourney/tools/task_tools.py
@@ -51,8 +51,14 @@ async def midjourney_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/minimax/core/utils.py
+++ b/minimax/core/utils.py
@@ -44,17 +44,19 @@ def _with_task_guidance(
 
     state = str(task.get("status") or task.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/minimax/tests/test_terminal_state_contract.py
+++ b/minimax/tests/test_terminal_state_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False

--- a/nanobanana/core/utils.py
+++ b/nanobanana/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/nanobanana/tests/test_terminal_state_contract.py
+++ b/nanobanana/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import nanobanana_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await nanobanana_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/nanobanana/tools/task_tools.py
+++ b/nanobanana/tools/task_tools.py
@@ -39,8 +39,14 @@ async def nanobanana_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/producer/core/utils.py
+++ b/producer/core/utils.py
@@ -50,12 +50,12 @@ def _with_task_guidance(
     # Determine task state for explicit guidance
     state = payload.get("state", "")
     response = payload.get("response", {})
-    success = response.get("success", False) if isinstance(response, dict) else False
+    success = response.get("success") if isinstance(response, dict) else None
 
-    if state == "complete" and success:
+    if success is True:
         payload["mcp_task_polling"] = {
             "task_id": task_id,
-            "state": state,
+            "state": "complete",
             "is_complete": True,
             "is_failed": False,
             "should_poll": False,
@@ -64,12 +64,18 @@ def _with_task_guidance(
             "note": "Task is complete. The audio URLs are final and ready to present to the user.",
         }
     else:
-        is_failed = str(state).lower() in {"failed", "error", "cancelled", "canceled"}
+        is_failed = success is False or str(state).lower() in {
+            "failed",
+            "error",
+            "cancelled",
+            "canceled",
+        }
+        effective_state = state or ("failed" if is_failed else "pending")
         payload["mcp_task_polling"] = {
             "task_id": task_id,
             "poll_tool": poll_tool,
             "batch_poll_tool": batch_poll_tool,
-            "state": state,
+            "state": effective_state,
             "is_complete": False,
             "is_failed": is_failed,
             "should_poll": not is_failed,
@@ -78,13 +84,13 @@ def _with_task_guidance(
             "polling_interval_seconds": 15,
             "max_poll_attempts": 100,
             "next_step": (
-                f'Task is NOT complete yet (state: "{state}"). '
-                f'IMPORTANT: Only state="complete" with success=true means the task is finished. '
-                f"Ignore any intermediate audio_url values — "
-                f"these are streaming previews, NOT final results. "
-                f'Wait 15 seconds, then call {poll_tool}(task_id="{task_id}") again. '
-                f"Media generation typically takes 1-5 minutes. "
-                f"Keep polling for up to 100 attempts. Do NOT stop early."
+                "Task failed. Inspect response.error for details and do not poll again."
+                if is_failed
+                else (
+                    f'Task is NOT complete yet (state: "{effective_state}"). '
+                    f'Wait 15 seconds, then call {poll_tool}(task_id="{task_id}") again. '
+                    f"Media generation typically takes 1-5 minutes."
+                )
             ),
         }
     return payload

--- a/producer/tests/test_terminal_state_contract.py
+++ b/producer/tests/test_terminal_state_contract.py
@@ -1,0 +1,58 @@
+"""Regression tests for Producer task terminal-state guidance."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from core.utils import format_task_result
+from tools.task_tools import producer_get_task, producer_get_tasks_batch
+
+
+def test_response_success_without_state_is_complete():
+    result = json.loads(
+        format_task_result({"id": "done", "state": "", "response": {"success": True, "data": []}})
+    )
+    guidance = result["mcp_task_polling"]
+    assert guidance["state"] == "complete"
+    assert guidance["is_complete"] is True
+    assert guidance["should_poll"] is False
+
+
+def test_response_failure_without_state_is_failed():
+    result = json.loads(
+        format_task_result(
+            {"id": "failed", "state": "", "response": {"success": False, "error": {"code": "bad"}}}
+        )
+    )
+    guidance = result["mcp_task_polling"]
+    assert guidance["state"] == "failed"
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        await producer_get_task(task_id="failed")
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_batch_normalizes_empty_states():
+    response = {
+        "count": 2,
+        "items": [
+            {"id": "done", "state": "", "response": {"success": True, "data": []}},
+            {"id": "failed", "state": "", "response": {"success": False, "error": {"code": "bad"}}},
+        ],
+    }
+    with patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=response)):
+        result = await producer_get_tasks_batch(task_ids=["done", "failed"])
+    assert "State: complete" in result
+    assert "State: failed" in result
+    assert "keep polling" not in result

--- a/producer/tests/test_utils.py
+++ b/producer/tests/test_utils.py
@@ -76,7 +76,8 @@ class TestFormatTaskResult:
         assert data["request"]["action"] == "generate"
         assert data["response"]["success"] is True
         assert data["response"]["data"][0]["title"] == "Test Song"
-        assert data["mcp_task_polling"]["poll_tool"] == "producer_get_task"
+        assert data["mcp_task_polling"]["state"] == "complete"
+        assert data["mcp_task_polling"]["should_poll"] is False
 
     def test_format_error(self):
         """Test formatting error response."""

--- a/producer/tools/task_tools.py
+++ b/producer/tools/task_tools.py
@@ -50,8 +50,14 @@ async def producer_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 
@@ -93,27 +99,37 @@ async def producer_get_tasks_batch(
 
     for item in result.get("items", []):
         response_info = item.get("response", {})
-        state = item.get("state", "unknown")
+        state = item.get("state", "")
         success = response_info.get("success", False)
+        is_complete = response_info.get("success") is True
+        is_failed = response_info.get("success") is False or str(state).lower() in {
+            "failed",
+            "error",
+            "cancelled",
+            "canceled",
+        }
+        effective_state = (
+            "complete" if is_complete else state or ("failed" if is_failed else "pending")
+        )
         lines.extend(
             [
                 f"=== Task: {item.get('id', 'N/A')} ===",
-                f"State: {state}",
+                f"State: {effective_state}",
                 f"Created At: {item.get('created_at', 'N/A')}",
                 f"Success: {success}",
             ]
         )
 
-        if state == "complete" and success:
+        if is_complete:
             for audio in response_info.get("data", []):
                 lines.append(
                     f"  - {audio.get('title', 'Untitled')}: {audio.get('audio_url', 'N/A')}"
                 )
-        elif state == "failed":
+        elif is_failed:
             lines.append(f"  Error: {response_info.get('error', 'Unknown error')}")
         else:
             lines.append(
-                f"  ⏳ Still {state} — keep polling. Any audio_url values are intermediate previews."
+                f"  ⏳ Still {effective_state} — keep polling. Any audio_url values are intermediate previews."
             )
 
         lines.append("")

--- a/seedance/core/utils.py
+++ b/seedance/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/seedance/tests/test_terminal_state_contract.py
+++ b/seedance/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import seedance_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await seedance_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/seedance/tools/task_tools.py
+++ b/seedance/tools/task_tools.py
@@ -48,8 +48,14 @@ async def seedance_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/seedream/core/utils.py
+++ b/seedream/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/seedream/tests/test_terminal_state_contract.py
+++ b/seedream/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import seedream_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await seedream_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/seedream/tools/task_tools.py
+++ b/seedream/tools/task_tools.py
@@ -41,8 +41,14 @@ async def seedream_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/sora/core/utils.py
+++ b/sora/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/sora/tests/test_terminal_state_contract.py
+++ b/sora/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import sora_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await sora_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/sora/tools/task_tools.py
+++ b/sora/tools/task_tools.py
@@ -44,8 +44,14 @@ async def sora_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 

--- a/veo/core/utils.py
+++ b/veo/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/veo/tests/test_terminal_state_contract.py
+++ b/veo/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import veo_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await veo_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/veo/tools/task_tools.py
+++ b/veo/tools/task_tools.py
@@ -51,8 +51,14 @@ async def veo_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 
@@ -61,7 +67,9 @@ async def veo_get_task(
 async def veo_get_tasks_batch(
     task_ids: Annotated[
         list[str] | None,
-        Field(description="Optional list of task IDs to query. Maximum recommended batch size is 50 tasks."),
+        Field(
+            description="Optional list of task IDs to query. Maximum recommended batch size is 50 tasks."
+        ),
     ] = None,
     trace_ids: Annotated[
         list[str] | None,

--- a/wan/core/utils.py
+++ b/wan/core/utils.py
@@ -43,17 +43,19 @@ def _with_task_guidance(
 
     state = str(payload.get("state", "")).lower()
     response = payload.get("response", {})
-    response_success = response.get("success", False) if isinstance(response, dict) else False
-    top_level_success = (
-        payload.get("success", False) if isinstance(payload.get("success", False), bool) else False
-    )
+    response_success = response.get("success") if isinstance(response, dict) else None
+    top_level_success = payload.get("success")
 
     is_complete = (
         state in {"complete", "completed", "succeeded", "success"}
-        or response_success
-        or top_level_success
+        or response_success is True
+        or top_level_success is True
     )
-    is_failed = state in {"failed", "error", "cancelled", "canceled"}
+    is_failed = (
+        state in {"failed", "error", "cancelled", "canceled"}
+        or response_success is False
+        or top_level_success is False
+    )
     should_poll = not (is_complete or is_failed)
 
     payload["mcp_task_polling"] = {

--- a/wan/tests/test_terminal_state_contract.py
+++ b/wan/tests/test_terminal_state_contract.py
@@ -1,0 +1,60 @@
+"""Regression tests for async task terminal-state guidance."""
+
+import json
+
+from core.utils import format_task_result
+
+
+def test_explicit_response_failure_without_state_is_terminal():
+    result = json.loads(
+        format_task_result(
+            {
+                "id": "failed-task",
+                "state": "",
+                "response": {
+                    "success": False,
+                    "error": {"code": "bad_request", "message": "invalid input"},
+                },
+            }
+        )
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False
+    assert guidance["terminal_state_reached"] is True
+    assert guidance["recommended_action"] == "stop"
+
+
+def test_missing_success_remains_pending():
+    result = json.loads(
+        format_task_result({"id": "pending-task", "state": "", "response": {"data": []}})
+    )
+
+    guidance = result["mcp_task_polling"]
+    assert guidance["is_complete"] is False
+    assert guidance["is_failed"] is False
+    assert guidance["should_poll"] is True
+    assert guidance["terminal_state_reached"] is False
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.task_tools import wan_get_task
+
+
+@pytest.mark.asyncio
+async def test_failed_task_does_not_sleep():
+    task = {"id": "failed-task", "state": "", "response": {"success": False}}
+    with (
+        patch("tools.task_tools.client.query_task", new=AsyncMock(return_value=task)),
+        patch("tools.task_tools.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        result = await wan_get_task(task_id="failed-task")
+
+    sleep.assert_not_awaited()
+    guidance = json.loads(result)["mcp_task_polling"]
+    assert guidance["is_failed"] is True
+    assert guidance["should_poll"] is False

--- a/wan/tools/task_tools.py
+++ b/wan/tools/task_tools.py
@@ -40,8 +40,14 @@ async def wan_get_task(
     # Throttle polling: sleep 5s for incomplete tasks so LLM clients
     # don't burn through poll attempts in seconds.
     response = result.get("response", {})
-    is_complete = response.get("success", False)
-    if not is_complete:
+    is_complete = response.get("success") is True
+    is_failed = response.get("success") is False or str(result.get("state", "")).lower() in {
+        "failed",
+        "error",
+        "cancelled",
+        "canceled",
+    }
+    if not is_complete and not is_failed:
         await asyncio.sleep(5)
     return format_task_result(result)
 


### PR DESCRIPTION
## Summary

- treat explicit `response.success=false` and top-level `success=false` as terminal failures in the shared media-task envelope
- keep responses with no success field pending, avoiding false terminal states
- skip the built-in five-second delay once a single-task query has explicitly failed
- bring Producer's older formatter up to the same success/failure normalization

Affected MCPs: Flux, Grok, Hailuo, Kling, Luma, Midjourney, MiniMax, NanoBanana, Producer, Seedance, Seedream, Sora, Veo, and Wan. Fish/OpenAI/WebExtrator use `finished_at`; DigitalHuman/HappyHorse/Maestro use service-specific state contracts and were intentionally left unchanged.

Kling also includes two formatter-only line wraps in `lip_sync_tools.py` required for its existing full-directory `ruff format --check .` gate.

## Evidence

Suno production E2E proved the shared envelope can return an empty top-level state with an explicit `response.success` terminal outcome. The same generated task formatters were copied across these MCPs. Before this patch, explicit failures remained `should_poll=true`; Producer also required top-level `state=complete` for successes.

## Validation

Each of the 14 affected projects passed its own full:

- `python -m pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy core tools main.py`

Aggregate local result: 408 passed, 39 integration tests skipped. Every affected MCP has new terminal-contract regression tests; 12 single-task tools also assert failures do not sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)