### PR TITLE
fix(acedatacloud): discover services without aliases

### DIFF
--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -57,6 +57,29 @@ async def test_get_service_by_alias_paginates():
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_get_service_resolves_exact_tag_when_alias_is_missing():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "items": [
+                    {
+                        "id": "svc-chat",
+                        "alias": None,
+                        "title": "AI Dialogue",
+                        "tags": ["aichat"],
+                    }
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_service(service="aichat"))
+    assert out["id"] == "svc-chat"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_get_pricing_returns_cost():
     respx.get(f"{API}/services/").mock(
         return_value=httpx.Response(
@@ -83,6 +106,12 @@ async def test_get_pricing_returns_cost():
 @respx.mock
 @pytest.mark.asyncio
 async def test_list_apis_uses_server_side_service_filter():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={"count": 1, "items": [{"id": UUID, "alias": "suno"}]},
+        )
+    )
     route = respx.get(f"{API}/apis/").mock(
         return_value=httpx.Response(
             200,
@@ -100,11 +129,10 @@ async def test_list_apis_uses_server_side_service_filter():
             },
         )
     )
-    out = json.loads(await acedatacloud_list_apis(service=UUID, stage="Production"))
+    out = json.loads(await acedatacloud_list_apis(service="suno", stage="Production"))
     assert out["count"] == 1
     assert out["items"][0]["path"] == "/suno/audios"
     assert "definition" not in out["items"][0]
-    # The service+stage filters are pushed to the server, not paged client-side.
     params = route.calls[0].request.url.params
     assert params["service"] == UUID
     assert params["stage"] == "Production"

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -103,6 +103,30 @@ async def test_list_services_filters_by_search(mock_services_page):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_services_searches_tags_when_alias_is_missing():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 1,
+                "items": [
+                    {
+                        "id": "svc-chat",
+                        "alias": None,
+                        "title": "AI Dialogue",
+                        "tags": ["aichat"],
+                    }
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_list_services(search="aichat"))
+    assert out["count"] == 1
+    assert out["items"][0]["id"] == "svc-chat"
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_get_balance_summarizes(mock_applications_page):
     respx.get(f"{API}/platform-tokens/me/").mock(
         return_value=httpx.Response(200, json={"id": "user-1"})

--- a/acedatacloud/tools/catalog_tools.py
+++ b/acedatacloud/tools/catalog_tools.py
@@ -26,21 +26,29 @@ async def _resolve_service(ref: str) -> dict[str, Any] | None:
         result = await client.get_public("/services/", {"id": ref})
         items: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
         return items[0] if items else None
-    target = ref.lower()
+    target = ref.casefold()
     offset = 0
+    title_match = None
+    tag_match = None
     while offset < 600:
         result = await client.get_public("/services/", {"limit": 50, "offset": offset})
         page: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
         if not page:
             break
         for it in page:
-            if (it.get("alias") or "").lower() == target:
+            if (it.get("alias") or "").casefold() == target:
                 return it
+            if title_match is None and (it.get("title") or "").casefold() == target:
+                title_match = it
+            if tag_match is None and any(
+                str(tag).casefold() == target for tag in (it.get("tags") or [])
+            ):
+                tag_match = it
         count = result.get("count", 0) if isinstance(result, dict) else 0
         offset += 50
         if offset >= count:
             break
-    return None
+    return title_match or tag_match
 
 
 @mcp.tool()
@@ -107,10 +115,14 @@ async def acedatacloud_list_apis(
     Each item carries the path, method, stage and billing ``cost``. No token required.
     """
     try:
-        # The backend `/apis/` list honors `service` (alias or UUID) and `stage`
-        # server-side, so filter there instead of paging the whole catalog.
+        service_id = service
+        if service:
+            resolved = await _resolve_service(service)
+            if not resolved:
+                return error_json("Not Found", f"No service matched '{service}'.")
+            service_id = resolved.get("id")
         result = await client.get_public(
-            "/apis/", {"limit": limit, "service": service, "stage": stage}
+            "/apis/", {"limit": limit, "service": service_id, "stage": stage}
         )
         if not isinstance(result, dict):
             return error_json("No Response", "The API returned an empty response.")

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -78,7 +78,9 @@ async def acedatacloud_list_services(
             items = [
                 it
                 for it in items
-                if s in (it.get("alias") or "").lower() or s in (it.get("title") or "").lower()
+                if s in (it.get("alias") or "").lower()
+                or s in (it.get("title") or "").lower()
+                or any(s in str(tag).lower() for tag in (it.get("tags") or []))
             ]
             return dumps({"count": len(items), "items": items})
         result = await client.get("/services/", {"limit": limit, **server_filters})


### PR DESCRIPTION
## Summary
- include service tags in catalog search
- resolve service refs by exact alias, title, or tag before listing APIs
- cover the live AI Chat shape where alias is empty and tag is `aichat`

## Root cause
The live AI Chat APIs and docs exist, but their owning service has no alias; its stable discovery key is the `aichat` tag. MCP search only checked alias/title and API listing sent the unresolved name to an alias/UUID backend filter.

## Verification
- `pytest -q` — 97 passed
- `ruff check ...`
- `ruff format --check ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)