### PR TITLE
feat(midjourney): expose version 8.2 in MCP

### DIFF
--- a/midjourney/core/types.py
+++ b/midjourney/core/types.py
@@ -6,7 +6,7 @@ from typing import Literal
 MidjourneyMode = Literal["fast", "relax", "turbo"]
 
 # Midjourney version
-MidjourneyVersion = Literal["5.2", "6", "6.1", "7", "8", "8.1"]
+MidjourneyVersion = Literal["5.2", "6", "6.1", "7", "8", "8.1", "8.2"]
 
 # Midjourney imagine actions
 ImagineAction = Literal[
@@ -49,4 +49,4 @@ DEFAULT_MODE: MidjourneyMode = "fast"
 DEFAULT_VIDEO_MODE: VideoMode = "fast"
 
 # Default version
-DEFAULT_VERSION: MidjourneyVersion = "8.1"
+DEFAULT_VERSION: MidjourneyVersion = "8.2"

--- a/midjourney/prompts/__init__.py
+++ b/midjourney/prompts/__init__.py
@@ -75,8 +75,11 @@ When the user wants to generate images, choose the appropriate tool based on the
 3. Use 'turbo' for faster results on versions that support it; V8.1 does not support Turbo
 4. Use 'relax' for slower, cheaper generation
 
+## Midjourney V8.2 Features:
+- **V8.2 is the latest model** - use `version='8.2'` for the newest capabilities
+- **Quality and modes**: Quality controls and fast, relax, or Turbo modes are supported.
+
 ## Midjourney V8.1 Features:
-- **V8.1 is the latest model** - use `version='8.1'` for the newest capabilities
 - **Resolution**: Standard (`hd=False`) and HD 2K (`hd=True`) use separate resolution-based rates.
 - **Quality is unsupported**: Do not use `quality` / `--q` with V8.1.
 - **Modes**: Use `fast` or `relax`; Turbo is not supported in V8.1.
@@ -134,7 +137,8 @@ def midjourney_workflow_examples() -> str:
 - Use aspect ratio parameter (--ar) for specific dimensions
 - Use --no parameter to exclude unwanted elements
 - For Chinese speakers, offer translation with `midjourney_translate`
-- For V8.1: use `version='8.1'` and consider `hd=True` for 2K; do not set `quality` or use Turbo
+- Prefer V8.2 for new generations; it supports quality controls and Turbo
+- For V8.1: consider `hd=True` for 2K; do not set `quality` or use Turbo
 - V8.1 style references and moodboards use the selected SD/HD resolution rate
 """
 

--- a/midjourney/tests/test_prompts.py
+++ b/midjourney/tests/test_prompts.py
@@ -10,6 +10,7 @@ def test_v81_guidance_excludes_unsupported_quality_and_turbo() -> None:
     guide = midjourney_image_generation_guide()
     examples = midjourney_workflow_examples()
 
+    assert "V8.2 is the latest model" in guide
     assert "Quality is unsupported" in guide
     assert "Turbo is not supported in V8.1" in guide
     assert "separate resolution-based rates" in guide
@@ -21,8 +22,8 @@ def test_v81_guidance_excludes_unsupported_quality_and_turbo() -> None:
 def test_v81_tool_schema_describes_supported_controls() -> None:
     source = (Path(__file__).resolve().parents[1] / "tools" / "imagine_tools.py").read_text()
 
-    assert "V8.1 only supports fast and relax" in source
+    assert "V8.2 supports it; V8.1 only supports fast and relax" in source
     assert "separate SD and HD resolution-based rates" in source
     assert "This parameter is not supported in V8.1" in source
     assert source.count("selected SD/HD resolution rate") == 2
-    assert DEFAULT_VERSION == "8.1"
+    assert DEFAULT_VERSION == "8.2"

--- a/midjourney/tests/test_types.py
+++ b/midjourney/tests/test_types.py
@@ -5,6 +5,6 @@ from typing import get_args
 from core.types import MidjourneyVersion
 
 
-def test_midjourney_version_includes_v81() -> None:
-    """Midjourney version enum should include the latest 8.1 model."""
-    assert "8.1" in get_args(MidjourneyVersion)
+def test_midjourney_version_includes_v82() -> None:
+    """Midjourney version enum should include the latest 8.2 model."""
+    assert "8.2" in get_args(MidjourneyVersion)

--- a/midjourney/tools/imagine_tools.py
+++ b/midjourney/tools/imagine_tools.py
@@ -21,7 +21,7 @@ async def midjourney_imagine(
     mode: Annotated[
         MidjourneyMode,
         Field(
-            description="Generation mode. 'fast' is recommended and 'relax' is slower but cheaper. 'turbo' is faster on supported versions, but V8.1 only supports fast and relax."
+            description="Generation mode. 'fast' is recommended and 'relax' is slower but cheaper. 'turbo' is faster on supported versions. V8.2 supports it; V8.1 only supports fast and relax."
         ),
     ] = DEFAULT_MODE,
     translation: Annotated[
@@ -49,19 +49,19 @@ async def midjourney_imagine(
     version: Annotated[
         MidjourneyVersion | None,
         Field(
-            description="Midjourney model version to use, e.g. '8.1', '8', '7', '6.1'. '8.1' is the latest version and is recommended. Leave unset to use Midjourney's default."
+            description="Midjourney model version to use, e.g. '8.2', '8.1', '8', '7', '6.1'. '8.2' is the latest version and is recommended. Leave unset to use Midjourney's default."
         ),
     ] = None,
     hd: Annotated[
         bool,
         Field(
-            description="Enable 2K HD output. V8.1 uses separate SD and HD resolution-based rates; V8.0 Alpha uses different premium rules."
+            description="Enable HD output. V8.2 supports HD; V8.1 uses separate SD and HD resolution-based rates."
         ),
     ] = False,
     quality: Annotated[
         str | None,
         Field(
-            description="Image quality level for versions that support --quality / --q. This parameter is not supported in V8.1; use hd for higher-resolution V8.1 output."
+            description="Image quality level for versions that support --quality / --q. V8.2 supports it. This parameter is not supported in V8.1."
         ),
     ] = None,
     style_reference: Annotated[


### PR DESCRIPTION
## Dependency graph
Agent-surface node; depends on the PlatformBackend 8.2 contract and PlatformService runtime support.

## Contract
- Add 8.2 to `MidjourneyVersion` and make it the default.
- Describe Quality/HD/Turbo support for 8.2 while preserving explicit V8.1 restrictions.

## Evidence
- Ruff passed.
- Pytest: 30 passed, 3 integration tests skipped.

## Rollout / rollback
Normal MCP package publication. Revert to restore 8.1 as the default.

## Out of scope
No new tool or endpoint; transport/auth remain unchanged.

## Adversarial review
Not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)