### PR TITLE
feat(oauth): retrieve shared credential before create

### DIFF
--- a/aichat/core/oauth.py
+++ b/aichat/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/aichat/core/oauth.py
+++ b/aichat/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/apply_query_first.py
+++ b/apply_query_first.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Apply query-first pattern to all API Credential OAuth implementations."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+PLATFORM_TOKEN_EXEMPTION = "acedatacloud"
+
+OLD_CODE = '''                if not application_id:
+                    return None
+
+                cred_resp = await client.post(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    headers={**headers, "Content-Type": "application/json"},
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
+                )
+                if cred_resp.status_code not in (200, 201):
+                    logger.error(
+                        "Failed to get managed MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
+                    )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("Managed MCP Credential response did not contain a token")'''
+
+NEW_CODE = '''                if not application_id:
+                    return None
+
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
+                cred_resp = await client.post(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    headers={**headers, "Content-Type": "application/json"},
+                    json={
+                        "application_id": application_id,
+                        "name": "OAuth MCP",
+                    },
+                )
+                if cred_resp.status_code not in (200, 201):
+                    logger.error(
+                        "Failed to create OAuth MCP Credential: "
+                        f"{cred_resp.status_code} {cred_resp.text[:500]}"
+                    )
+                    return None
+                data = cred_resp.json()
+                token = data.get("token") if isinstance(data, dict) else None
+                if isinstance(token, str) and token:
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
+                    return token
+                logger.error("OAuth MCP Credential response did not contain a token")'''
+
+
+def main():
+    updated = []
+    for path in sorted(ROOT.glob("*/core/oauth.py")):
+        name = path.parts[-3]
+        if name == PLATFORM_TOKEN_EXEMPTION:
+            continue
+
+        source = path.read_text()
+        if "_get_user_credential" not in source:
+            continue
+
+        # Skip if already has query-first pattern
+        if 'params={"application_id": application_id, "name": "OAuth MCP"}' in source:
+            print(f"✓ {name}: already has query-first pattern")
+            continue
+
+        if OLD_CODE not in source:
+            print(f"✗ {name}: old pattern not found")
+            continue
+
+        # Apply transformation
+        new_source = source.replace(OLD_CODE, NEW_CODE)
+        path.write_text(new_source)
+        updated.append(name)
+        print(f"✓ {name}: applied query-first pattern")
+
+    print(f"\nUpdated {len(updated)} MCPs: {', '.join(updated)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/digitalhuman/core/oauth.py
+++ b/digitalhuman/core/oauth.py
@@ -280,6 +280,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -290,16 +312,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/digitalhuman/core/oauth.py
+++ b/digitalhuman/core/oauth.py
@@ -296,9 +296,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/face/core/oauth.py
+++ b/face/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/face/core/oauth.py
+++ b/face/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/fish/core/oauth.py
+++ b/fish/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/fish/core/oauth.py
+++ b/fish/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/flux/core/oauth.py
+++ b/flux/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/flux/core/oauth.py
+++ b/flux/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/glm/core/oauth.py
+++ b/glm/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/glm/core/oauth.py
+++ b/glm/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/grok/core/oauth.py
+++ b/grok/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/grok/core/oauth.py
+++ b/grok/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/hailuo/core/oauth.py
+++ b/hailuo/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/hailuo/core/oauth.py
+++ b/hailuo/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/happyhorse/core/oauth.py
+++ b/happyhorse/core/oauth.py
@@ -280,6 +280,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -290,16 +312,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/happyhorse/core/oauth.py
+++ b/happyhorse/core/oauth.py
@@ -296,9 +296,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/hcaptcha/core/oauth.py
+++ b/hcaptcha/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/hcaptcha/core/oauth.py
+++ b/hcaptcha/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/image2text/core/oauth.py
+++ b/image2text/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/image2text/core/oauth.py
+++ b/image2text/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/kling/core/oauth.py
+++ b/kling/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/kling/core/oauth.py
+++ b/kling/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/luma/core/oauth.py
+++ b/luma/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/luma/core/oauth.py
+++ b/luma/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/maestro/core/oauth.py
+++ b/maestro/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/maestro/core/oauth.py
+++ b/maestro/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/midjourney/core/oauth.py
+++ b/midjourney/core/oauth.py
@@ -438,9 +438,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/midjourney/core/oauth.py
+++ b/midjourney/core/oauth.py
@@ -422,6 +422,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -432,16 +454,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/minimax/core/oauth.py
+++ b/minimax/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/minimax/core/oauth.py
+++ b/minimax/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/minimax/tests/test_oauth.py
+++ b/minimax/tests/test_oauth.py
@@ -23,15 +23,20 @@ async def test_oauth_gets_only_its_managed_credential():
     respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(
         return_value=Response(200, json={"items": [{"id": "app-1"}]})
     )
-    credentials = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+    get_creds = respx.get(
+        f"{settings.platform_base_url}/api/v1/credentials/",
+        params={"application_id": "app-1", "name": "OAuth MCP"},
+    ).mock(return_value=Response(200, json={"items": []}))
+    create_cred = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
         return_value=Response(201, json={"id": "credential-1", "token": "managed-token"})
     )
 
     token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
 
     assert token == "managed-token"
-    assert not any(call.request.method == "GET" for call in credentials.calls)
-    assert json.loads(credentials.calls.last.request.content) == {
+    assert get_creds.called
+    assert create_cred.called
+    assert json.loads(create_cred.calls.last.request.content) == {
         "application_id": "app-1",
         "name": "OAuth MCP",
     }
@@ -47,6 +52,10 @@ async def test_oauth_creates_global_application_before_managed_credential():
     create_app = respx.post(f"{settings.platform_base_url}/api/v1/applications/").mock(
         return_value=Response(201, json={"id": "app-1"})
     )
+    get_creds = respx.get(
+        f"{settings.platform_base_url}/api/v1/credentials/",
+        params={"application_id": "app-1", "name": "OAuth MCP"},
+    ).mock(return_value=Response(200, json={"items": []}))
     create_credential = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
         return_value=Response(201, json={"id": "credential-1", "token": "managed-token"})
     )
@@ -55,4 +64,5 @@ async def test_oauth_creates_global_application_before_managed_credential():
 
     assert token == "managed-token"
     assert json.loads(create_app.calls.last.request.content) == {"type": "Usage", "scope": "Global"}
+    assert get_creds.called
     assert json.loads(create_credential.calls.last.request.content)["name"] == "OAuth MCP"

--- a/minimax/tests/test_oauth.py
+++ b/minimax/tests/test_oauth.py
@@ -44,6 +44,33 @@ async def test_oauth_gets_only_its_managed_credential():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_oauth_reuses_retrieved_credential_without_creating():
+    owner = "owner-1"
+    respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(
+        return_value=Response(200, json={"items": [{"id": "app-1"}]})
+    )
+    get_creds = respx.get(
+        f"{settings.platform_base_url}/api/v1/credentials/",
+        params={"application_id": "app-1", "name": "OAuth MCP"},
+    ).mock(
+        return_value=Response(
+            200,
+            json={"items": [{"id": "credential-1", "token": "existing-token"}]},
+        )
+    )
+    create_cred = respx.post(f"{settings.platform_base_url}/api/v1/credentials/").mock(
+        return_value=Response(201, json={"id": "unexpected", "token": "new-token"})
+    )
+
+    token = await AceDataCloudOAuthProvider()._get_user_credential(_jwt(owner))
+
+    assert token == "existing-token"
+    assert get_creds.called
+    assert not create_cred.called
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_oauth_creates_global_application_before_managed_credential():
     owner = "owner-1"
     respx.get(f"{settings.platform_base_url}/api/v1/applications/").mock(

--- a/nanobanana/core/oauth.py
+++ b/nanobanana/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/nanobanana/core/oauth.py
+++ b/nanobanana/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/openai/core/oauth.py
+++ b/openai/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/openai/core/oauth.py
+++ b/openai/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/producer/core/oauth.py
+++ b/producer/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/producer/core/oauth.py
+++ b/producer/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/recaptcha/core/oauth.py
+++ b/recaptcha/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/recaptcha/core/oauth.py
+++ b/recaptcha/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/scripts/check_oauth_contract.py
+++ b/scripts/check_oauth_contract.py
@@ -38,8 +38,10 @@ def main() -> None:
             "shared OAuth MCP name sent": '"name": "OAuth MCP"' in source,
             "Global Usage application lookup": '"scope": "Global"' in source
             and '"type": "Usage"' in source,
-            "credential list scanning removed": '/api/v1/credentials/"'
-            not in source.split("cred_resp =", 1)[0],
+            "query-first pattern": 'params={"application_id": application_id, "name": "OAuth MCP"}'
+            in source
+            or 'params={\'application_id\': application_id, \'name\': \'OAuth MCP\'}'
+            in source,
             "arbitrary selector removed": "_is_reusable_credential" not in source,
             "per-server managed key removed": "managed_key" not in source
             and "_managed_credential_key" not in functions,

--- a/seedance/core/oauth.py
+++ b/seedance/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/seedance/core/oauth.py
+++ b/seedance/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/seedream/core/oauth.py
+++ b/seedream/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/seedream/core/oauth.py
+++ b/seedream/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/serp/core/oauth.py
+++ b/serp/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/serp/core/oauth.py
+++ b/serp/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/shorturl/core/oauth.py
+++ b/shorturl/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/shorturl/core/oauth.py
+++ b/shorturl/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/sora/core/oauth.py
+++ b/sora/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/sora/core/oauth.py
+++ b/sora/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/suno/core/oauth.py
+++ b/suno/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/suno/core/oauth.py
+++ b/suno/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/turnstile/core/oauth.py
+++ b/turnstile/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/turnstile/core/oauth.py
+++ b/turnstile/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/veo/core/oauth.py
+++ b/veo/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/veo/core/oauth.py
+++ b/veo/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/wan/core/oauth.py
+++ b/wan/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/wan/core/oauth.py
+++ b/wan/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found

--- a/webextrator/core/oauth.py
+++ b/webextrator/core/oauth.py
@@ -376,6 +376,28 @@ class AceDataCloudOAuthProvider:
                 if not application_id:
                     return None
 
+                # Query for existing shared "OAuth MCP" credential first
+                cred_list_resp = await client.get(
+                    f"{settings.platform_base_url}/api/v1/credentials/",
+                    params={"application_id": application_id, "name": "OAuth MCP"},
+                    headers=headers,
+                )
+                existing_creds = []
+                if cred_list_resp.status_code == 200:
+                    cred_data = cred_list_resp.json()
+                    existing_creds = cred_data.get("items", cred_data.get("results", []))
+
+                # Reuse existing credential if found
+                if existing_creds and isinstance(existing_creds, list):
+                    data = existing_creds[0]
+                    token = data.get("token") if isinstance(data, dict) else None
+                    if isinstance(token, str) and token:
+                        logger.info(
+                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
+                        )
+                        return token
+
+                # Create new credential only if not found
                 cred_resp = await client.post(
                     f"{settings.platform_base_url}/api/v1/credentials/",
                     headers={**headers, "Content-Type": "application/json"},
@@ -386,16 +408,16 @@ class AceDataCloudOAuthProvider:
                 )
                 if cred_resp.status_code not in (200, 201):
                     logger.error(
-                        "Failed to get managed MCP Credential: "
+                        "Failed to create OAuth MCP Credential: "
                         f"{cred_resp.status_code} {cred_resp.text[:500]}"
                     )
                     return None
                 data = cred_resp.json()
                 token = data.get("token") if isinstance(data, dict) else None
                 if isinstance(token, str) and token:
-                    logger.info(f"Using shared OAuth MCP Credential (id={data.get('id')})")
+                    logger.info(f"Created new OAuth MCP Credential (id={data.get('id')})")
                     return token
-                logger.error("Managed MCP Credential response did not contain a token")
+                logger.error("OAuth MCP Credential response did not contain a token")
         except Exception:
             logger.exception("Managed MCP Credential provisioning failed")
         return None

--- a/webextrator/core/oauth.py
+++ b/webextrator/core/oauth.py
@@ -392,9 +392,7 @@ class AceDataCloudOAuthProvider:
                     data = existing_creds[0]
                     token = data.get("token") if isinstance(data, dict) else None
                     if isinstance(token, str) and token:
-                        logger.info(
-                            f"Reusing existing OAuth MCP Credential (id={data.get('id')})"
-                        )
+                        logger.info(f"Reusing existing OAuth MCP Credential (id={data.get('id')})")
                         return token
 
                 # Create new credential only if not found


### PR DESCRIPTION
## Summary
- update all 30 API-Credential OAuth MCPs to retrieve the shared credential first
- reuse the retrieved token when present
- create a credential only when the filtered retrieve returns no match
- keep the AceDataCloud PlatformToken implementation as the sole exemption

## Flow
1. retrieve the user's Global Usage application
2. call `GET /api/v1/credentials/?application_id=<id>&name=OAuth%20MCP`
3. if a credential is returned, reuse its token and do not POST
4. if no credential is returned, call `POST /api/v1/credentials/` with that application and name

The credential name is a client-side lookup value. PlatformBackend does not special-case it.

## Verification
- `python scripts/check_oauth_contract.py` → 30 shared-Credential MCPs; 1 PlatformToken exemption
- `cd minimax && pytest tests/test_oauth.py -q` → retrieve-hit and retrieve-empty/create behavior pass
- retrieve-hit test asserts no credential POST occurs
- Ruff lint and format checks pass for the representative implementation and tests

## Dependency
Requires the generic credential `name` filter from https://github.com/AceDataCloud/PlatformBackend/pull/1532 to be deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)