### PR TITLE
fix(minimax): select safe OAuth credential

### DIFF
--- a/minimax/core/oauth.py
+++ b/minimax/core/oauth.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import secrets
 import time
+from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 import httpx
@@ -39,6 +40,25 @@ from core.client import set_request_api_token
 from core.config import settings
 
 MCP_ACCESS_SCOPE = "mcp:access"
+
+
+def _is_reusable_credential(credential: dict[str, object], user_id: str | None) -> bool:
+    """Reuse only the owner's unlimited, unexpired API credentials."""
+    if not credential.get("token") or credential.get("limited_amount") is not None:
+        return False
+    if user_id and str(credential.get("user_id") or "") != user_id:
+        return False
+    expired_at = credential.get("expired_at")
+    if isinstance(expired_at, str) and expired_at:
+        try:
+            expiry = datetime.fromisoformat(expired_at.replace("Z", "+00:00"))
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=timezone.utc)
+            if expiry <= datetime.now(timezone.utc):
+                return False
+        except ValueError:
+            return False
+    return True
 
 
 def _normalize_scopes(scopes: list[str] | None) -> list[str]:
@@ -393,10 +413,11 @@ class AceDataCloudOAuthProvider:
                                 f"type={cred.get('type')}, "
                                 f"keys={list(cred.keys())}"
                             )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
+                            if _is_reusable_credential(cred, user_id):
+                                cred_token = cred.get("token")
+                                assert isinstance(cred_token, str)
                                 logger.info(
-                                    f"Found existing credential token "
+                                    f"Found reusable owner credential "
                                     f"(id={cred.get('id')}, token={cred_token[:12]}...)"
                                 )
                                 return cred_token
@@ -456,15 +477,16 @@ class AceDataCloudOAuthProvider:
                             f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
                         )
                         if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
+                            for app_cred in app_creds:
+                                if _is_reusable_credential(app_cred, user_id):
+                                    existing_token = app_cred.get("token")
+                                    assert isinstance(existing_token, str)
+                                    logger.info(
+                                        f"Found reusable credential in existing application "
+                                        f"(app_id={application_id}, token={existing_token[:12]}...)"
+                                    )
+                                    return existing_token
+                            logger.debug("Step 2a: application has no reusable owner credential")
                     else:
                         logger.debug("Step 2a: no Global Usage applications found")
                 else:
@@ -499,7 +521,11 @@ class AceDataCloudOAuthProvider:
 
                 # Step 2b: Create a credential under the application
                 cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
+                cred_create_payload = {
+                    "application_id": application_id,
+                    "name": "MiniMax MCP OAuth",
+                    "limited_amount": None,
+                }
                 logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
                 cred_resp = await client.post(
                     cred_create_url,

--- a/minimax/tests/test_oauth.py
+++ b/minimax/tests/test_oauth.py
@@ -1,0 +1,93 @@
+import base64
+import json
+
+import pytest
+import respx
+from httpx import Response
+
+from core.config import settings
+from core.oauth import AceDataCloudOAuthProvider, _is_reusable_credential
+
+
+def _jwt(user_id: str) -> str:
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"user_id": user_id}).encode()).rstrip(b"=").decode()
+    )
+    return f"header.{payload}.signature"
+
+
+def test_reusable_credential_requires_owner_unlimited_and_unexpired():
+    owner = "owner-1"
+    assert _is_reusable_credential({"token": "ok", "user_id": owner, "limited_amount": None}, owner)
+    assert not _is_reusable_credential(
+        {"token": "grant", "user_id": "holder", "limited_amount": 1}, owner
+    )
+    assert not _is_reusable_credential(
+        {"token": "limited", "user_id": owner, "limited_amount": 100}, owner
+    )
+    assert not _is_reusable_credential(
+        {
+            "token": "expired",
+            "user_id": owner,
+            "limited_amount": None,
+            "expired_at": "2020-01-01T00:00:00Z",
+        },
+        owner,
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_oauth_skips_grant_and_selects_owner_unlimited_credential():
+    owner = "owner-1"
+    credentials = respx.get(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": "grant",
+                        "token": "grant-token",
+                        "user_id": "holder",
+                        "limited_amount": 1,
+                    },
+                    {
+                        "id": "owner",
+                        "token": "owner-token",
+                        "user_id": owner,
+                        "limited_amount": None,
+                    },
+                ]
+            },
+        )
+    )
+
+    token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
+
+    assert credentials.called
+    assert token == "owner-token"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_oauth_creates_named_unlimited_credential_when_none_reusable():
+    owner = "owner-1"
+    respx.get(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(200, json={"results": []})
+    )
+    respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(
+        return_value=Response(200, json={"items": [{"id": "app-1", "credentials": []}]})
+    )
+    create = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(201, json={"token": "new-token"})
+    )
+
+    token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
+
+    assert token == "new-token"
+    payload = json.loads(create.calls.last.request.content)
+    assert payload == {
+        "application_id": "app-1",
+        "name": "MiniMax MCP OAuth",
+        "limited_amount": None,
+    }


### PR DESCRIPTION
## Summary
- reuse only unlimited, unexpired credentials owned by the OAuth user
- skip grant-out credentials held by another user and limited credentials
- explicitly create a named unlimited credential when no safe credential exists

## Production evidence
aichat2 loaded MiniMax MCP but generation failed before submit: the selected credential had `limited_amount=1`, while the 4s request required 2.40283288 Credits. The same Global Application has 219 credentials, 207 unlimited; the old OAuth loop returned the first token without checking holder or limit. The failed request was charged 0.

## Verification
- `python3 -m pytest -q` (45 passed, 3 live skipped)
- focused tests reproduce grant-out limit=1 before an owner unlimited credential
- `ruff format --check`, `ruff check`, `mypy core tools`

## Rollout note
Existing OAuth connections retain their durable old credential until reconnected once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)