### PR TITLE
fix(acedatacloud): reject ambiguous service tags

### DIFF
--- a/acedatacloud/tests/test_catalog_docs.py
+++ b/acedatacloud/tests/test_catalog_docs.py
@@ -57,7 +57,7 @@ async def test_get_service_by_alias_paginates():
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_get_service_resolves_exact_tag_when_alias_is_missing():
+async def test_get_service_resolves_unique_exact_tag_when_alias_is_missing():
     respx.get(f"{API}/services/").mock(
         return_value=httpx.Response(
             200,
@@ -76,6 +76,26 @@ async def test_get_service_resolves_exact_tag_when_alias_is_missing():
     )
     out = json.loads(await acedatacloud_get_service(service="aichat"))
     assert out["id"] == "svc-chat"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_service_rejects_ambiguous_tag():
+    respx.get(f"{API}/services/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "count": 2,
+                "items": [
+                    {"id": "svc-chat", "title": "AI Dialogue", "tags": ["aichat"]},
+                    {"id": "svc-deepseek", "alias": "deepseek", "tags": ["aichat"]},
+                ],
+            },
+        )
+    )
+    out = json.loads(await acedatacloud_get_service(service="aichat"))
+    assert out["error"] == "validation_error"
+    assert "service UUID or exact alias" in out["message"]
 
 
 @respx.mock

--- a/acedatacloud/tests/test_tools.py
+++ b/acedatacloud/tests/test_tools.py
@@ -103,8 +103,8 @@ async def test_list_services_filters_by_search(mock_services_page):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_list_services_searches_tags_when_alias_is_missing():
-    respx.get(f"{API}/services/").mock(
+async def test_list_services_searches_tags_without_forwarding_credentials():
+    route = respx.get(f"{API}/services/").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -123,6 +123,7 @@ async def test_list_services_searches_tags_when_alias_is_missing():
     out = json.loads(await acedatacloud_list_services(search="aichat"))
     assert out["count"] == 1
     assert out["items"][0]["id"] == "svc-chat"
+    assert "authorization" not in {key.lower() for key in route.calls[0].request.headers}
 
 
 @respx.mock

--- a/acedatacloud/tools/catalog_tools.py
+++ b/acedatacloud/tools/catalog_tools.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any
 from pydantic import Field
 
 from core.client import client
-from core.exceptions import PlatformError
+from core.exceptions import PlatformError, PlatformValidationError
 from core.server import mcp
 from core.utils import dumps, error_json
 
@@ -29,7 +29,7 @@ async def _resolve_service(ref: str) -> dict[str, Any] | None:
     target = ref.casefold()
     offset = 0
     title_match = None
-    tag_match = None
+    tag_matches: list[dict[str, Any]] = []
     while offset < 600:
         result = await client.get_public("/services/", {"limit": 50, "offset": offset})
         page: list[dict[str, Any]] = result.get("items", []) if isinstance(result, dict) else []
@@ -40,15 +40,21 @@ async def _resolve_service(ref: str) -> dict[str, Any] | None:
                 return it
             if title_match is None and (it.get("title") or "").casefold() == target:
                 title_match = it
-            if tag_match is None and any(
-                str(tag).casefold() == target for tag in (it.get("tags") or [])
-            ):
-                tag_match = it
+            if any(str(tag).casefold() == target for tag in (it.get("tags") or [])):
+                tag_matches.append(it)
         count = result.get("count", 0) if isinstance(result, dict) else 0
         offset += 50
         if offset >= count:
             break
-    return title_match or tag_match
+    if title_match:
+        return title_match
+    if len(tag_matches) == 1:
+        return tag_matches[0]
+    if len(tag_matches) > 1:
+        raise PlatformValidationError(
+            f"Service reference '{ref}' matches multiple tags; use a service UUID or exact alias."
+        )
+    return None
 
 
 @mcp.tool()

--- a/acedatacloud/tools/read_tools.py
+++ b/acedatacloud/tools/read_tools.py
@@ -72,7 +72,7 @@ async def acedatacloud_list_services(
             "private": None if private is None else str(private).lower(),
         }
         if search:
-            result = await client.get("/services/", {"limit": 300, **server_filters})
+            result = await client.get_public("/services/", {"limit": 300, **server_filters})
             items = result.get("items", []) if isinstance(result, dict) else []
             s = search.lower()
             items = [
@@ -83,7 +83,7 @@ async def acedatacloud_list_services(
                 or any(s in str(tag).lower() for tag in (it.get("tags") or []))
             ]
             return dumps({"count": len(items), "items": items})
-        result = await client.get("/services/", {"limit": limit, **server_filters})
+        result = await client.get_public("/services/", {"limit": limit, **server_filters})
         return _wrap(result)
     except PlatformError as error:
         return error_json(error.code, error.message)


### PR DESCRIPTION
## Summary
- keep service-list catalog reads anonymous when an MCP API key is present
- resolve exact aliases/titles first and only accept a tag when it identifies one service
- reject ambiguous tag refs instead of silently selecting the first product

## Root cause
After credential isolation shipped, live `get_service("aichat")` selected DeepSeek because multiple services carry the `aichat` tag. `list_services` also still used the authenticated client and returned `token_not_valid` with an API key.

## Verification
- `pytest -q` — 99 passed
- Ruff check + format check passed
- live pre-fix proof: `get_service("aichat")` returned `deepseek`; `list_apis` returned `/deepseek/chat/completions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)