### PR TITLE
fix(acedatacloud): omit credentials from public catalog

### DIFF
--- a/acedatacloud/core/client.py
+++ b/acedatacloud/core/client.py
@@ -92,10 +92,12 @@ class PlatformClient:
             "accept": "application/json",
             "content-type": "application/json",
         }
+        if not auth_required:
+            return headers
         token = get_request_api_token() or self.api_token
         if token:
             headers["authorization"] = f"Bearer {token}"
-        elif auth_required:
+        else:
             logger.error("Platform token not configured")
             raise PlatformAuthError("Platform token not configured")
         return headers
@@ -251,7 +253,7 @@ class PlatformClient:
         endpoint: str,
         params: dict[str, Any] | list[tuple[str, Any]] | None = None,
     ) -> Any:
-        """GET a public endpoint, optionally sending a configured token."""
+        """GET a public endpoint without forwarding caller credentials."""
         return await self.request("GET", endpoint, params=params, auth_required=False)
 
     async def post(

--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -278,6 +278,6 @@ async def test_public_get_omits_auth_header_when_no_token():
     route = respx.get(f"{API}/services/").mock(
         return_value=httpx.Response(200, json={"count": 0, "items": []})
     )
-    public_client = PlatformClient(api_token="")
+    public_client = PlatformClient(api_token="must-not-be-forwarded")
     await public_client.get_public("/services/")
     assert "authorization" not in {k.lower() for k in route.calls[0].request.headers}

--- a/acedatacloud/tests/test_client.py
+++ b/acedatacloud/tests/test_client.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 import respx
 
-from core.client import PlatformClient
+from core.client import PlatformClient, reset_request_api_token, set_request_api_token
 from core.exceptions import PlatformAPIError, PlatformAuthError, PlatformTimeoutError
 
 BASE = "https://api.test.com"
@@ -31,6 +31,15 @@ def test_get_headers_no_token_raises():
     c = PlatformClient(api_token="", base_url=BASE)
     with pytest.raises(PlatformAuthError, match="not configured"):
         c._get_headers()
+
+
+def test_public_headers_never_forward_credentials(client):
+    context = set_request_api_token("request-token")
+    try:
+        headers = client._get_headers(auth_required=False)
+    finally:
+        reset_request_api_token(context)
+    assert "authorization" not in headers
 
 
 @respx.mock


### PR DESCRIPTION
## Summary
- never forward MCP caller credentials to anonymous PlatformBackend catalog endpoints
- retain authenticated headers for account-management requests
- cover configured-token and request-context-token isolation

## Root cause
The hosted MCP accepts an AceDataCloud API key, then `get_public()` forwarded that key to anonymous catalog endpoints. Those endpoints return 200 anonymously but reject the API key as an invalid JWT/platform token, so all service/API/doc discovery returned `auth_error`.

## Verification
- `pytest -q` — 98 passed
- Ruff check + format check passed
- live pre-fix MCP reproduction returned `token_not_valid` for service search, service detail, and API listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)