### PR TITLE
fix(minimax): map public async tool argument

### DIFF
--- a/minimax/tests/test_video_tools.py
+++ b/minimax/tests/test_video_tools.py
@@ -29,6 +29,31 @@ async def test_generation_tool_schemas_expose_async_default():
 
 
 @pytest.mark.asyncio
+async def test_fastmcp_dispatch_maps_public_async_parameter(monkeypatch, generated_response):
+    generate = AsyncMock(return_value=generated_response)
+    monkeypatch.setattr(video_tools.client, "generate_video", generate)
+
+    result = await mcp.call_tool(
+        "minimax_generate_video_from_text",
+        {"prompt": "fox", "async": False},
+    )
+
+    assert result
+    assert generate.await_args.kwargs["async"] is False
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_dispatch_applies_async_default(monkeypatch, generated_response):
+    generate = AsyncMock(return_value=generated_response)
+    monkeypatch.setattr(video_tools.client, "generate_video", generate)
+
+    result = await mcp.call_tool("minimax_generate_video_from_text", {"prompt": "fox"})
+
+    assert result
+    assert generate.await_args.kwargs["async"] is True
+
+
+@pytest.mark.asyncio
 async def test_text_tool_payload(monkeypatch, generated_response):
     generate = AsyncMock(return_value=generated_response)
     monkeypatch.setattr(video_tools.client, "generate_video", generate)

--- a/minimax/tools/video_tools.py
+++ b/minimax/tools/video_tools.py
@@ -66,7 +66,7 @@ async def minimax_generate_video_from_text(
     async_: Annotated[
         bool,
         Field(
-            alias="async",
+            validation_alias="async",
             description="Return a task_id immediately for minimax_get_task polling.",
         ),
     ] = True,
@@ -104,7 +104,7 @@ async def minimax_generate_video_from_images(
     async_: Annotated[
         bool,
         Field(
-            alias="async",
+            validation_alias="async",
             description="Return a task_id immediately for minimax_get_task polling.",
         ),
     ] = True,
@@ -162,7 +162,7 @@ async def minimax_generate_video_from_audio(
     async_: Annotated[
         bool,
         Field(
-            alias="async",
+            validation_alias="async",
             description="Return a task_id immediately for minimax_get_task polling.",
         ),
     ] = True,
@@ -225,7 +225,7 @@ async def minimax_generate_video(
     async_: Annotated[
         bool,
         Field(
-            alias="async",
+            validation_alias="async",
             description="Return a task_id immediately for minimax_get_task polling.",
         ),
     ] = True,


### PR DESCRIPTION
## Summary
- use a Pydantic validation alias so the public MCP field remains `async` while FastMCP invokes the legal Python parameter `async_`
- cover explicit `async: false` and the MCP default through real `mcp.call_tool` dispatch

## Production evidence
Hosted `tools/list` exposed `async`, but `tools/call` failed with `unexpected keyword argument async` because FastMCP dumped the field alias as the Python kwarg. No generation task or charge was created.

## Verification
- `python3 -m pytest -q` (42 passed, 3 live skipped)
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m mypy core tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)