### PR TITLE
fix: remove unavailable Claude 3 Opus

### DIFF
--- a/aichat/core/types.py
+++ b/aichat/core/types.py
@@ -122,7 +122,6 @@ AiChatV2Model = Literal[
     "claude-3-5-sonnet-20241022",
     "claude-3-7-sonnet-20250219",
     "claude-3-haiku-20240307",
-    "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
     "claude-fable-5",
     "claude-haiku-4-5-20251001",

--- a/aichat/tests/test_contract.py
+++ b/aichat/tests/test_contract.py
@@ -71,7 +71,6 @@ def test_v2_offers_claude_spec_models():
         "claude-3-5-sonnet-20240620",
         "claude-3-haiku-20240307",
         "claude-3-sonnet-20240229",
-        "claude-3-opus-20240229",
     }
     missing = spec_models - set(get_args(AiChatV2Model))
     assert not missing, f"AiChatV2Model is missing Claude spec models {sorted(missing)}"


### PR DESCRIPTION
## Summary
- remove only `claude-3-opus-20240229`, which currently has no healthy AceDataCloud capability
- preserve all other legacy aliases that remain serviceable through AceDataCloud compatibility routes
- preserve Claude Opus 4.5, Sonnet 4.5, and Haiku 4.5

Scope was narrowed after review; this does not apply Anthropic retirement status as an automatic AceDataCloud removal policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)