### PR TITLE
fix(suno): label all-stems candidate sets

### DIFF
--- a/suno/README.md
+++ b/suno/README.md
@@ -38,7 +38,7 @@ Generate AI music, lyrics, and manage audio projects directly from Claude, VS Co
 | `suno_upload_extend` | Extend an uploaded audio (your own music) with new AI-generated content. |
 | `suno_upload_cover` | Create an AI cover of an uploaded audio (your own music). |
 | `suno_mashup_music` | Blend exactly two songs using a required creative-direction prompt. |
-| `suno_all_stems_music` | Return full stem separation; two same-named 12-stem sets may be returned. |
+| `suno_all_stems_music` | Return two distinct 12-stem candidate sets, labeled `stem_set` 1 and 2 in task results. |
 | `suno_generate_lyrics` | Generate song lyrics from a text prompt. |
 | `suno_get_mp4` | Get an MP4 video version of a generated song. |
 | `suno_get_timing` | Get timing and subtitle data for a generated song. |

--- a/suno/core/utils.py
+++ b/suno/core/utils.py
@@ -34,6 +34,31 @@ def _with_submission_guidance(
     return payload
 
 
+def _label_all_stem_sets(data: dict[str, Any]) -> dict[str, Any]:
+    """Label the two distinct 12-stem candidates returned by all_stems."""
+    payload = dict(data)
+    if payload.get("request", {}).get("action") != "all_stems":
+        return payload
+
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return payload
+    items = response.get("data")
+    if not isinstance(items, list) or len(items) != 24:
+        return payload
+
+    def stem_name(item: Any) -> str:
+        title = str(item.get("title", "")) if isinstance(item, dict) else ""
+        return title.rsplit(" (", 1)[-1].removesuffix(")")
+
+    if [stem_name(item) for item in items[:12]] != [stem_name(item) for item in items[12:]]:
+        return payload
+
+    labeled = [dict(item, stem_set=index // 12 + 1) for index, item in enumerate(items)]
+    payload["response"] = dict(response, data=labeled)
+    return payload
+
+
 def _with_task_guidance(
     data: dict[str, Any], poll_tool: str, batch_poll_tool: str | None = None
 ) -> dict[str, Any]:
@@ -137,7 +162,7 @@ def format_task_result(data: dict[str, Any]) -> str:
         JSON string representation of the result
     """
     return json.dumps(
-        _with_task_guidance(data, "suno_get_task", "suno_get_tasks_batch"),
+        _with_task_guidance(_label_all_stem_sets(data), "suno_get_task", "suno_get_tasks_batch"),
         ensure_ascii=False,
         indent=2,
     )

--- a/suno/tests/test_utils.py
+++ b/suno/tests/test_utils.py
@@ -103,6 +103,54 @@ class TestFormatTaskResult:
         assert guidance["terminal_state_reached"] is True
         assert guidance["recommended_action"] == "stop"
 
+    def test_all_stems_labels_two_distinct_candidate_sets(self):
+        names = [
+            "Vocals",
+            "Backing Vocals",
+            "Drums",
+            "Bass",
+            "Guitar",
+            "Keyboard",
+            "Percussion",
+            "Strings",
+            "Synth",
+            "FX",
+            "Brass",
+            "Woodwinds",
+        ]
+        items = [
+            {"id": f"set-{set_number}-{name}", "title": f"Song ({name})"}
+            for set_number in (1, 2)
+            for name in names
+        ]
+        data = json.loads(
+            format_task_result(
+                {
+                    "id": "all-stems-task",
+                    "request": {"action": "all_stems"},
+                    "response": {"success": True, "data": items},
+                }
+            )
+        )
+
+        labeled = data["response"]["data"]
+        assert [item["stem_set"] for item in labeled[:12]] == [1] * 12
+        assert [item["stem_set"] for item in labeled[12:]] == [2] * 12
+        assert [item["id"] for item in labeled] == [item["id"] for item in items]
+
+    def test_all_stems_does_not_guess_when_shape_changes(self):
+        items = [{"id": str(index), "title": f"Song ({index})"} for index in range(24)]
+        data = json.loads(
+            format_task_result(
+                {
+                    "id": "all-stems-task",
+                    "request": {"action": "all_stems"},
+                    "response": {"success": True, "data": items},
+                }
+            )
+        )
+        assert all("stem_set" not in item for item in data["response"]["data"])
+
     def test_response_error_without_state_is_terminal(self):
         result = format_task_result(
             {


### PR DESCRIPTION
## Summary

- label the two distinct 12-stem candidates returned by `all_stems` as `stem_set` 1 and 2
- preserve every original result, ID, title, and URL
- fail open without labels if the service response is no longer exactly two matching 12-stem sequences

## Production evidence

Real hosted MCP task `5e736f53-41ab-487e-8c1e-2d959c9534a3` returned 24 items. Comparing corresponding stems showed 0/12 identical URLs and 0/12 identical first-64-KiB SHA-256 hashes, proving these are two distinct candidate sets rather than duplicate response rows.

## Validation

- full Suno suite: 48 passed, 7 skipped
- focused formatter tests: 12 passed
- `ruff check .`
- `ruff format --check .`
- `mypy core tools main.py`

Related: https://github.com/AceDataCloud/SunoMCP/issues/84

🤖 Generated with [Claude Code](https://claude.com/claude-code)