### PR TITLE
fix(catalog): align mapped MCP inventory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,13 @@ on:
     branches: [main]
 
 jobs:
+  inventory:
+    name: README Inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: python3 scripts/check_readme_inventory.py
+
   detect-changes:
     runs-on: ubuntu-latest
     outputs:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Monorepo for all AceDataCloud MCP (Model Context Protocol) servers.
 | `suno/` | [SunoMCP](https://github.com/AceDataCloud/SunoMCP) | [mcp-suno](https://pypi.org/project/mcp-suno/) | Music |
 | `veo/` | [VeoMCP](https://github.com/AceDataCloud/VeoMCP) | [mcp-veo](https://pypi.org/project/mcp-veo/) | Video |
 | `wan/` | [WanMCP](https://github.com/AceDataCloud/WanMCP) | [mcp-wan](https://pypi.org/project/mcp-wan/) | Video |
+| `aichat/` | [AiChatMCP](https://github.com/AceDataCloud/AiChatMCP) | [mcp-aichat](https://pypi.org/project/mcp-aichat/) | Chat |
+| `discord-bot/` | [DiscordBotMCP](https://github.com/AceDataCloud/DiscordBotMCP) | [mcp-discord-bot](https://pypi.org/project/mcp-discord-bot/) | Messaging |
+| `glm/` | [GLMMCP](https://github.com/AceDataCloud/GLMMCP) | [mcp-glm](https://pypi.org/project/mcp-glm/) | Chat |
+| `grok/` | [GrokMCP](https://github.com/AceDataCloud/GrokMCP) | [mcp-grok](https://pypi.org/project/mcp-grok/) | Video |
+| `minimax/` | [MinimaxMCP](https://github.com/AceDataCloud/MinimaxMCP) | [mcp-minimax](https://pypi.org/project/mcp-minimax/) | Video |
+| `openai/` | [OpenAIMCP](https://github.com/AceDataCloud/OpenAIMCP) | [mcp-openai](https://pypi.org/project/mcp-openai/) | AI APIs |
+| `webextrator/` | [WebExtratorMCP](https://github.com/AceDataCloud/WebExtratorMCP) | [mcp-webextrator](https://pypi.org/project/mcp-webextrator/) | Web & Data |
 
 ## Publishing
 

--- a/scripts/check_readme_inventory.py
+++ b/scripts/check_readme_inventory.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Require README server inventory to match sync.yaml mappings."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    mappings = set(re.findall(r"^  ([a-z0-9_-]+):\s*$", (ROOT / "sync.yaml").read_text(), re.MULTILINE))
+    listed = set(re.findall(r"^\| `([^/`]+)/`", (ROOT / "README.md").read_text(), re.MULTILINE))
+    missing = sorted(mappings - listed)
+    extra = sorted(listed - mappings)
+    if missing or extra:
+        if missing:
+            print(f"README missing mapped servers: {', '.join(missing)}", file=sys.stderr)
+        if extra:
+            print(f"README lists unmapped servers: {', '.join(extra)}", file=sys.stderr)
+        return 1
+    print(f"README inventory matches {len(mappings)} mapped servers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Contract node
MCP publication inventory.

## Changes
- add the 7 mapped servers omitted from README
- add an always-on README ↔ `sync.yaml` CI gate

## Evidence
`README inventory matches 27 mapped servers`; Python compile, workflow YAML parse, and diff check passed.

## Rollout / rollback
Documentation/CI only; revert safely.

## Dependencies
Independent.

## Out of scope
Five intentionally unmapped package directories remain classified as unpublished/unmapped, not advertised. Adversarial review was not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)