### PR TITLE
feat(minimax): expose async video submission

### DIFF
--- a/minimax/README.md
+++ b/minimax/README.md
@@ -13,7 +13,7 @@ Model Context Protocol server for MiniMax H3 multimodal video generation through
 - Text-to-video
 - Image-, video-, and audio-guided video generation
 - 4–15 second output in 768P or 2K, with adaptive, landscape, portrait, and square ratios
-- Asynchronous task retrieval, batch retrieval, and deletion
+- Optional asynchronous submission, task retrieval, batch retrieval, and deletion
 - Hosted OAuth HTTP transport and local stdio transport
 
 ## Tools
@@ -94,7 +94,7 @@ Audio:
 Create a 9:16 dance video guided by this audio, with cuts and motion following the beat.
 ```
 
-Generation tools wait for a completed task by default. Set `async` to `true` (or provide `callback_url`) to return a task ID immediately, then poll it with `minimax_get_task`.
+The HTTP API waits for completion by default, while MCP generation tools default `async` to `true` so agents receive a task ID immediately. Poll it with `minimax_get_task` until the final AceDataCloud CDN video is available. Set `async=false` only when the client can safely wait for the complete result.
 
 ## Development
 

--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 from pydantic import ValidationError
 
+from core.server import mcp
 from core.types import MinimaxContent
 from tools import video_tools
 
@@ -10,6 +11,21 @@ from tools import video_tools
 @pytest.fixture
 def generated_response():
     return {"task_id": "task-1", "started_at": 1}
+
+
+@pytest.mark.asyncio
+async def test_generation_tool_schemas_expose_async_default():
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+    for name in (
+        "minimax_generate_video_from_text",
+        "minimax_generate_video_from_images",
+        "minimax_generate_video_from_audio",
+        "minimax_generate_video",
+    ):
+        properties = tools[name].inputSchema["properties"]
+        assert properties["async"]["default"] is True
+        assert "async_" not in properties
 
 
 @pytest.mark.asyncio
@@ -26,6 +42,23 @@ async def test_text_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="16:9",
         duration=6,
+        **{"async": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_tool_can_request_synchronous_response(monkeypatch, generated_response):
+    generate = AsyncMock(return_value=generated_response)
+    monkeypatch.setattr(video_tools.client, "generate_video", generate)
+
+    await video_tools.minimax_generate_video_from_text("fox", async_=False)
+
+    generate.assert_awaited_once_with(
+        model="MiniMax-H3",
+        content=[{"type": "text", "text": "fox"}],
+        resolution="2K",
+        ratio="16:9",
+        duration=4,
         **{"async": False},
     )
 
@@ -52,7 +85,7 @@ async def test_image_tool_single_image_uses_first_frame(monkeypatch, generated_r
         resolution="2K",
         ratio="16:9",
         duration=4,
-        **{"async": False},
+        **{"async": True},
     )
 
 
@@ -83,7 +116,7 @@ async def test_image_tool_multiple_images_uses_reference(monkeypatch, generated_
         resolution="2K",
         ratio="16:9",
         duration=4,
-        **{"async": False},
+        **{"async": True},
     )
 
 
@@ -114,7 +147,7 @@ async def test_audio_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="16:9",
         duration=4,
-        **{"async": False},
+        **{"async": True},
     )
 
 
@@ -148,34 +181,8 @@ async def test_full_schema_tool_payload(monkeypatch, generated_response):
         resolution="2K",
         ratio="adaptive",
         duration=4,
-        **{"async": False},
+        **{"async": True},
     )
-
-
-@pytest.mark.asyncio
-async def test_text_tool_enables_async_submission(monkeypatch, generated_response):
-    generate = AsyncMock(return_value=generated_response)
-    monkeypatch.setattr(video_tools.client, "generate_video", generate)
-
-    await video_tools.minimax_generate_video_from_text("fox", async_=True)
-
-    assert generate.await_args.kwargs["async"] is True
-
-
-@pytest.mark.asyncio
-async def test_generation_tool_schemas_use_documented_async_default():
-    generation_tools = {
-        tool.name: tool for tool in await video_tools.mcp.list_tools() if "generate_video" in tool.name
-    }
-
-    assert set(generation_tools) == {
-        "minimax_generate_video_from_text",
-        "minimax_generate_video_from_images",
-        "minimax_generate_video_from_audio",
-        "minimax_generate_video",
-    }
-    for tool in generation_tools.values():
-        assert tool.inputSchema["properties"]["async"]["default"] is False
 
 
 def test_content_schema_rejects_extra_fields():

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -65,8 +65,11 @@ async def minimax_generate_video_from_text(
     ] = None,
     async_: Annotated[
         bool,
-        Field(alias="async", description="Whether to return immediately with a task_id."),
-    ] = False,
+        Field(
+            alias="async",
+            description="Return a task_id immediately for minimax_get_task polling.",
+        ),
+    ] = True,
 ) -> str:
     """Generate a MiniMax H3 video from a text prompt."""
     payload = _common_payload(
@@ -100,8 +103,11 @@ async def minimax_generate_video_from_images(
     ] = None,
     async_: Annotated[
         bool,
-        Field(alias="async", description="Whether to return immediately with a task_id."),
-    ] = False,
+        Field(
+            alias="async",
+            description="Return a task_id immediately for minimax_get_task polling.",
+        ),
+    ] = True,
 ) -> str:
     """Generate from one first-frame image or multiple reference images.
 
@@ -155,8 +161,11 @@ async def minimax_generate_video_from_audio(
     ] = None,
     async_: Annotated[
         bool,
-        Field(alias="async", description="Whether to return immediately with a task_id."),
-    ] = False,
+        Field(
+            alias="async",
+            description="Return a task_id immediately for minimax_get_task polling.",
+        ),
+    ] = True,
 ) -> str:
     """Generate a MiniMax H3 video guided by audio and reference images.
 
@@ -215,8 +224,11 @@ async def minimax_generate_video(
     ] = None,
     async_: Annotated[
         bool,
-        Field(alias="async", description="Whether to return immediately with a task_id."),
-    ] = False,
+        Field(
+            alias="async",
+            description="Return a task_id immediately for minimax_get_task polling.",
+        ),
+    ] = True,
 ) -> str:
     """Generate a video from the full MiniMax content schema."""
     payload = _common_payload(


### PR DESCRIPTION
## Summary
- expose the API `async` field on all MiniMax video generation MCP tools
- default MCP calls to `async: true` so agents receive `task_id` immediately and poll `minimax_get_task`
- preserve `async: false` for clients that can wait for the complete result
- lock the public schema and payload behavior with regressions

## Dependency
Requires the worker contract in https://github.com/AceDataCloud/PlatformService/pull/2034 to deploy first.

## Verification
- `python3 -m pytest -q` (41 passed, 3 skipped live tests)
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy core tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)