### PR TITLE
fix(oauth): reuse shared OAuth MCP credential

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: python3 scripts/check_readme_inventory.py
+      - run: python3 scripts/check_oauth_contract.py
 
   detect-changes:
     runs-on: ubuntu-latest

--- a/aichat/core/oauth.py
+++ b/aichat/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/digitalhuman/core/oauth.py
+++ b/digitalhuman/core/oauth.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+import json
 import secrets
 import time
 from typing import Any
@@ -224,67 +225,81 @@ class AceDataCloudOAuthProvider:
             logger.exception("OAuth token exchange failed")
             return None
 
-    async def _get_user_credential(self, jwt_token: str) -> str | None:
-        headers = {"Authorization": "Bearer " + jwt_token}
+    @staticmethod
+    def _decode_jwt_payload(token: str) -> dict[str, object] | None:
         try:
-            async with httpx.AsyncClient(timeout=30) as http_client:
-                credentials_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                response = await http_client.get(credentials_url, headers=headers)
-                if response.status_code == 200:
-                    data = response.json()
-                    credentials = data.get("results", data) if isinstance(data, dict) else data
-                    if isinstance(credentials, list):
-                        for credential in credentials:
-                            token = (
-                                credential.get("token") if isinstance(credential, dict) else None
-                            )
-                            if isinstance(token, str) and token:
-                                return token
+            parts = token.split(".")
+            if len(parts) != 3:
+                return None
+            payload = parts[1] + "=" * (-len(parts[1]) % 4)
+            result = json.loads(base64.urlsafe_b64decode(payload))
+            return result if isinstance(result, dict) else None
+        except (ValueError, json.JSONDecodeError):
+            return None
 
-                applications_url = f"{settings.platform_base_url}/api/v1/applications/"
-                response = await http_client.get(
-                    applications_url,
-                    headers=headers,
-                    params={
-                        "limit": "10",
-                        "ordering": "-created_at",
-                        "type": "Usage",
-                        "scope": "Global",
-                    },
-                )
+    async def _get_user_credential(self, jwt_token: str) -> str | None:
+        """Get or create this Hosted MCP's dedicated Global Credential."""
+        headers = {"Authorization": f"Bearer {jwt_token}"}
+        claims = self._decode_jwt_payload(jwt_token)
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                apps_url = f"{settings.platform_base_url}/api/v1/applications/"
+                apps_params: dict[str, str] = {
+                    "limit": "10",
+                    "ordering": "-created_at",
+                    "type": "Usage",
+                    "scope": "Global",
+                }
+                if user_id:
+                    apps_params["user_id"] = user_id
+                app_resp = await client.get(apps_url, params=apps_params, headers=headers)
+
                 application_id: str | None = None
-                if response.status_code == 200:
-                    data = response.json()
-                    items = (
-                        data.get("items", data.get("results", [])) if isinstance(data, dict) else []
-                    )
+                if app_resp.status_code == 200:
+                    app_data = app_resp.json()
+                    items = app_data.get("items", app_data.get("results", []))
                     if isinstance(items, list) and items:
                         application_id = items[0].get("id")
-                        app_credentials = items[0].get("credentials", [])
-                        if isinstance(app_credentials, list) and app_credentials:
-                            token = app_credentials[0].get("token")
-                            if isinstance(token, str) and token:
-                                return token
+
                 if not application_id:
-                    response = await http_client.post(
-                        applications_url,
+                    create_app_resp = await client.post(
+                        apps_url,
                         headers={**headers, "Content-Type": "application/json"},
                         json={"type": "Usage", "scope": "Global"},
                     )
-                    if response.status_code not in (200, 201):
+                    if create_app_resp.status_code not in (200, 201):
+                        logger.error(
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
+                        )
                         return None
-                    application_id = response.json().get("id")
+                    application_id = create_app_resp.json().get("id")
+
                 if not application_id:
                     return None
-                response = await http_client.post(
-                    credentials_url,
+
+                cred_resp = await client.post(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json={"application_id": application_id},
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                if response.status_code not in (200, 201):
+                if cred_resp.status_code not in (200, 201):
+                    logger.error(
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
+                    )
                     return None
-                token = response.json().get("token")
-                return token if isinstance(token, str) and token else None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch or provisioning failed")
-            return None
+            logger.exception("Managed MCP Credential provisioning failed")
+        return None

--- a/digitalhuman/main.py
+++ b/digitalhuman/main.py
@@ -85,7 +85,10 @@ def main() -> None:
                         "name": "digitalhuman_get_tasks_batch",
                         "description": "Get multiple Digital Human tasks",
                     },
-                    {"name": "digitalhuman_delete_task", "description": "Delete one Digital Human task"},
+                    {
+                        "name": "digitalhuman_delete_task",
+                        "description": "Delete one Digital Human task",
+                    },
                 ],
                 "prompts": [
                     {

--- a/digitalhuman/tests/test_oauth.py
+++ b/digitalhuman/tests/test_oauth.py
@@ -9,6 +9,15 @@ from pydantic import AnyUrl
 from core.oauth import AceDataCloudOAuthProvider
 
 
+def test_decode_jwt_payload_extracts_owner() -> None:
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(json.dumps({"user_id": "owner-1"}).encode()).rstrip(b"=")
+    token = f"header.{payload.decode()}.signature"
+    assert AceDataCloudOAuthProvider._decode_jwt_payload(token) == {"user_id": "owner-1"}
+
+
 def _client() -> OAuthClientInformationFull:
     return OAuthClientInformationFull(
         client_id="client-1",

--- a/digitalhuman/tools/task_tools.py
+++ b/digitalhuman/tools/task_tools.py
@@ -16,7 +16,9 @@ from core.utils import format_batch_task_result, format_task_result, is_task_set
 async def digitalhuman_get_task(
     task_id: Annotated[
         str,
-        Field(description="Task ID returned by a Digital Human create-video or clone-voice request."),
+        Field(
+            description="Task ID returned by a Digital Human create-video or clone-voice request."
+        ),
     ],
     action: Annotated[
         str | None,

--- a/face/core/oauth.py
+++ b/face/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/fish/core/oauth.py
+++ b/fish/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/fish/tools/info_tools.py
+++ b/fish/tools/info_tools.py
@@ -112,7 +112,9 @@ async def fish_list_models(
     ] = None,
     self_: Annotated[
         bool | None,
-        Field(alias="self", description="When true, only return models owned by the calling account."),
+        Field(
+            alias="self", description="When true, only return models owned by the calling account."
+        ),
     ] = None,
     author_id: Annotated[
         str | None,

--- a/flux/core/oauth.py
+++ b/flux/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/glm/core/oauth.py
+++ b/glm/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/grok/core/oauth.py
+++ b/grok/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/hailuo/core/oauth.py
+++ b/hailuo/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/happyhorse/core/oauth.py
+++ b/happyhorse/core/oauth.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+import json
 import secrets
 import time
 from typing import Any
@@ -224,67 +225,81 @@ class AceDataCloudOAuthProvider:
             logger.exception("OAuth token exchange failed")
             return None
 
-    async def _get_user_credential(self, jwt_token: str) -> str | None:
-        headers = {"Authorization": f"Bearer {jwt_token}"}
+    @staticmethod
+    def _decode_jwt_payload(token: str) -> dict[str, object] | None:
         try:
-            async with httpx.AsyncClient(timeout=30) as http_client:
-                credentials_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                response = await http_client.get(credentials_url, headers=headers)
-                if response.status_code == 200:
-                    data = response.json()
-                    credentials = data.get("results", data) if isinstance(data, dict) else data
-                    if isinstance(credentials, list):
-                        for credential in credentials:
-                            token = (
-                                credential.get("token") if isinstance(credential, dict) else None
-                            )
-                            if isinstance(token, str) and token:
-                                return token
+            parts = token.split(".")
+            if len(parts) != 3:
+                return None
+            payload = parts[1] + "=" * (-len(parts[1]) % 4)
+            result = json.loads(base64.urlsafe_b64decode(payload))
+            return result if isinstance(result, dict) else None
+        except (ValueError, json.JSONDecodeError):
+            return None
 
-                applications_url = f"{settings.platform_base_url}/api/v1/applications/"
-                response = await http_client.get(
-                    applications_url,
-                    headers=headers,
-                    params={
-                        "limit": "10",
-                        "ordering": "-created_at",
-                        "type": "Usage",
-                        "scope": "Global",
-                    },
-                )
+    async def _get_user_credential(self, jwt_token: str) -> str | None:
+        """Get or create this Hosted MCP's dedicated Global Credential."""
+        headers = {"Authorization": f"Bearer {jwt_token}"}
+        claims = self._decode_jwt_payload(jwt_token)
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                apps_url = f"{settings.platform_base_url}/api/v1/applications/"
+                apps_params: dict[str, str] = {
+                    "limit": "10",
+                    "ordering": "-created_at",
+                    "type": "Usage",
+                    "scope": "Global",
+                }
+                if user_id:
+                    apps_params["user_id"] = user_id
+                app_resp = await client.get(apps_url, params=apps_params, headers=headers)
+
                 application_id: str | None = None
-                if response.status_code == 200:
-                    data = response.json()
-                    items = (
-                        data.get("items", data.get("results", [])) if isinstance(data, dict) else []
-                    )
+                if app_resp.status_code == 200:
+                    app_data = app_resp.json()
+                    items = app_data.get("items", app_data.get("results", []))
                     if isinstance(items, list) and items:
                         application_id = items[0].get("id")
-                        app_credentials = items[0].get("credentials", [])
-                        if isinstance(app_credentials, list) and app_credentials:
-                            token = app_credentials[0].get("token")
-                            if isinstance(token, str) and token:
-                                return token
+
                 if not application_id:
-                    response = await http_client.post(
-                        applications_url,
+                    create_app_resp = await client.post(
+                        apps_url,
                         headers={**headers, "Content-Type": "application/json"},
                         json={"type": "Usage", "scope": "Global"},
                     )
-                    if response.status_code not in (200, 201):
+                    if create_app_resp.status_code not in (200, 201):
+                        logger.error(
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
+                        )
                         return None
-                    application_id = response.json().get("id")
+                    application_id = create_app_resp.json().get("id")
+
                 if not application_id:
                     return None
-                response = await http_client.post(
-                    credentials_url,
+
+                cred_resp = await client.post(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json={"application_id": application_id},
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                if response.status_code not in (200, 201):
+                if cred_resp.status_code not in (200, 201):
+                    logger.error(
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
+                    )
                     return None
-                token = response.json().get("token")
-                return token if isinstance(token, str) and token else None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch or provisioning failed")
-            return None
+            logger.exception("Managed MCP Credential provisioning failed")
+        return None

--- a/happyhorse/tests/test_oauth.py
+++ b/happyhorse/tests/test_oauth.py
@@ -9,6 +9,15 @@ from pydantic import AnyUrl
 from core.oauth import AceDataCloudOAuthProvider
 
 
+def test_decode_jwt_payload_extracts_owner() -> None:
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(json.dumps({"user_id": "owner-1"}).encode()).rstrip(b"=")
+    token = f"header.{payload.decode()}.signature"
+    assert AceDataCloudOAuthProvider._decode_jwt_payload(token) == {"user_id": "owner-1"}
+
+
 def _client() -> OAuthClientInformationFull:
     return OAuthClientInformationFull(
         client_id="client-1",

--- a/hcaptcha/core/__init__.py
+++ b/hcaptcha/core/__init__.py
@@ -5,4 +5,11 @@ from core.config import settings
 from core.exceptions import HCaptchaAPIError, HCaptchaAuthError, HCaptchaValidationError
 from core.server import mcp
 
-__all__ = ["HCaptchaClient", "settings", "mcp", "HCaptchaAPIError", "HCaptchaAuthError", "HCaptchaValidationError"]
+__all__ = [
+    "HCaptchaClient",
+    "settings",
+    "mcp",
+    "HCaptchaAPIError",
+    "HCaptchaAuthError",
+    "HCaptchaValidationError",
+]

--- a/hcaptcha/core/client.py
+++ b/hcaptcha/core/client.py
@@ -10,7 +10,9 @@ from loguru import logger
 from core.config import settings
 from core.exceptions import HCaptchaAPIError, HCaptchaAuthError, HCaptchaError, HCaptchaTimeoutError
 
-_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_api_token", default=None)
+_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_request_api_token", default=None
+)
 
 
 def set_request_api_token(token: str | None) -> None:
@@ -53,12 +55,24 @@ class HCaptchaClient:
             body = {}
         error_obj = body.get("error", {}) if isinstance(body, dict) else {}
         code = error_obj.get("code", f"http_{status}")
-        message = error_obj.get("message") or (body.get("detail") if isinstance(body, dict) else None) or response.text or f"HTTP {status}"
+        message = (
+            error_obj.get("message")
+            or (body.get("detail") if isinstance(body, dict) else None)
+            or response.text
+            or f"HTTP {status}"
+        )
         if status in (401, 403):
             raise HCaptchaAuthError(message)
         raise HCaptchaAPIError(message=message, code=code, status_code=status)
 
-    async def request(self, method: str, endpoint: str, *, payload: dict[str, Any] | None = None, timeout: float | None = None) -> dict[str, Any]:
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         method_upper = method.upper()
         url = f"{self.base_url}{endpoint}"
         request_timeout = timeout or self.timeout
@@ -66,18 +80,28 @@ class HCaptchaClient:
             logger.debug(f"Request payload: {json.dumps(payload, ensure_ascii=False, indent=2)}")
         async with httpx.AsyncClient() as http_client:
             try:
-                response = await http_client.request(method_upper, url, json=payload, headers=self._get_headers(), timeout=request_timeout)
+                response = await http_client.request(
+                    method_upper,
+                    url,
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=request_timeout,
+                )
                 if response.status_code >= 400:
                     self._handle_error_response(response)
                 return response.json()  # type: ignore[no-any-return]
             except httpx.TimeoutException as e:
-                raise HCaptchaTimeoutError(f"Request to {endpoint} timed out after {request_timeout}s") from e
+                raise HCaptchaTimeoutError(
+                    f"Request to {endpoint} timed out after {request_timeout}s"
+                ) from e
             except HCaptchaError:
                 raise
             except Exception as e:
                 raise HCaptchaAPIError(message=str(e)) from e
 
-    async def recognize(self, queries: list[str] | None = None, question: str | None = None, mode: str | None = None) -> dict[str, Any]:
+    async def recognize(
+        self, queries: list[str] | None = None, question: str | None = None, mode: str | None = None
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {}
         if queries is not None:
             payload["queries"] = queries
@@ -86,7 +110,14 @@ class HCaptchaClient:
         _apply_submission_mode(payload, mode)
         return await self.request("POST", "/captcha/recognition/hcaptcha", payload=payload)
 
-    async def get_token(self, website_key: str, website_url: str, rqdata: str | None = None, proxy: str | None = None, mode: str | None = None) -> dict[str, Any]:
+    async def get_token(
+        self,
+        website_key: str,
+        website_url: str,
+        rqdata: str | None = None,
+        proxy: str | None = None,
+        mode: str | None = None,
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {"website_key": website_key, "website_url": website_url}
         if rqdata is not None:
             payload["rqdata"] = rqdata

--- a/hcaptcha/core/config.py
+++ b/hcaptcha/core/config.py
@@ -14,20 +14,36 @@ load_dotenv(dotenv_path=_env_path)
 class Settings:
     """Application settings loaded from environment variables."""
 
-    api_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud"))
+    api_base_url: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud")
+    )
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
-    request_timeout: float = field(default_factory=lambda: float(os.getenv("HCAPTCHA_REQUEST_TIMEOUT", "120")))
+    request_timeout: float = field(
+        default_factory=lambda: float(os.getenv("HCAPTCHA_REQUEST_TIMEOUT", "120"))
+    )
     server_name: str = field(default_factory=lambda: os.getenv("MCP_SERVER_NAME", "hcaptcha"))
     transport: str = field(default_factory=lambda: os.getenv("MCP_TRANSPORT", "stdio"))
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
     server_url: str = field(default_factory=lambda: os.getenv("MCP_SERVER_URL", ""))
-    auth_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"))
-    platform_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"))
-    oauth_client_id: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", ""))
+    auth_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"
+        )
+    )
+    platform_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"
+        )
+    )
+    oauth_client_id: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", "")
+    )
 
     def validate(self) -> None:
         if not self.api_token:
-            raise ValueError("ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud")
+            raise ValueError(
+                "ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud"
+            )
 
     @property
     def is_configured(self) -> bool:

--- a/hcaptcha/core/oauth.py
+++ b/hcaptcha/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/hcaptcha/main.py
+++ b/hcaptcha/main.py
@@ -118,21 +118,50 @@ Environment Variables:
                 return JSONResponse({"status": "ok"})
 
             async def favicon(_request: Request) -> RedirectResponse:
-                return RedirectResponse("https://cdn.acedata.cloud/acedata-logo.png", status_code=301)
+                return RedirectResponse(
+                    "https://cdn.acedata.cloud/acedata-logo.png", status_code=301
+                )
 
             async def server_card(_request: Request) -> JSONResponse:
-                return JSONResponse({
-                    "serverInfo": {"name": "MCP HCaptcha"},
-                    "authentication": {"required": True, "schemes": ["bearer"]},
-                    "tools": [{"name": "hcaptcha_recognize", "description": "Recognize hCaptcha image challenges"},
-                    {"name": "hcaptcha_get_token", "description": "Get an hCaptcha token for a website"},
-                    {"name": "hcaptcha_get_task", "description": "Poll a captcha task result"},
-                    {"name": "hcaptcha_get_usage_guide", "description": "Get hCaptcha usage guide"},
-                    {"name": "hcaptcha_get_api_info", "description": "Get hCaptcha API information"}],
-                    "prompts": [{"name": "hcaptcha_guide", "description": "hCaptcha tool selection guide"},
-                    {"name": "hcaptcha_workflow_examples", "description": "Example hCaptcha workflows"}],
-                    "resources": [],
-                })
+                return JSONResponse(
+                    {
+                        "serverInfo": {"name": "MCP HCaptcha"},
+                        "authentication": {"required": True, "schemes": ["bearer"]},
+                        "tools": [
+                            {
+                                "name": "hcaptcha_recognize",
+                                "description": "Recognize hCaptcha image challenges",
+                            },
+                            {
+                                "name": "hcaptcha_get_token",
+                                "description": "Get an hCaptcha token for a website",
+                            },
+                            {
+                                "name": "hcaptcha_get_task",
+                                "description": "Poll a captcha task result",
+                            },
+                            {
+                                "name": "hcaptcha_get_usage_guide",
+                                "description": "Get hCaptcha usage guide",
+                            },
+                            {
+                                "name": "hcaptcha_get_api_info",
+                                "description": "Get hCaptcha API information",
+                            },
+                        ],
+                        "prompts": [
+                            {
+                                "name": "hcaptcha_guide",
+                                "description": "hCaptcha tool selection guide",
+                            },
+                            {
+                                "name": "hcaptcha_workflow_examples",
+                                "description": "Example hCaptcha workflows",
+                            },
+                        ],
+                        "resources": [],
+                    }
+                )
 
             @contextlib.asynccontextmanager
             async def lifespan(_app: Starlette):  # type: ignore[no-untyped-def]

--- a/hcaptcha/tests/test_smoke.py
+++ b/hcaptcha/tests/test_smoke.py
@@ -36,7 +36,13 @@ def test_tools_register():
     import tools  # noqa: F401
     from core.server import mcp
 
-    expected = {"hcaptcha_recognize", "hcaptcha_get_token", "hcaptcha_get_task", "hcaptcha_get_usage_guide", "hcaptcha_get_api_info"}
+    expected = {
+        "hcaptcha_recognize",
+        "hcaptcha_get_token",
+        "hcaptcha_get_task",
+        "hcaptcha_get_usage_guide",
+        "hcaptcha_get_api_info",
+    }
     registered = {tool.name for tool in mcp._tool_manager.list_tools()}
     missing = expected - registered
     assert not missing, f"Missing tools: {missing}"
@@ -60,7 +66,9 @@ async def test_get_token_includes_optional_rqdata():
     client = HCaptchaClient(api_token="test-token")
 
     async def fake_request(method, endpoint, *, payload=None, timeout=None):
-        captured.update({"method": method, "endpoint": endpoint, "payload": payload, "timeout": timeout})
+        captured.update(
+            {"method": method, "endpoint": endpoint, "payload": payload, "timeout": timeout}
+        )
         return {"success": True}
 
     client.request = fake_request

--- a/hcaptcha/tools/captcha_tools.py
+++ b/hcaptcha/tools/captcha_tools.py
@@ -14,9 +14,18 @@ TaskMode = Literal["sync", "async"]
 
 @mcp.tool()
 async def hcaptcha_recognize(
-    queries: Annotated[list[str] | None, Field(description="Optional list of base64-encoded challenge tiles.")] = None,
-    question: Annotated[str | None, Field(description="Optional challenge question text shown by hCaptcha.")] = None,
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    queries: Annotated[
+        list[str] | None, Field(description="Optional list of base64-encoded challenge tiles.")
+    ] = None,
+    question: Annotated[
+        str | None, Field(description="Optional challenge question text shown by hCaptcha.")
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Recognize hCaptcha image challenges."""
     try:
@@ -33,14 +42,27 @@ async def hcaptcha_recognize(
 @mcp.tool()
 async def hcaptcha_get_token(
     website_key: Annotated[str, Field(description="The hCaptcha site key from the target page.")],
-    website_url: Annotated[str, Field(description="The full URL of the page containing the widget.")],
-    rqdata: Annotated[str | None, Field(description="Optional hCaptcha rqdata value expected by the site.")] = None,
-    proxy: Annotated[str | None, Field(description="Optional proxy string to use while solving.")] = None,
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    website_url: Annotated[
+        str, Field(description="The full URL of the page containing the widget.")
+    ],
+    rqdata: Annotated[
+        str | None, Field(description="Optional hCaptcha rqdata value expected by the site.")
+    ] = None,
+    proxy: Annotated[
+        str | None, Field(description="Optional proxy string to use while solving.")
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Get an hCaptcha token for a website."""
     if not website_key or not website_url:
-        return json.dumps({"error": "Validation Error", "message": "website_key and website_url are required"})
+        return json.dumps(
+            {"error": "Validation Error", "message": "website_key and website_url are required"}
+        )
 
     try:
         result = await client.get_token(

--- a/hcaptcha/tools/task_tools.py
+++ b/hcaptcha/tools/task_tools.py
@@ -12,7 +12,9 @@ from core.server import mcp
 
 
 @mcp.tool()
-async def hcaptcha_get_task(task_id: Annotated[str, Field(description="Task ID returned by an async hCaptcha request.")]) -> str:
+async def hcaptcha_get_task(
+    task_id: Annotated[str, Field(description="Task ID returned by an async hCaptcha request.")],
+) -> str:
     """Poll an async hCaptcha task."""
     if not task_id:
         return json.dumps({"error": "Validation Error", "message": "task_id is required"})

--- a/image2text/core/__init__.py
+++ b/image2text/core/__init__.py
@@ -5,4 +5,11 @@ from core.config import settings
 from core.exceptions import Image2TextAPIError, Image2TextAuthError, Image2TextValidationError
 from core.server import mcp
 
-__all__ = ["Image2TextClient", "settings", "mcp", "Image2TextAPIError", "Image2TextAuthError", "Image2TextValidationError"]
+__all__ = [
+    "Image2TextClient",
+    "settings",
+    "mcp",
+    "Image2TextAPIError",
+    "Image2TextAuthError",
+    "Image2TextValidationError",
+]

--- a/image2text/core/client.py
+++ b/image2text/core/client.py
@@ -15,7 +15,9 @@ from core.exceptions import (
     Image2TextTimeoutError,
 )
 
-_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_api_token", default=None)
+_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_request_api_token", default=None
+)
 
 
 def set_request_api_token(token: str | None) -> None:
@@ -58,12 +60,24 @@ class Image2TextClient:
             body = {}
         error_obj = body.get("error", {}) if isinstance(body, dict) else {}
         code = error_obj.get("code", f"http_{status}")
-        message = error_obj.get("message") or (body.get("detail") if isinstance(body, dict) else None) or response.text or f"HTTP {status}"
+        message = (
+            error_obj.get("message")
+            or (body.get("detail") if isinstance(body, dict) else None)
+            or response.text
+            or f"HTTP {status}"
+        )
         if status in (401, 403):
             raise Image2TextAuthError(message)
         raise Image2TextAPIError(message=message, code=code, status_code=status)
 
-    async def request(self, method: str, endpoint: str, *, payload: dict[str, Any] | None = None, timeout: float | None = None) -> dict[str, Any]:
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         method_upper = method.upper()
         url = f"{self.base_url}{endpoint}"
         request_timeout = timeout or self.timeout
@@ -71,12 +85,20 @@ class Image2TextClient:
             logger.debug(f"Request payload: {json.dumps(payload, ensure_ascii=False, indent=2)}")
         async with httpx.AsyncClient() as http_client:
             try:
-                response = await http_client.request(method_upper, url, json=payload, headers=self._get_headers(), timeout=request_timeout)
+                response = await http_client.request(
+                    method_upper,
+                    url,
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=request_timeout,
+                )
                 if response.status_code >= 400:
                     self._handle_error_response(response)
                 return response.json()  # type: ignore[no-any-return]
             except httpx.TimeoutException as e:
-                raise Image2TextTimeoutError(f"Request to {endpoint} timed out after {request_timeout}s") from e
+                raise Image2TextTimeoutError(
+                    f"Request to {endpoint} timed out after {request_timeout}s"
+                ) from e
             except Image2TextError:
                 raise
             except Exception as e:

--- a/image2text/core/config.py
+++ b/image2text/core/config.py
@@ -14,20 +14,36 @@ load_dotenv(dotenv_path=_env_path)
 class Settings:
     """Application settings loaded from environment variables."""
 
-    api_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud"))
+    api_base_url: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud")
+    )
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
-    request_timeout: float = field(default_factory=lambda: float(os.getenv("IMAGE2TEXT_REQUEST_TIMEOUT", "120")))
+    request_timeout: float = field(
+        default_factory=lambda: float(os.getenv("IMAGE2TEXT_REQUEST_TIMEOUT", "120"))
+    )
     server_name: str = field(default_factory=lambda: os.getenv("MCP_SERVER_NAME", "image2text"))
     transport: str = field(default_factory=lambda: os.getenv("MCP_TRANSPORT", "stdio"))
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
     server_url: str = field(default_factory=lambda: os.getenv("MCP_SERVER_URL", ""))
-    auth_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"))
-    platform_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"))
-    oauth_client_id: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", ""))
+    auth_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"
+        )
+    )
+    platform_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"
+        )
+    )
+    oauth_client_id: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", "")
+    )
 
     def validate(self) -> None:
         if not self.api_token:
-            raise ValueError("ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud")
+            raise ValueError(
+                "ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud"
+            )
 
     @property
     def is_configured(self) -> bool:

--- a/image2text/core/oauth.py
+++ b/image2text/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/image2text/main.py
+++ b/image2text/main.py
@@ -117,20 +117,46 @@ Environment Variables:
                 return JSONResponse({"status": "ok"})
 
             async def favicon(_request: Request) -> RedirectResponse:
-                return RedirectResponse("https://cdn.acedata.cloud/acedata-logo.png", status_code=301)
+                return RedirectResponse(
+                    "https://cdn.acedata.cloud/acedata-logo.png", status_code=301
+                )
 
             async def server_card(_request: Request) -> JSONResponse:
-                return JSONResponse({
-                    "serverInfo": {"name": "MCP Image2Text"},
-                    "authentication": {"required": True, "schemes": ["bearer"]},
-                    "tools": [{"name": "image2text_recognize", "description": "Recognize text from an image"},
-                    {"name": "image2text_get_task", "description": "Poll an image2text task result"},
-                    {"name": "image2text_get_usage_guide", "description": "Get image2text usage guide"},
-                    {"name": "image2text_get_api_info", "description": "Get image2text API information"}],
-                    "prompts": [{"name": "image2text_guide", "description": "image2text tool selection guide"},
-                    {"name": "image2text_workflow_examples", "description": "Example image2text workflows"}],
-                    "resources": [],
-                })
+                return JSONResponse(
+                    {
+                        "serverInfo": {"name": "MCP Image2Text"},
+                        "authentication": {"required": True, "schemes": ["bearer"]},
+                        "tools": [
+                            {
+                                "name": "image2text_recognize",
+                                "description": "Recognize text from an image",
+                            },
+                            {
+                                "name": "image2text_get_task",
+                                "description": "Poll an image2text task result",
+                            },
+                            {
+                                "name": "image2text_get_usage_guide",
+                                "description": "Get image2text usage guide",
+                            },
+                            {
+                                "name": "image2text_get_api_info",
+                                "description": "Get image2text API information",
+                            },
+                        ],
+                        "prompts": [
+                            {
+                                "name": "image2text_guide",
+                                "description": "image2text tool selection guide",
+                            },
+                            {
+                                "name": "image2text_workflow_examples",
+                                "description": "Example image2text workflows",
+                            },
+                        ],
+                        "resources": [],
+                    }
+                )
 
             @contextlib.asynccontextmanager
             async def lifespan(_app: Starlette):  # type: ignore[no-untyped-def]

--- a/image2text/tests/test_smoke.py
+++ b/image2text/tests/test_smoke.py
@@ -34,7 +34,12 @@ def test_tools_register():
     import tools  # noqa: F401
     from core.server import mcp
 
-    expected = {"image2text_recognize", "image2text_get_task", "image2text_get_usage_guide", "image2text_get_api_info"}
+    expected = {
+        "image2text_recognize",
+        "image2text_get_task",
+        "image2text_get_usage_guide",
+        "image2text_get_api_info",
+    }
     registered = {tool.name for tool in mcp._tool_manager.list_tools()}
     missing = expected - registered
     assert not missing, f"Missing tools: {missing}"

--- a/image2text/tools/captcha_tools.py
+++ b/image2text/tools/captcha_tools.py
@@ -15,7 +15,12 @@ TaskMode = Literal["sync", "async"]
 @mcp.tool()
 async def image2text_recognize(
     image: Annotated[str, Field(description="Base64-encoded image content to recognize.")],
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Recognize text from a captcha-style image."""
     if not image:

--- a/image2text/tools/task_tools.py
+++ b/image2text/tools/task_tools.py
@@ -12,7 +12,9 @@ from core.server import mcp
 
 
 @mcp.tool()
-async def image2text_get_task(task_id: Annotated[str, Field(description="Task ID returned by an async image2text request.")]) -> str:
+async def image2text_get_task(
+    task_id: Annotated[str, Field(description="Task ID returned by an async image2text request.")],
+) -> str:
     """Poll an async image2text task."""
     if not task_id:
         return json.dumps({"error": "Validation Error", "message": "task_id is required"})

--- a/kling/core/oauth.py
+++ b/kling/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/luma/core/oauth.py
+++ b/luma/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/maestro/core/oauth.py
+++ b/maestro/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/midjourney/core/oauth.py
+++ b/midjourney/core/oauth.py
@@ -380,87 +380,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -470,113 +396,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/minimax/core/oauth.py
+++ b/minimax/core/oauth.py
@@ -19,7 +19,6 @@ import hashlib
 import json
 import secrets
 import time
-from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 import httpx
@@ -40,25 +39,6 @@ from core.client import set_request_api_token
 from core.config import settings
 
 MCP_ACCESS_SCOPE = "mcp:access"
-
-
-def _is_reusable_credential(credential: dict[str, object], user_id: str | None) -> bool:
-    """Reuse only the owner's unlimited, unexpired API credentials."""
-    if not credential.get("token") or credential.get("limited_amount") is not None:
-        return False
-    if user_id and str(credential.get("user_id") or "") != user_id:
-        return False
-    expired_at = credential.get("expired_at")
-    if isinstance(expired_at, str) and expired_at:
-        try:
-            expiry = datetime.fromisoformat(expired_at.replace("Z", "+00:00"))
-            if expiry.tzinfo is None:
-                expiry = expiry.replace(tzinfo=timezone.utc)
-            if expiry <= datetime.now(timezone.utc):
-                return False
-        except ValueError:
-            return False
-    return True
 
 
 def _normalize_scopes(scopes: list[str] | None) -> list[str]:
@@ -354,88 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            if _is_reusable_credential(cred, user_id):
-                                cred_token = cred.get("token")
-                                assert isinstance(cred_token, str)
-                                logger.info(
-                                    f"Found reusable owner credential "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -445,118 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            for app_cred in app_creds:
-                                if _is_reusable_credential(app_cred, user_id):
-                                    existing_token = app_cred.get("token")
-                                    assert isinstance(existing_token, str)
-                                    logger.info(
-                                        f"Found reusable credential in existing application "
-                                        f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                    )
-                                    return existing_token
-                            logger.debug("Step 2a: application has no reusable owner credential")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {
-                    "application_id": application_id,
-                    "name": "MiniMax MCP OAuth",
-                    "limited_amount": None,
-                }
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/minimax/tests/test_oauth.py
+++ b/minimax/tests/test_oauth.py
@@ -6,7 +6,7 @@ import respx
 from httpx import Response
 
 from core.config import settings
-from core.oauth import AceDataCloudOAuthProvider, _is_reusable_credential
+from core.oauth import AceDataCloudOAuthProvider
 
 
 def _jwt(user_id: str) -> str:
@@ -16,78 +16,43 @@ def _jwt(user_id: str) -> str:
     return f"header.{payload}.signature"
 
 
-def test_reusable_credential_requires_owner_unlimited_and_unexpired():
-    owner = "owner-1"
-    assert _is_reusable_credential({"token": "ok", "user_id": owner, "limited_amount": None}, owner)
-    assert not _is_reusable_credential(
-        {"token": "grant", "user_id": "holder", "limited_amount": 1}, owner
-    )
-    assert not _is_reusable_credential(
-        {"token": "limited", "user_id": owner, "limited_amount": 100}, owner
-    )
-    assert not _is_reusable_credential(
-        {
-            "token": "expired",
-            "user_id": owner,
-            "limited_amount": None,
-            "expired_at": "2020-01-01T00:00:00Z",
-        },
-        owner,
-    )
-
-
 @pytest.mark.asyncio
 @respx.mock
-async def test_oauth_skips_grant_and_selects_owner_unlimited_credential():
+async def test_oauth_gets_only_its_managed_credential():
     owner = "owner-1"
-    credentials = respx.get(f"{settings.platform_base_url}/api/v1/credentials/").mock(
-        return_value=Response(
-            200,
-            json={
-                "results": [
-                    {
-                        "id": "grant",
-                        "token": "grant-token",
-                        "user_id": "holder",
-                        "limited_amount": 1,
-                    },
-                    {
-                        "id": "owner",
-                        "token": "owner-token",
-                        "user_id": owner,
-                        "limited_amount": None,
-                    },
-                ]
-            },
-        )
-    )
-
-    token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
-
-    assert credentials.called
-    assert token == "owner-token"
-
-
-@pytest.mark.asyncio
-@respx.mock
-async def test_oauth_creates_named_unlimited_credential_when_none_reusable():
-    owner = "owner-1"
-    respx.get(f"{settings.platform_base_url}/api/v1/credentials/").mock(
-        return_value=Response(200, json={"results": []})
-    )
     respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(
-        return_value=Response(200, json={"items": [{"id": "app-1", "credentials": []}]})
+        return_value=Response(200, json={"items": [{"id": "app-1"}]})
     )
-    create = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
-        return_value=Response(201, json={"token": "new-token"})
+    credentials = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(201, json={"id": "credential-1", "token": "managed-token"})
     )
 
     token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
 
-    assert token == "new-token"
-    payload = json.loads(create.calls.last.request.content)
-    assert payload == {
+    assert token == "managed-token"
+    assert not any(call.request.method == "GET" for call in credentials.calls)
+    assert json.loads(credentials.calls.last.request.content) == {
         "application_id": "app-1",
-        "name": "MiniMax MCP OAuth",
-        "limited_amount": None,
+        "name": "OAuth MCP",
     }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_oauth_creates_global_application_before_managed_credential():
+    owner = "owner-1"
+    respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(
+        return_value=Response(200, json={"items": []})
+    )
+    create_app = respx.post(f"{settings.platform_base_url}/api/v1/applications/").mock(
+        return_value=Response(201, json={"id": "app-1"})
+    )
+    create_credential = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(201, json={"id": "credential-1", "token": "managed-token"})
+    )
+
+    token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
+
+    assert token == "managed-token"
+    assert json.loads(create_app.calls.last.request.content) == {"type": "Usage", "scope": "Global"}
+    assert json.loads(create_credential.calls.last.request.content)["name"] == "OAuth MCP"

--- a/nanobanana/core/oauth.py
+++ b/nanobanana/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/openai/core/oauth.py
+++ b/openai/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/producer/core/oauth.py
+++ b/producer/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/recaptcha/core/__init__.py
+++ b/recaptcha/core/__init__.py
@@ -5,4 +5,11 @@ from core.config import settings
 from core.exceptions import ReCaptchaAPIError, ReCaptchaAuthError, ReCaptchaValidationError
 from core.server import mcp
 
-__all__ = ["ReCaptchaClient", "settings", "mcp", "ReCaptchaAPIError", "ReCaptchaAuthError", "ReCaptchaValidationError"]
+__all__ = [
+    "ReCaptchaClient",
+    "settings",
+    "mcp",
+    "ReCaptchaAPIError",
+    "ReCaptchaAuthError",
+    "ReCaptchaValidationError",
+]

--- a/recaptcha/core/client.py
+++ b/recaptcha/core/client.py
@@ -15,7 +15,9 @@ from core.exceptions import (
     ReCaptchaTimeoutError,
 )
 
-_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_api_token", default=None)
+_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_request_api_token", default=None
+)
 
 
 def set_request_api_token(token: str | None) -> None:
@@ -58,12 +60,24 @@ class ReCaptchaClient:
             body = {}
         error_obj = body.get("error", {}) if isinstance(body, dict) else {}
         code = error_obj.get("code", f"http_{status}")
-        message = error_obj.get("message") or (body.get("detail") if isinstance(body, dict) else None) or response.text or f"HTTP {status}"
+        message = (
+            error_obj.get("message")
+            or (body.get("detail") if isinstance(body, dict) else None)
+            or response.text
+            or f"HTTP {status}"
+        )
         if status in (401, 403):
             raise ReCaptchaAuthError(message)
         raise ReCaptchaAPIError(message=message, code=code, status_code=status)
 
-    async def request(self, method: str, endpoint: str, *, payload: dict[str, Any] | None = None, timeout: float | None = None) -> dict[str, Any]:
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         method_upper = method.upper()
         url = f"{self.base_url}{endpoint}"
         request_timeout = timeout or self.timeout
@@ -71,32 +85,51 @@ class ReCaptchaClient:
             logger.debug(f"Request payload: {json.dumps(payload, ensure_ascii=False, indent=2)}")
         async with httpx.AsyncClient() as http_client:
             try:
-                response = await http_client.request(method_upper, url, json=payload, headers=self._get_headers(), timeout=request_timeout)
+                response = await http_client.request(
+                    method_upper,
+                    url,
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=request_timeout,
+                )
                 if response.status_code >= 400:
                     self._handle_error_response(response)
                 return response.json()  # type: ignore[no-any-return]
             except httpx.TimeoutException as e:
-                raise ReCaptchaTimeoutError(f"Request to {endpoint} timed out after {request_timeout}s") from e
+                raise ReCaptchaTimeoutError(
+                    f"Request to {endpoint} timed out after {request_timeout}s"
+                ) from e
             except ReCaptchaError:
                 raise
             except Exception as e:
                 raise ReCaptchaAPIError(message=str(e)) from e
 
-    async def recognize2(self, image: str, question: str, mode: str | None = None) -> dict[str, Any]:
+    async def recognize2(
+        self, image: str, question: str, mode: str | None = None
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {"image": image, "question": question}
         _apply_submission_mode(payload, mode)
         return await self.request("POST", "/captcha/recognition/recaptcha2", payload=payload)
 
-    async def get_token2(self, website_key: str, website_url: str, proxy: str | None = None, mode: str | None = None) -> dict[str, Any]:
+    async def get_token2(
+        self, website_key: str, website_url: str, proxy: str | None = None, mode: str | None = None
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {"website_key": website_key, "website_url": website_url}
         if proxy is not None:
             payload["proxy"] = proxy
         _apply_submission_mode(payload, mode)
         return await self.request("POST", "/captcha/token/recaptcha2", payload=payload)
 
-    async def get_token3(self, page_action: str, website_key: str, website_url: str, mode: str | None = None) -> dict[str, Any]:
-        payload: dict[str, Any] = {"page_action": page_action, "website_key": website_key, "website_url": website_url}
+    async def get_token3(
+        self, page_action: str, website_key: str, website_url: str, mode: str | None = None
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "page_action": page_action,
+            "website_key": website_key,
+            "website_url": website_url,
+        }
         _apply_submission_mode(payload, mode)
         return await self.request("POST", "/captcha/token/recaptcha3", payload=payload)
+
 
 client = ReCaptchaClient()

--- a/recaptcha/core/config.py
+++ b/recaptcha/core/config.py
@@ -14,20 +14,36 @@ load_dotenv(dotenv_path=_env_path)
 class Settings:
     """Application settings loaded from environment variables."""
 
-    api_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud"))
+    api_base_url: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud")
+    )
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
-    request_timeout: float = field(default_factory=lambda: float(os.getenv("RECAPTCHA_REQUEST_TIMEOUT", "120")))
+    request_timeout: float = field(
+        default_factory=lambda: float(os.getenv("RECAPTCHA_REQUEST_TIMEOUT", "120"))
+    )
     server_name: str = field(default_factory=lambda: os.getenv("MCP_SERVER_NAME", "recaptcha"))
     transport: str = field(default_factory=lambda: os.getenv("MCP_TRANSPORT", "stdio"))
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
     server_url: str = field(default_factory=lambda: os.getenv("MCP_SERVER_URL", ""))
-    auth_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"))
-    platform_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"))
-    oauth_client_id: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", ""))
+    auth_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"
+        )
+    )
+    platform_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"
+        )
+    )
+    oauth_client_id: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", "")
+    )
 
     def validate(self) -> None:
         if not self.api_token:
-            raise ValueError("ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud")
+            raise ValueError(
+                "ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud"
+            )
 
     @property
     def is_configured(self) -> bool:

--- a/recaptcha/core/oauth.py
+++ b/recaptcha/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/recaptcha/main.py
+++ b/recaptcha/main.py
@@ -118,21 +118,50 @@ Environment Variables:
                 return JSONResponse({"status": "ok"})
 
             async def favicon(_request: Request) -> RedirectResponse:
-                return RedirectResponse("https://cdn.acedata.cloud/acedata-logo.png", status_code=301)
+                return RedirectResponse(
+                    "https://cdn.acedata.cloud/acedata-logo.png", status_code=301
+                )
 
             async def server_card(_request: Request) -> JSONResponse:
-                return JSONResponse({
-                    "serverInfo": {"name": "MCP ReCaptcha"},
-                    "authentication": {"required": True, "schemes": ["bearer"]},
-                    "tools": [{"name": "recaptcha2_recognize", "description": "Recognize a reCAPTCHA v2 image challenge"},
-                    {"name": "recaptcha2_get_token", "description": "Get a reCAPTCHA v2 token"},
-                    {"name": "recaptcha3_get_token", "description": "Get a reCAPTCHA v3 token"},
-                    {"name": "recaptcha_get_usage_guide", "description": "Get reCAPTCHA usage guide"},
-                    {"name": "recaptcha_get_api_info", "description": "Get reCAPTCHA API information"}],
-                    "prompts": [{"name": "recaptcha_guide", "description": "reCAPTCHA tool selection guide"},
-                    {"name": "recaptcha_workflow_examples", "description": "Example reCAPTCHA workflows"}],
-                    "resources": [],
-                })
+                return JSONResponse(
+                    {
+                        "serverInfo": {"name": "MCP ReCaptcha"},
+                        "authentication": {"required": True, "schemes": ["bearer"]},
+                        "tools": [
+                            {
+                                "name": "recaptcha2_recognize",
+                                "description": "Recognize a reCAPTCHA v2 image challenge",
+                            },
+                            {
+                                "name": "recaptcha2_get_token",
+                                "description": "Get a reCAPTCHA v2 token",
+                            },
+                            {
+                                "name": "recaptcha3_get_token",
+                                "description": "Get a reCAPTCHA v3 token",
+                            },
+                            {
+                                "name": "recaptcha_get_usage_guide",
+                                "description": "Get reCAPTCHA usage guide",
+                            },
+                            {
+                                "name": "recaptcha_get_api_info",
+                                "description": "Get reCAPTCHA API information",
+                            },
+                        ],
+                        "prompts": [
+                            {
+                                "name": "recaptcha_guide",
+                                "description": "reCAPTCHA tool selection guide",
+                            },
+                            {
+                                "name": "recaptcha_workflow_examples",
+                                "description": "Example reCAPTCHA workflows",
+                            },
+                        ],
+                        "resources": [],
+                    }
+                )
 
             @contextlib.asynccontextmanager
             async def lifespan(_app: Starlette):  # type: ignore[no-untyped-def]

--- a/recaptcha/tests/test_smoke.py
+++ b/recaptcha/tests/test_smoke.py
@@ -34,7 +34,13 @@ def test_tools_register():
     import tools  # noqa: F401
     from core.server import mcp
 
-    expected = {"recaptcha2_recognize", "recaptcha2_get_token", "recaptcha3_get_token", "recaptcha_get_usage_guide", "recaptcha_get_api_info"}
+    expected = {
+        "recaptcha2_recognize",
+        "recaptcha2_get_token",
+        "recaptcha3_get_token",
+        "recaptcha_get_usage_guide",
+        "recaptcha_get_api_info",
+    }
     registered = {tool.name for tool in mcp._tool_manager.list_tools()}
     missing = expected - registered
     assert not missing, f"Missing tools: {missing}"

--- a/recaptcha/tools/captcha_tools.py
+++ b/recaptcha/tools/captcha_tools.py
@@ -16,11 +16,18 @@ TaskMode = Literal["sync", "async"]
 async def recaptcha2_recognize(
     image: Annotated[str, Field(description="Base64-encoded reCAPTCHA v2 challenge image.")],
     question: Annotated[str, Field(description="Challenge question text shown to the user.")],
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Recognize a reCAPTCHA v2 image challenge."""
     if not image or not question:
-        return json.dumps({"error": "Validation Error", "message": "image and question are required"})
+        return json.dumps(
+            {"error": "Validation Error", "message": "image and question are required"}
+        )
     try:
         result = await client.recognize2(image=image, question=question, mode=mode)
         return json.dumps(result, ensure_ascii=False, indent=2)
@@ -34,16 +41,31 @@ async def recaptcha2_recognize(
 
 @mcp.tool()
 async def recaptcha2_get_token(
-    website_key: Annotated[str, Field(description="The reCAPTCHA v2 site key from the target page.")],
-    website_url: Annotated[str, Field(description="The full URL of the page containing the widget.")],
-    proxy: Annotated[str | None, Field(description="Optional proxy string to use while solving.")] = None,
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    website_key: Annotated[
+        str, Field(description="The reCAPTCHA v2 site key from the target page.")
+    ],
+    website_url: Annotated[
+        str, Field(description="The full URL of the page containing the widget.")
+    ],
+    proxy: Annotated[
+        str | None, Field(description="Optional proxy string to use while solving.")
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Get a reCAPTCHA v2 token."""
     if not website_key or not website_url:
-        return json.dumps({"error": "Validation Error", "message": "website_key and website_url are required"})
+        return json.dumps(
+            {"error": "Validation Error", "message": "website_key and website_url are required"}
+        )
     try:
-        result = await client.get_token2(website_key=website_key, website_url=website_url, proxy=proxy, mode=mode)
+        result = await client.get_token2(
+            website_key=website_key, website_url=website_url, proxy=proxy, mode=mode
+        )
         return json.dumps(result, ensure_ascii=False, indent=2)
     except ReCaptchaAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})
@@ -55,16 +77,34 @@ async def recaptcha2_get_token(
 
 @mcp.tool()
 async def recaptcha3_get_token(
-    page_action: Annotated[str, Field(description="The reCAPTCHA v3 page action value expected by the site.")],
-    website_key: Annotated[str, Field(description="The reCAPTCHA v3 site key from the target page.")],
-    website_url: Annotated[str, Field(description="The full URL of the page containing the widget.")],
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously.")] = None,
+    page_action: Annotated[
+        str, Field(description="The reCAPTCHA v3 page action value expected by the site.")
+    ],
+    website_key: Annotated[
+        str, Field(description="The reCAPTCHA v3 site key from the target page.")
+    ],
+    website_url: Annotated[
+        str, Field(description="The full URL of the page containing the widget.")
+    ],
+    mode: Annotated[
+        TaskMode | None,
+        Field(
+            description="Processing mode. Defaults to API sync behavior; use 'async' to submit asynchronously."
+        ),
+    ] = None,
 ) -> str:
     """Get a reCAPTCHA v3 token."""
     if not page_action or not website_key or not website_url:
-        return json.dumps({"error": "Validation Error", "message": "page_action, website_key, and website_url are required"})
+        return json.dumps(
+            {
+                "error": "Validation Error",
+                "message": "page_action, website_key, and website_url are required",
+            }
+        )
     try:
-        result = await client.get_token3(page_action=page_action, website_key=website_key, website_url=website_url, mode=mode)
+        result = await client.get_token3(
+            page_action=page_action, website_key=website_key, website_url=website_url, mode=mode
+        )
         return json.dumps(result, ensure_ascii=False, indent=2)
     except ReCaptchaAuthError as e:
         return json.dumps({"error": "Authentication Error", "message": e.message})

--- a/scripts/check_oauth_contract.py
+++ b/scripts/check_oauth_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Guard the shared Hosted MCP OAuth Credential contract."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLATFORM_TOKEN_EXEMPTION = "acedatacloud"
+
+
+def main() -> None:
+    failures: list[str] = []
+    applicable: list[str] = []
+
+    for path in sorted(ROOT.glob("*/core/oauth.py")):
+        name = path.parts[-3]
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+        functions = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+
+        if name == PLATFORM_TOKEN_EXEMPTION:
+            if "_get_platform_token" not in source or '"name": "OAuth MCP"' in source:
+                failures.append(
+                    f"{name}: PlatformToken exemption drifted into API Credential mode"
+                )
+            continue
+        if "_get_user_credential" not in source:
+            continue
+
+        applicable.append(name)
+        checks = {
+            "shared OAuth MCP name sent": '"name": "OAuth MCP"' in source,
+            "Global Usage application lookup": '"scope": "Global"' in source
+            and '"type": "Usage"' in source,
+            "credential list scanning removed": '/api/v1/credentials/"'
+            not in source.split("cred_resp =", 1)[0],
+            "arbitrary selector removed": "_is_reusable_credential" not in source,
+            "per-server managed key removed": "managed_key" not in source
+            and "_managed_credential_key" not in functions,
+            "nested credential fallback removed": "app_creds" not in source
+            and "app_credentials" not in source,
+        }
+        for label, passed in checks.items():
+            if not passed:
+                failures.append(f"{name}: {label}")
+
+    if not applicable:
+        failures.append("no API Credential OAuth implementations discovered")
+    if failures:
+        raise SystemExit("OAuth contract violations:\n- " + "\n- ".join(failures))
+    print(
+        f"OAuth contract OK: {len(applicable)} shared-Credential MCPs; 1 PlatformToken exemption"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/seedance/core/oauth.py
+++ b/seedance/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/seedream/core/oauth.py
+++ b/seedream/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/serp/core/oauth.py
+++ b/serp/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/shorturl/core/oauth.py
+++ b/shorturl/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/sora/core/oauth.py
+++ b/sora/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/suno/core/oauth.py
+++ b/suno/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/turnstile/core/__init__.py
+++ b/turnstile/core/__init__.py
@@ -5,4 +5,11 @@ from core.config import settings
 from core.exceptions import TurnstileAPIError, TurnstileAuthError, TurnstileValidationError
 from core.server import mcp
 
-__all__ = ["TurnstileClient", "settings", "mcp", "TurnstileAPIError", "TurnstileAuthError", "TurnstileValidationError"]
+__all__ = [
+    "TurnstileClient",
+    "settings",
+    "mcp",
+    "TurnstileAPIError",
+    "TurnstileAuthError",
+    "TurnstileValidationError",
+]

--- a/turnstile/core/client.py
+++ b/turnstile/core/client.py
@@ -15,7 +15,9 @@ from core.exceptions import (
     TurnstileTimeoutError,
 )
 
-_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar("_request_api_token", default=None)
+_request_api_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_request_api_token", default=None
+)
 
 
 def set_request_api_token(token: str | None) -> None:
@@ -59,12 +61,24 @@ class TurnstileClient:
             body = {}
         error_obj = body.get("error", {}) if isinstance(body, dict) else {}
         code = error_obj.get("code", f"http_{status}")
-        message = error_obj.get("message") or (body.get("detail") if isinstance(body, dict) else None) or response.text or f"HTTP {status}"
+        message = (
+            error_obj.get("message")
+            or (body.get("detail") if isinstance(body, dict) else None)
+            or response.text
+            or f"HTTP {status}"
+        )
         if status in (401, 403):
             raise TurnstileAuthError(message)
         raise TurnstileAPIError(message=message, code=code, status_code=status)
 
-    async def request(self, method: str, endpoint: str, *, payload: dict[str, Any] | None = None, timeout: float | None = None) -> dict[str, Any]:
+    async def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         method_upper = method.upper()
         url = f"{self.base_url}{endpoint}"
         request_timeout = timeout or self.timeout
@@ -72,18 +86,33 @@ class TurnstileClient:
             logger.debug(f"Request payload: {json.dumps(payload, ensure_ascii=False, indent=2)}")
         async with httpx.AsyncClient() as http_client:
             try:
-                response = await http_client.request(method_upper, url, json=payload, headers=self._get_headers(), timeout=request_timeout)
+                response = await http_client.request(
+                    method_upper,
+                    url,
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=request_timeout,
+                )
                 if response.status_code >= 400:
                     self._handle_error_response(response)
                 return response.json()  # type: ignore[no-any-return]
             except httpx.TimeoutException as e:
-                raise TurnstileTimeoutError(f"Request to {endpoint} timed out after {request_timeout}s") from e
+                raise TurnstileTimeoutError(
+                    f"Request to {endpoint} timed out after {request_timeout}s"
+                ) from e
             except TurnstileError:
                 raise
             except Exception as e:
                 raise TurnstileAPIError(message=str(e)) from e
 
-    async def get_token(self, website_key: str, website_url: str, action: str | None = None, cdata: str | None = None, mode: str | None = None) -> dict[str, Any]:
+    async def get_token(
+        self,
+        website_key: str,
+        website_url: str,
+        action: str | None = None,
+        cdata: str | None = None,
+        mode: str | None = None,
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {"website_key": website_key, "website_url": website_url}
         if action is not None:
             payload["action"] = action

--- a/turnstile/core/config.py
+++ b/turnstile/core/config.py
@@ -14,20 +14,36 @@ load_dotenv(dotenv_path=_env_path)
 class Settings:
     """Application settings loaded from environment variables."""
 
-    api_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud"))
+    api_base_url: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_API_BASE_URL", "https://api.acedata.cloud")
+    )
     api_token: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_API_TOKEN", ""))
-    request_timeout: float = field(default_factory=lambda: float(os.getenv("TURNSTILE_REQUEST_TIMEOUT", "120")))
+    request_timeout: float = field(
+        default_factory=lambda: float(os.getenv("TURNSTILE_REQUEST_TIMEOUT", "120"))
+    )
     server_name: str = field(default_factory=lambda: os.getenv("MCP_SERVER_NAME", "turnstile"))
     transport: str = field(default_factory=lambda: os.getenv("MCP_TRANSPORT", "stdio"))
     log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
     server_url: str = field(default_factory=lambda: os.getenv("MCP_SERVER_URL", ""))
-    auth_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"))
-    platform_base_url: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"))
-    oauth_client_id: str = field(default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", ""))
+    auth_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_AUTH_BASE_URL", "https://auth.acedata.cloud"
+        )
+    )
+    platform_base_url: str = field(
+        default_factory=lambda: os.getenv(
+            "ACEDATACLOUD_PLATFORM_BASE_URL", "https://platform.acedata.cloud"
+        )
+    )
+    oauth_client_id: str = field(
+        default_factory=lambda: os.getenv("ACEDATACLOUD_OAUTH_CLIENT_ID", "")
+    )
 
     def validate(self) -> None:
         if not self.api_token:
-            raise ValueError("ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud")
+            raise ValueError(
+                "ACEDATACLOUD_API_TOKEN environment variable is required. Get your token from https://platform.acedata.cloud"
+            )
 
     @property
     def is_configured(self) -> bool:

--- a/turnstile/core/oauth.py
+++ b/turnstile/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/turnstile/main.py
+++ b/turnstile/main.py
@@ -117,20 +117,46 @@ Environment Variables:
                 return JSONResponse({"status": "ok"})
 
             async def favicon(_request: Request) -> RedirectResponse:
-                return RedirectResponse("https://cdn.acedata.cloud/acedata-logo.png", status_code=301)
+                return RedirectResponse(
+                    "https://cdn.acedata.cloud/acedata-logo.png", status_code=301
+                )
 
             async def server_card(_request: Request) -> JSONResponse:
-                return JSONResponse({
-                    "serverInfo": {"name": "MCP Turnstile"},
-                    "authentication": {"required": True, "schemes": ["bearer"]},
-                    "tools": [{"name": "turnstile_get_token", "description": "Get a Cloudflare Turnstile token"},
-                    {"name": "turnstile_get_task", "description": "Poll a Turnstile task result"},
-                    {"name": "turnstile_get_usage_guide", "description": "Get Turnstile usage guide"},
-                    {"name": "turnstile_get_api_info", "description": "Get Turnstile API information"}],
-                    "prompts": [{"name": "turnstile_guide", "description": "Turnstile tool selection guide"},
-                    {"name": "turnstile_workflow_examples", "description": "Example Turnstile workflows"}],
-                    "resources": [],
-                })
+                return JSONResponse(
+                    {
+                        "serverInfo": {"name": "MCP Turnstile"},
+                        "authentication": {"required": True, "schemes": ["bearer"]},
+                        "tools": [
+                            {
+                                "name": "turnstile_get_token",
+                                "description": "Get a Cloudflare Turnstile token",
+                            },
+                            {
+                                "name": "turnstile_get_task",
+                                "description": "Poll a Turnstile task result",
+                            },
+                            {
+                                "name": "turnstile_get_usage_guide",
+                                "description": "Get Turnstile usage guide",
+                            },
+                            {
+                                "name": "turnstile_get_api_info",
+                                "description": "Get Turnstile API information",
+                            },
+                        ],
+                        "prompts": [
+                            {
+                                "name": "turnstile_guide",
+                                "description": "Turnstile tool selection guide",
+                            },
+                            {
+                                "name": "turnstile_workflow_examples",
+                                "description": "Example Turnstile workflows",
+                            },
+                        ],
+                        "resources": [],
+                    }
+                )
 
             @contextlib.asynccontextmanager
             async def lifespan(_app: Starlette):  # type: ignore[no-untyped-def]

--- a/turnstile/tests/test_smoke.py
+++ b/turnstile/tests/test_smoke.py
@@ -34,7 +34,12 @@ def test_tools_register():
     import tools  # noqa: F401
     from core.server import mcp
 
-    expected = {"turnstile_get_token", "turnstile_get_task", "turnstile_get_usage_guide", "turnstile_get_api_info"}
+    expected = {
+        "turnstile_get_token",
+        "turnstile_get_task",
+        "turnstile_get_usage_guide",
+        "turnstile_get_api_info",
+    }
     registered = {tool.name for tool in mcp._tool_manager.list_tools()}
     missing = expected - registered
     assert not missing, f"Missing tools: {missing}"

--- a/turnstile/tools/captcha_tools.py
+++ b/turnstile/tools/captcha_tools.py
@@ -15,14 +15,25 @@ TaskMode = Literal["sync", "async"]
 @mcp.tool()
 async def turnstile_get_token(
     website_key: Annotated[str, Field(description="The Turnstile site key from the target page.")],
-    website_url: Annotated[str, Field(description="The full URL of the page containing the widget.")],
-    action: Annotated[str | None, Field(description="Optional Turnstile action value expected by the site.")] = None,
-    cdata: Annotated[str | None, Field(description="Optional Turnstile cData value expected by the site.")] = None,
-    mode: Annotated[TaskMode | None, Field(description="Processing mode. Defaults to 'async'; use 'sync' to wait inline.")] = None,
+    website_url: Annotated[
+        str, Field(description="The full URL of the page containing the widget.")
+    ],
+    action: Annotated[
+        str | None, Field(description="Optional Turnstile action value expected by the site.")
+    ] = None,
+    cdata: Annotated[
+        str | None, Field(description="Optional Turnstile cData value expected by the site.")
+    ] = None,
+    mode: Annotated[
+        TaskMode | None,
+        Field(description="Processing mode. Defaults to 'async'; use 'sync' to wait inline."),
+    ] = None,
 ) -> str:
     """Get a Cloudflare Turnstile token."""
     if not website_key or not website_url:
-        return json.dumps({"error": "Validation Error", "message": "website_key and website_url are required"})
+        return json.dumps(
+            {"error": "Validation Error", "message": "website_key and website_url are required"}
+        )
     try:
         result = await client.get_token(
             website_key=website_key,

--- a/turnstile/tools/task_tools.py
+++ b/turnstile/tools/task_tools.py
@@ -12,7 +12,9 @@ from core.server import mcp
 
 
 @mcp.tool()
-async def turnstile_get_task(task_id: Annotated[str, Field(description="Task ID returned by an async Turnstile request.")]) -> str:
+async def turnstile_get_task(
+    task_id: Annotated[str, Field(description="Task ID returned by an async Turnstile request.")],
+) -> str:
     """Poll an async Turnstile task."""
     if not task_id:
         return json.dumps({"error": "Validation Error", "message": "task_id is required"})

--- a/veo/core/oauth.py
+++ b/veo/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/wan/core/oauth.py
+++ b/wan/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/webextrator/core/oauth.py
+++ b/webextrator/core/oauth.py
@@ -334,87 +334,13 @@ class AceDataCloudOAuthProvider:
         return None
 
     async def _get_user_credential(self, jwt_token: str) -> str | None:
-        """Fetch or auto-create user's API credential token from PlatformBackend.
-
-        Flow:
-        1. List existing credentials → return first token if found
-        2. List Global Usage applications → use first if found
-        3. If no application, create one (POST /api/v1/applications/)
-        4. Create credential under that application (POST /api/v1/credentials/)
-        """
+        """Get or create this Hosted MCP's dedicated Global Credential."""
         headers = {"Authorization": f"Bearer {jwt_token}"}
-        logger.debug(
-            f"_get_user_credential: platform_base_url={settings.platform_base_url}, "
-            f"jwt_token={jwt_token[:32]}..."
-        )
-
-        # Decode JWT to extract user_id (needed for filtering API queries)
         claims = self._decode_jwt_payload(jwt_token)
-        user_id: str | None = None
-        if claims:
-            user_id = claims.get("user_id")
-            logger.debug(
-                f"_get_user_credential JWT: user_id={user_id}, "
-                f"scope={claims.get('scope')}, "
-                f"permissions={claims.get('permissions')}, "
-                f"token_type={claims.get('token_type')}, "
-                f"exp={claims.get('exp')}"
-            )
-        else:
-            logger.warning("_get_user_credential: could not decode JWT for debug")
+        user_id = str(claims.get("user_id")) if claims and claims.get("user_id") else None
 
         try:
             async with httpx.AsyncClient(timeout=30) as client:
-                # Step 1: Check for existing credentials
-                creds_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                creds_params: dict[str, str] = {}
-                if user_id:
-                    creds_params["user_id"] = user_id
-                logger.debug(f"Step 1: GET {creds_url} params={creds_params}")
-                response = await client.get(creds_url, headers=headers, params=creds_params)
-                logger.debug(
-                    f"Step 1 response: status={response.status_code}, body={response.text[:1000]}"
-                )
-
-                if response.status_code == 200:
-                    data = response.json()
-                    results = data.get("results", data) if isinstance(data, dict) else data
-                    logger.debug(
-                        f"Step 1 parsed: type(data)={type(data).__name__}, "
-                        f"type(results)={type(results).__name__}, "
-                        f"count={len(results) if isinstance(results, list) else 'N/A'}"
-                    )
-                    if isinstance(results, list):
-                        for i, cred in enumerate(results):
-                            logger.debug(
-                                f"Step 1 credential[{i}]: "
-                                f"id={cred.get('id')}, "
-                                f"token={'present' if cred.get('token') else 'MISSING'}, "
-                                f"type={cred.get('type')}, "
-                                f"keys={list(cred.keys())}"
-                            )
-                            cred_token: str | None = cred.get("token")
-                            if cred_token:
-                                logger.info(
-                                    f"Found existing credential token "
-                                    f"(id={cred.get('id')}, token={cred_token[:12]}...)"
-                                )
-                                return cred_token
-                        logger.debug(
-                            f"Step 1: iterated {len(results)} credentials, none had a token"
-                        )
-                    else:
-                        logger.warning(f"Step 1: results is not a list: {type(results).__name__}")
-                else:
-                    logger.error(
-                        f"Step 1 FAILED: credentials list returned "
-                        f"status={response.status_code}, body={response.text[:500]}"
-                    )
-
-                # Step 2: No credentials found — auto-provision
-                logger.info("No credentials found, auto-provisioning Application + Credential")
-
-                # Step 2a: Find or create a Global Usage application
                 apps_url = f"{settings.platform_base_url}/api/v1/applications/"
                 apps_params: dict[str, str] = {
                     "limit": "10",
@@ -424,113 +350,52 @@ class AceDataCloudOAuthProvider:
                 }
                 if user_id:
                     apps_params["user_id"] = user_id
-                logger.debug(f"Step 2a: GET {apps_url} params={apps_params}")
                 app_resp = await client.get(apps_url, params=apps_params, headers=headers)
-                logger.debug(
-                    f"Step 2a response: status={app_resp.status_code}, body={app_resp.text[:1000]}"
-                )
 
                 application_id: str | None = None
                 if app_resp.status_code == 200:
                     app_data = app_resp.json()
                     items = app_data.get("items", app_data.get("results", []))
-                    logger.debug(
-                        f"Step 2a parsed: "
-                        f"data_keys={list(app_data.keys()) if isinstance(app_data, dict) else 'not-dict'}, "
-                        f"items_count={len(items) if isinstance(items, list) else 'N/A'}"
-                    )
                     if isinstance(items, list) and items:
-                        app = items[0]
-                        application_id = app.get("id")
-                        logger.debug(
-                            f"Step 2a: using app id={application_id}, "
-                            f"type={app.get('type')}, "
-                            f"scope={app.get('scope')}, "
-                            f"remaining_amount={app.get('remaining_amount')}, "
-                            f"keys={list(app.keys())}"
-                        )
-                        # Check if the app already has a credential
-                        app_creds = app.get("credentials", [])
-                        logger.debug(
-                            f"Step 2a: app.credentials count="
-                            f"{len(app_creds) if isinstance(app_creds, list) else 'not-list'}"
-                        )
-                        if isinstance(app_creds, list) and app_creds:
-                            logger.debug(f"Step 2a: first credential in app: {app_creds[0]}")
-                            existing_token: str | None = app_creds[0].get("token")
-                            if isinstance(existing_token, str) and existing_token:
-                                logger.info(
-                                    f"Found credential in existing application "
-                                    f"(app_id={application_id}, token={existing_token[:12]}...)"
-                                )
-                                return existing_token
-                            logger.debug("Step 2a: credential in app has no token field or empty")
-                    else:
-                        logger.debug("Step 2a: no Global Usage applications found")
-                else:
-                    logger.error(
-                        f"Step 2a FAILED: applications list returned "
-                        f"status={app_resp.status_code}, body={app_resp.text[:500]}"
-                    )
+                        application_id = items[0].get("id")
 
                 if not application_id:
-                    # Create a new Global Usage application
-                    create_payload = {"type": "Usage", "scope": "Global"}
-                    logger.debug(f"Step 2a-create: POST {apps_url} json={create_payload}")
                     create_app_resp = await client.post(
                         apps_url,
                         headers={**headers, "Content-Type": "application/json"},
-                        json=create_payload,
+                        json={"type": "Usage", "scope": "Global"},
                     )
-                    logger.debug(
-                        f"Step 2a-create response: status={create_app_resp.status_code}, "
-                        f"body={create_app_resp.text[:1000]}"
-                    )
-                    if create_app_resp.status_code in (200, 201):
-                        new_app = create_app_resp.json()
-                        application_id = new_app.get("id")
-                        logger.info(f"Created Global Application: {application_id}")
-                    else:
+                    if create_app_resp.status_code not in (200, 201):
                         logger.error(
-                            f"Failed to create application: "
-                            f"{create_app_resp.status_code} {create_app_resp.text}"
+                            "Failed to create Global Application: "
+                            f"{create_app_resp.status_code} {create_app_resp.text[:500]}"
                         )
                         return None
+                    application_id = create_app_resp.json().get("id")
 
-                # Step 2b: Create a credential under the application
-                cred_create_url = f"{settings.platform_base_url}/api/v1/credentials/"
-                cred_create_payload = {"application_id": application_id}
-                logger.debug(f"Step 2b: POST {cred_create_url} json={cred_create_payload}")
+                if not application_id:
+                    return None
+
                 cred_resp = await client.post(
-                    cred_create_url,
+                    f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
-                    json=cred_create_payload,
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
                 )
-                logger.debug(
-                    f"Step 2b response: status={cred_resp.status_code}, "
-                    f"body={cred_resp.text[:1000]}"
-                )
-                if cred_resp.status_code in (200, 201):
-                    cred_data = cred_resp.json()
-                    logger.debug(
-                        f"Step 2b parsed: type={type(cred_data).__name__}, "
-                        f"keys={list(cred_data.keys()) if isinstance(cred_data, dict) else 'not-dict'}"
-                    )
-                    new_token: str | None = (
-                        cred_data.get("token") if isinstance(cred_data, dict) else None
-                    )
-                    if isinstance(new_token, str) and new_token:
-                        logger.info(
-                            f"Auto-provisioned new credential token (token={new_token[:12]}...)"
-                        )
-                        return new_token
-                    logger.error(f"Credential created but no token in response: {cred_data}")
-                else:
+                if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        f"Failed to create credential: {cred_resp.status_code} {cred_resp.text}"
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")
         except Exception:
-            logger.exception("Credential fetch/provision error")
-
-        logger.error("_get_user_credential: returning None — all steps failed")
+            logger.exception("Managed MCP Credential provisioning failed")
         return None


### PR DESCRIPTION
## Summary
- make all 30 API Credential OAuth MCPs request the same shared Credential named `OAuth MCP`
- never list, scan, or reuse arbitrary user Credentials
- find-or-create the user Global Usage Application, then atomically get-or-create the shared Token through PlatformBackend
- preserve `acedatacloud` as the intentional `platform-*` PlatformToken exemption
- add a repository-wide shared-Credential OAuth guard to CI

## Scope
- Connector Catalog coverage: 24/24 hosted MCPs
- Standard OAuth family: 27 byte-identical implementations
- Adapted forks: Midjourney, DigitalHuman, HappyHorse
- Explicit exemption: AceDataCloud management MCP

## Correctness
All Hosted MCPs send `{application_id, name: "OAuth MCP"}`. They do not inspect existing Credentials or select a Token themselves. PlatformBackend PR #1532 locks the Global Application, returns the owner’s existing unrestricted `OAuth MCP` Credential, or creates it once. Credentials with any other name are never reused.

## Verification
- OAuth contract guard: 30 shared-Credential MCPs, 1 PlatformToken exemption
- 27 standard implementations remain byte-identical
- MiniMax tests cover existing-application and absent-application paths and exact `OAuth MCP` payload
- Midjourney and compact forks retain their OAuth/JWT behavior
- representative Ruff, pytest, and mypy pass
- CI runs every changed MCP on Python 3.10/3.11/3.12

## Baseline formatting
Six affected packages already failed the repository-wide Ruff formatter gate outside OAuth files. Formatter-only changes in DigitalHuman, Fish, hCaptcha, Image2Text, reCAPTCHA, and Turnstile are retained so mandatory CI can run; focused tests remain green.

## Dependency
Merge and deploy https://github.com/AceDataCloud/PlatformBackend/pull/1532 before this PR. Existing OAuth Connections retain their old durable token until reauthorized once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)